### PR TITLE
Add .cgcignore Support for Ignoring Files from Indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ htmlcov/
 
 # MCP
 mcp.json
+
+# Docker
+docker-compose.yml 


### PR DESCRIPTION
This PR adds support for a .cgcignore file format, allowing users to specify files or directories that should be excluded from MCP indexing and graph building. The .cgcignore file works similarly to .gitignore

