### PR TITLE
tests(samples/typescript): add typescript sample_project_typescript

### DIFF
--- a/tests/sample_project_typescript/README.md
+++ b/tests/sample_project_typescript/README.md
@@ -1,0 +1,419 @@
+# TypeScript Sample Project
+
+A comprehensive TypeScript sample project for testing code analysis and indexing tools. This project covers major TypeScript language features, patterns, and best practices across approximately 10 files.
+
+## Project Overview
+
+This sample project is designed to demonstrate and test TypeScript's capabilities for:
+- Code analysis tools
+- Code indexing systems
+- Graph database population
+- Understanding TypeScript language features
+- Reference implementation for TypeScript patterns
+
+## Files Overview
+
+### 1. `src/types-interfaces.ts`
+Demonstrates TypeScript's core type system including:
+- ✅ **Primitive Types**: string, number, boolean, null, undefined, symbol, bigint
+- ✅ **Array and Tuple Types**: typed arrays, named tuples, readonly arrays
+- ✅ **Object Types**: inline object types, optional properties
+- ✅ **Interface Definitions**: basic interfaces, inheritance, index signatures
+- ✅ **Type Aliases**: union types, intersection types, generic aliases
+- ✅ **Union Types**: discriminated unions, type guards, exhaustive checks
+- ✅ **Intersection Types**: combining types, complex compositions
+- ✅ **Conditional Types**: type-level conditionals, infer keyword
+- ✅ **Template Literal Types**: string manipulation at type level
+- ✅ **Utility Types**: Pick, Omit, Partial, Required, etc.
+
+### 2. `src/classes-inheritance.ts`
+Covers object-oriented programming features:
+- ✅ **Basic Classes**: constructors, properties, methods
+- ✅ **Access Modifiers**: public, private, protected, readonly
+- ✅ **Static Members**: static properties and methods
+- ✅ **Inheritance**: extends keyword, super calls, method overriding
+- ✅ **Abstract Classes**: abstract methods and properties
+- ✅ **Interface Implementation**: implementing multiple interfaces
+- ✅ **Generic Classes**: class-level generics, constraints
+- ✅ **Design Patterns**: Singleton, Factory, Mixin patterns
+- ✅ **Getters and Setters**: property accessors
+- ✅ **Method Overloads**: multiple function signatures
+
+### 3. `src/functions-generics.ts`
+Explores function types and generic programming:
+- ✅ **Function Types**: basic functions, arrow functions, optional parameters
+- ✅ **Function Overloads**: multiple signatures for same function
+- ✅ **Generic Functions**: type parameters, constraints, inference
+- ✅ **Higher-Order Functions**: functions returning functions
+- ✅ **Utility Functions**: memoization, debouncing, throttling
+- ✅ **Generic Constraints**: extends keyword, keyof operator
+- ✅ **Generic Data Structures**: Stack, Queue, PriorityQueue
+- ✅ **Function Composition**: pipe, compose patterns
+- ✅ **Currying**: partial application, function currying
+
+### 4. `src/async-promises.ts`
+Demonstrates asynchronous programming patterns:
+- ✅ **Promises**: creating, chaining, error handling
+- ✅ **Async/Await**: modern async syntax, error handling
+- ✅ **Promise Combinators**: Promise.all, Promise.race, custom combinators
+- ✅ **Async Iterators**: async generators, for-await-of
+- ✅ **Observable Patterns**: EventEmitter, subscription management
+- ✅ **Concurrency Control**: Promise pools, semaphores, rate limiting
+- ✅ **Async Cache**: TTL-based caching, async operations
+- ✅ **Error Handling**: retry patterns, timeout handling
+- ✅ **Stream Processing**: batch processing, async pipelines
+
+### 5. `src/decorators-metadata.ts`
+Showcases TypeScript decorator system:
+- ✅ **Class Decorators**: @Entity, @Injectable, @Component
+- ✅ **Method Decorators**: @Log, @Cache, @Validate, @Retry
+- ✅ **Property Decorators**: @Column, @Required, @SerializableProperty
+- ✅ **Parameter Decorators**: @Inject, @ValidateParam
+- ✅ **Metadata Reflection**: using reflect-metadata
+- ✅ **Decorator Factories**: parameterized decorators
+- ✅ **Custom Decorators**: role-based access, validation
+- ✅ **Metadata Readers**: utility classes for metadata access
+
+### 6. `src/modules-namespaces.ts`
+Covers module system and organization:
+- ✅ **Basic Exports**: named exports, default exports, re-exports
+- ✅ **Namespace Declarations**: nested namespaces, namespace merging
+- ✅ **Module Augmentation**: extending existing types globally
+- ✅ **Ambient Declarations**: declaring external libraries
+- ✅ **Dynamic Imports**: code splitting, conditional loading
+- ✅ **Module Factories**: configurable modules, dependency injection
+- ✅ **Barrel Exports**: index files, re-export patterns
+- ✅ **Triple-Slash Directives**: type references, library references
+
+### 7. `src/advanced-types.ts`
+Advanced type system features:
+- ✅ **Mapped Types**: transforming object types, key transformation
+- ✅ **Conditional Types**: type-level logic, distributive conditionals
+- ✅ **Template Literal Types**: string manipulation, path building
+- ✅ **Recursive Types**: deeply nested type operations
+- ✅ **Branded Types**: nominal typing patterns, type safety
+- ✅ **Tuple Utilities**: head, tail, reverse operations
+- ✅ **String Manipulation**: uppercase, lowercase, split, join
+- ✅ **Type Predicates**: union detection, type guards
+- ✅ **Higher-Kinded Types**: functor simulation, HKT patterns
+
+### 8. `src/error-validation.ts`
+Error handling and validation patterns:
+- ✅ **Custom Error Classes**: structured error hierarchies
+- ✅ **Result Pattern**: functional error handling
+- ✅ **Type Guards**: runtime type checking, assertion functions
+- ✅ **Validation Schemas**: rule-based validation, transformers
+- ✅ **Error Boundaries**: centralized error handling
+- ✅ **Safe Parsing**: result-based parsing functions
+- ✅ **Assertion Functions**: type-narrowing assertions
+- ✅ **Try-Catch Utilities**: functional try-catch patterns
+
+### 9. `src/utilities-helpers.ts`
+Common utility functions and type helpers:
+- ✅ **String Utilities**: case conversion, truncation, normalization
+- ✅ **Array Utilities**: chunking, grouping, shuffling, sampling
+- ✅ **Object Utilities**: deep cloning, merging, property access
+- ✅ **Function Utilities**: debouncing, throttling, memoization
+- ✅ **Date Utilities**: formatting, arithmetic, comparisons
+- ✅ **Number Utilities**: clamping, rounding, formatting
+- ✅ **Validation Helpers**: email, URL, UUID, password validation
+- ✅ **Color Utilities**: hex/RGB conversion, color manipulation
+- ✅ **Performance Utilities**: timing, batching, measurement
+
+### 10. `src/index.ts` (Entry Point)
+Main entry point that imports and demonstrates usage of all modules.
+
+## Project Structure
+
+```
+sample_project_typescript/
+├── package.json                 # Dependencies and scripts
+├── tsconfig.json               # TypeScript configuration
+├── README.md                   # This documentation
+└── src/
+    ├── index.ts               # Main entry point
+    ├── types-interfaces.ts    # Core type system
+    ├── classes-inheritance.ts # OOP features
+    ├── functions-generics.ts  # Functions and generics
+    ├── async-promises.ts      # Async programming
+    ├── decorators-metadata.ts # Decorators system
+    ├── modules-namespaces.ts  # Module organization
+    ├── advanced-types.ts      # Advanced type features
+    ├── error-validation.ts    # Error handling
+    └── utilities-helpers.ts   # Common utilities
+```
+
+## Installation and Setup
+
+### Prerequisites
+- Node.js (v16 or higher)
+- npm or yarn package manager
+
+### Installation
+```bash
+# Install dependencies
+npm install
+
+# Or with yarn
+yarn install
+```
+
+### Available Scripts
+
+```bash
+# Compile TypeScript
+npm run build
+
+# Compile and watch for changes
+npm run build:watch
+
+# Run compiled JavaScript
+npm start
+
+# Run with ts-node (development)
+npm run dev
+
+# Run tests
+npm test
+
+# Run tests in watch mode
+npm run test:watch
+
+# Lint code
+npm run lint
+
+# Fix lint issues
+npm run lint:fix
+
+# Clean build artifacts
+npm run clean
+```
+
+## TypeScript Configuration
+
+The project uses strict TypeScript settings for maximum type safety:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    // ... other strict settings
+  }
+}
+```
+
+## Key Features Demonstrated
+
+### Type Safety
+- Strict null checks
+- Exact optional properties
+- No unchecked indexed access
+- Comprehensive type annotations
+
+### Modern TypeScript
+- Latest ES features (ES2020 target)
+- Experimental decorators
+- Advanced type manipulations
+- Template literal types
+
+### Best Practices
+- Proper error handling patterns
+- Functional programming concepts
+- Design pattern implementations
+- Performance optimization techniques
+
+### Real-World Patterns
+- Dependency injection
+- Validation frameworks
+- Async operation management
+- Utility library patterns
+
+## Usage Examples
+
+### Basic Type Usage
+```typescript
+import { User, createUser } from './types-interfaces';
+
+const user: User = {
+  id: 1,
+  name: "John Doe",
+  email: "john@example.com",
+  createdAt: new Date(),
+  preferences: {
+    theme: "dark",
+    notifications: true,
+    language: "en"
+  }
+};
+```
+
+### Class Inheritance
+```typescript
+import { Employee, Person } from './classes-inheritance';
+
+const employee = new Employee("Jane Smith", 28, 456, "Engineering", 75000);
+console.log(employee.introduce()); // Uses overridden method
+employee.celebrateBirthday(); // Accesses protected members
+```
+
+### Async Operations
+```typescript
+import { PromisePool, AsyncCache } from './async-promises';
+
+const pool = new PromisePool(3);
+const cache = new AsyncCache(60000);
+
+// Use promise pool for concurrent operations
+userIds.forEach(id => {
+  pool.add(() => fetchUserData(id));
+});
+
+const results = await pool.execute();
+```
+
+### Advanced Types
+```typescript
+import { DeepPartial, Paths, Get } from './advanced-types';
+
+type UserUpdate = DeepPartial<User>;
+type UserPaths = Paths<User>; // "name" | "email" | "preferences.theme" | etc.
+
+function getValue<T, K extends Paths<T>>(obj: T, path: K): Get<T, K> {
+  // Type-safe nested property access
+}
+```
+
+### Error Handling
+```typescript
+import { Result, Ok, Err, validateUser } from './error-validation';
+
+const result = validateUser(userData);
+
+if (result.success) {
+  // result.data is properly typed
+  console.log(result.data.name);
+} else {
+  // result.error contains validation errors
+  console.error(result.error);
+}
+```
+
+## Testing with Code Analysis Tools
+
+This project is specifically designed to test various code analysis scenarios:
+
+### Dependency Analysis
+- Import/export relationships
+- Module dependencies
+- Circular dependency detection
+
+### Type Analysis
+- Type inference testing
+- Generic resolution
+- Complex type relationships
+
+### Pattern Recognition
+- Design pattern detection
+- Common TypeScript idioms
+- Best practice validation
+
+### Complexity Metrics
+- Cyclomatic complexity
+- Type complexity
+- Inheritance hierarchies
+
+## Integration with Graph Databases
+
+The project structure supports graph database population for:
+
+### Node Types
+- **Files**: Source files, test files, configuration files
+- **Classes**: Regular classes, abstract classes, interfaces
+- **Functions**: Methods, static methods, constructors
+- **Types**: Interfaces, type aliases, enums
+- **Variables**: Properties, parameters, local variables
+
+### Relationship Types
+- **IMPORTS**: File import relationships
+- **EXTENDS**: Class/interface inheritance
+- **IMPLEMENTS**: Interface implementation
+- **CALLS**: Function call relationships
+- **USES**: Type usage relationships
+- **CONTAINS**: Containment relationships
+
+### Properties
+- **Language Features**: decorators, generics, async/await
+- **Access Modifiers**: public, private, protected
+- **Type Information**: parameter types, return types
+- **Metadata**: JSDoc comments, decorator metadata
+
+## Contributing
+
+When adding new TypeScript features or patterns:
+
+1. Create focused examples in the appropriate file
+2. Include comprehensive type annotations
+3. Add JSDoc comments for documentation
+4. Update this README with new features
+5. Ensure examples are realistic and practical
+
+## Language Features Coverage
+
+| Feature Category | Coverage | File Location |
+|-----------------|----------|---------------|
+| Basic Types | ✅ Complete | `types-interfaces.ts` |
+| Classes & OOP | ✅ Complete | `classes-inheritance.ts` |
+| Functions & Generics | ✅ Complete | `functions-generics.ts` |
+| Async Programming | ✅ Complete | `async-promises.ts` |
+| Decorators | ✅ Complete | `decorators-metadata.ts` |
+| Modules & Namespaces | ✅ Complete | `modules-namespaces.ts` |
+| Advanced Types | ✅ Complete | `advanced-types.ts` |
+| Error Handling | ✅ Complete | `error-validation.ts` |
+| Utilities | ✅ Complete | `utilities-helpers.ts` |
+
+## Use Cases
+
+This sample project is ideal for:
+
+### Development Tools
+- **IDEs**: Testing IntelliSense, refactoring, navigation
+- **Linters**: ESLint rule validation, custom rule testing
+- **Formatters**: Prettier configuration testing
+
+### Code Analysis
+- **Static Analysis**: Type checking, unused code detection
+- **Dependency Analysis**: Import graph construction
+- **Complexity Analysis**: Metrics calculation
+
+### Learning & Training
+- **TypeScript Education**: Comprehensive feature examples
+- **Best Practices**: Real-world pattern demonstration
+- **Code Reviews**: Reference implementation examples
+
+### Testing & QA
+- **Type System Testing**: Edge case coverage
+- **Tool Validation**: Ensuring tools handle complex TypeScript
+- **Performance Testing**: Large-scale TypeScript compilation
+
+## Versioning
+
+This project follows semantic versioning:
+- **Major**: Breaking changes to file structure or major feature additions
+- **Minor**: New TypeScript features, enhanced examples
+- **Patch**: Bug fixes, documentation improvements, minor updates
+
+Current version: **1.0.0**
+
+## License
+
+MIT License - feel free to use this project for testing, education, or as a reference implementation.
+
+---
+
+*This TypeScript sample project provides comprehensive coverage of modern TypeScript features and patterns, making it an ideal testing ground for code analysis tools, educational purposes, and development tool validation.*

--- a/tests/sample_project_typescript/package.json
+++ b/tests/sample_project_typescript/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "sample_project_typescript",
+  "version": "1.0.0",
+  "description": "Comprehensive TypeScript sample project for testing code analysis and indexing tools",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "clean": "rimraf dist"
+  },
+  "keywords": [
+    "typescript",
+    "sample",
+    "code-analysis",
+    "indexing",
+    "testing"
+  ],
+  "author": "Sample Project",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0",
+    "rimraf": "^5.0.0"
+  },
+  "dependencies": {
+    "reflect-metadata": "^0.1.13"
+  }
+}

--- a/tests/sample_project_typescript/src/advanced-types.ts
+++ b/tests/sample_project_typescript/src/advanced-types.ts
@@ -1,0 +1,376 @@
+/**
+ * Advanced Types
+ * Demonstrates TypeScript's advanced type system including mapped types,
+ * conditional types, template literal types, type manipulation, and complex patterns
+ */
+
+// ========== Mapped Types ==========
+export type Optional<T> = {
+  [K in keyof T]?: T[K];
+};
+
+export type Required<T> = {
+  [K in keyof T]-?: T[K];
+};
+
+export type Readonly<T> = {
+  readonly [K in keyof T]: T[K];
+};
+
+export type Mutable<T> = {
+  -readonly [K in keyof T]: T[K];
+};
+
+// Custom mapped type with transformation
+export type Stringify<T> = {
+  [K in keyof T]: string;
+};
+
+export type Nullify<T> = {
+  [K in keyof T]: T[K] | null;
+};
+
+// Mapped type with key transformation
+export type Getters<T> = {
+  [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
+};
+
+export type Setters<T> = {
+  [K in keyof T as `set${Capitalize<string & K>}`]: (value: T[K]) => void;
+};
+
+// ========== Conditional Types ==========
+export type NonNullable<T> = T extends null | undefined ? never : T;
+
+export type IsArray<T> = T extends any[] ? true : false;
+
+export type ArrayElementType<T> = T extends (infer U)[] ? U : never;
+
+export type ReturnTypeOf<T> = T extends (...args: any[]) => infer R ? R : never;
+
+export type ParametersOf<T> = T extends (...args: infer P) => any ? P : never;
+
+// Complex conditional type
+export type DeepReadonly<T> = T extends (infer U)[]
+  ? DeepReadonlyArray<U>
+  : T extends object
+  ? DeepReadonlyObject<T>
+  : T;
+
+interface DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
+
+type DeepReadonlyObject<T> = {
+  readonly [K in keyof T]: DeepReadonly<T[K]>;
+};
+
+// Conditional type with multiple conditions
+export type TypeName<T> = T extends string
+  ? "string"
+  : T extends number
+  ? "number"
+  : T extends boolean
+  ? "boolean"
+  : T extends undefined
+  ? "undefined"
+  : T extends Function
+  ? "function"
+  : "object";
+
+// ========== Template Literal Types ==========
+export type EventNames<T extends string> = `${T}Changed` | `${T}Updated` | `before${Capitalize<T>}`;
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+export type ApiEndpoint<T extends string> = `api/${T}`;
+export type ApiUrl<T extends string, M extends HttpMethod> = `${M} /${ApiEndpoint<T>}`;
+
+// CSS-in-JS style types
+export type CSSProperty = `--${string}` | keyof CSSStyleDeclaration;
+export type PixelValue<T extends number> = `${T}px`;
+export type PercentValue<T extends number> = `${T}%`;
+
+// Path-like template literals
+export type Join<K, P> = K extends string | number
+  ? P extends string | number
+    ? `${K}${"" extends P ? "" : "."}${P}`
+    : never
+  : never;
+
+export type Paths<T, D extends number = 10> = [D] extends [never]
+  ? never
+  : T extends object
+  ? {
+      [K in keyof T]-?: K extends string | number
+        ? `${K}` | Join<K, Paths<T[K], Prev[D]>>
+        : never;
+    }[keyof T]
+  : "";
+
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...0[]];
+
+// ========== Utility Types and Type Manipulation ==========
+export type PickByType<T, U> = Pick<T, { [K in keyof T]: T[K] extends U ? K : never }[keyof T]>;
+
+export type OmitByType<T, U> = Omit<T, { [K in keyof T]: T[K] extends U ? K : never }[keyof T]>;
+
+export type ExcludeKeys<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export type KeysOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
+
+// Deep pick utility
+export type DeepPick<T, K extends Paths<T>> = K extends `${infer Key}.${infer Rest}`
+  ? Key extends keyof T
+    ? { [P in Key]: DeepPick<T[P], Rest> }
+    : never
+  : K extends keyof T
+  ? { [P in K]: T[P] }
+  : never;
+
+// Function type utilities
+export type Promisify<T> = T extends (...args: infer A) => infer R
+  ? (...args: A) => Promise<R>
+  : never;
+
+export type Curry<T> = T extends (...args: infer A) => infer R
+  ? A extends [infer First, ...infer Rest]
+    ? (arg: First) => Rest extends []
+      ? R
+      : Curry<(...args: Rest) => R>
+    : () => R
+  : never;
+
+// ========== Recursive Types ==========
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;
+
+export type DeepRequired<T> = T extends object
+  ? {
+      [P in keyof T]-?: DeepRequired<T[P]>;
+    }
+  : T;
+
+// JSON type
+export type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
+interface JSONObject {
+  [key: string]: JSONValue;
+}
+interface JSONArray extends Array<JSONValue> {}
+
+// ========== Branded Types ==========
+declare const __brand: unique symbol;
+type Brand<T, TBrand extends string> = T & { [__brand]: TBrand };
+
+export type UserId = Brand<number, "UserId">;
+export type Email = Brand<string, "Email">;
+export type Timestamp = Brand<number, "Timestamp">;
+
+// Brand creation utilities
+export const createUserId = (id: number): UserId => id as UserId;
+export const createEmail = (email: string): Email => {
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw new Error("Invalid email format");
+  }
+  return email as Email;
+};
+
+// ========== Tuple Utilities ==========
+export type Head<T extends readonly any[]> = T extends readonly [infer H, ...any[]] ? H : never;
+export type Tail<T extends readonly any[]> = T extends readonly [any, ...infer Rest] ? Rest : [];
+export type Last<T extends readonly any[]> = T extends readonly [...any[], infer L] ? L : never;
+export type Length<T extends readonly any[]> = T["length"];
+
+export type Reverse<T extends any[]> = T extends [...infer Rest, infer Last]
+  ? [Last, ...Reverse<Rest>]
+  : [];
+
+// ========== String Manipulation Types ==========
+export type Uppercase<S extends string> = intrinsic;
+export type Lowercase<S extends string> = intrinsic;
+export type Capitalize<S extends string> = intrinsic;
+export type Uncapitalize<S extends string> = intrinsic;
+
+export type Split<S extends string, D extends string> = string extends S
+  ? string[]
+  : S extends ""
+  ? []
+  : S extends `${infer T}${D}${infer U}`
+  ? [T, ...Split<U, D>]
+  : [S];
+
+export type Join<T extends string[], D extends string> = T extends [
+  infer First,
+  ...infer Rest
+]
+  ? First extends string
+    ? Rest extends string[]
+      ? Rest["length"] extends 0
+        ? First
+        : `${First}${D}${Join<Rest, D>}`
+      : never
+    : never
+  : "";
+
+// ========== Advanced Pattern Matching ==========
+export type ExtractRouteParams<T extends string> = T extends `${string}:${infer Param}/${infer Rest}`
+  ? { [K in Param]: string } & ExtractRouteParams<Rest>
+  : T extends `${string}:${infer Param}`
+  ? { [K in Param]: string }
+  : {};
+
+export type ParseQueryString<T extends string> = T extends `${infer Key}=${infer Value}&${infer Rest}`
+  ? { [K in Key]: Value } & ParseQueryString<Rest>
+  : T extends `${infer Key}=${infer Value}`
+  ? { [K in Key]: Value }
+  : {};
+
+// ========== Type Predicates and Guards ==========
+export type IsUnion<T, U = T> = T extends U ? ([U] extends [T] ? false : true) : false;
+export type IsNever<T> = [T] extends [never] ? true : false;
+export type IsAny<T> = 0 extends 1 & T ? true : false;
+export type IsUnknown<T> = IsAny<T> extends true ? false : unknown extends T ? true : false;
+
+// ========== Higher-Kinded Types Simulation ==========
+export interface Functor<F> {
+  map<A, B>(fn: (a: A) => B): <T extends F>(fa: T) => T extends HKT<F, A> ? HKT<F, B> : never;
+}
+
+export interface HKT<F, A> {
+  _F: F;
+  _A: A;
+}
+
+// Array functor instance
+export type ArrayHKT = "Array";
+export interface ArrayF<A> extends HKT<ArrayHKT, A> {
+  _tag: A[];
+}
+
+// ========== Example Usage Types ==========
+interface User {
+  id: number;
+  name: string;
+  email: string;
+  age: number;
+  address: {
+    street: string;
+    city: string;
+    country: string;
+  };
+  preferences: {
+    theme: "light" | "dark";
+    notifications: boolean;
+  };
+}
+
+// Applied utility types
+export type Examples = {
+  // Mapped types
+  optionalUser: Optional<User>;
+  readonlyUser: Readonly<User>;
+  stringifiedUser: Stringify<User>;
+  
+  // Conditional types
+  userIsArray: IsArray<User>;
+  userArrayElement: ArrayElementType<User[]>;
+  nonNullableString: NonNullable<string | null>;
+  
+  // Template literals
+  userEventNames: EventNames<"user">;
+  apiEndpoints: ApiUrl<"users", "GET"> | ApiUrl<"posts", "POST">;
+  
+  // Utility combinations
+  userOnlyStrings: PickByType<User, string>;
+  userWithoutStrings: OmitByType<User, string>;
+  userPaths: Paths<User>;
+  
+  // Branded types
+  userId: UserId;
+  userEmail: Email;
+  
+  // Advanced patterns
+  routeParams: ExtractRouteParams<"/users/:id/posts/:postId">;
+  queryParams: ParseQueryString<"search=typescript&sort=date&limit=10">;
+};
+
+// ========== Complex Type Challenges ==========
+// Function composition types
+export type Compose<F extends any[], T = any> = F extends [
+  (...args: any[]) => infer R
+]
+  ? (arg: T) => R
+  : F extends [(...args: any[]) => infer R, ...infer Rest]
+  ? (arg: T) => Compose<Rest, R>
+  : never;
+
+// Object path access
+export type Get<T, K> = K extends `${infer Key}.${infer Rest}`
+  ? Key extends keyof T
+    ? Get<T[Key], Rest>
+    : never
+  : K extends keyof T
+  ? T[K]
+  : never;
+
+// Type-safe SQL-like operations
+export type Select<T, K extends keyof T> = Pick<T, K>;
+export type Where<T, K extends keyof T, V> = T[K] extends V ? T : never;
+export type OrderBy<T, K extends keyof T> = T; // Simplified for demo
+
+// State machine types
+export type StateMachine<States extends string, Events extends string> = {
+  [S in States]: {
+    [E in Events]?: States;
+  };
+};
+
+export type UserStateMachine = StateMachine<
+  "idle" | "loading" | "success" | "error",
+  "fetch" | "success" | "error" | "reset"
+>;
+
+// ========== Type-Level Arithmetic (Basic) ==========
+export type Add<A extends number, B extends number> = [...Tuple<A>, ...Tuple<B>]["length"];
+export type Tuple<T extends number> = T extends T ? (T extends 0 ? [] : [...Tuple<Subtract<T, 1>>, any]) : never;
+export type Subtract<A extends number, B extends number> = Tuple<A> extends [...infer U, ...Tuple<B>] ? U["length"] : never;
+
+// ========== Usage Examples ==========
+export const advancedTypesExamples = {
+  // Branded types usage
+  userId: createUserId(123),
+  userEmail: createEmail("user@example.com"),
+  
+  // Template literal types
+  apiUrl: "GET /api/users" as ApiUrl<"users", "GET">,
+  
+  // Complex type transformations
+  userPaths: ["id", "name", "email", "address.street", "preferences.theme"] as Paths<User>[],
+  
+  // Type predicates
+  isUnion: false as IsUnion<string | number>,
+  isNever: false as IsNever<never>,
+  isAny: false as IsAny<any>,
+};
+
+// Example of using advanced types in practice
+export function createTypeSafeGetter<T>() {
+  return function get<K extends Paths<T>>(obj: T, path: K): Get<T, K> {
+    const keys = path.split('.') as string[];
+    let result: any = obj;
+    
+    for (const key of keys) {
+      result = result?.[key];
+    }
+    
+    return result as Get<T, K>;
+  };
+}
+
+// Usage of the type-safe getter
+const userGetter = createTypeSafeGetter<User>();
+export const getExample = {
+  userName: userGetter({} as User, "name"), // Type is string
+  userCity: userGetter({} as User, "address.city"), // Type is string
+  userTheme: userGetter({} as User, "preferences.theme"), // Type is "light" | "dark"
+};

--- a/tests/sample_project_typescript/src/async-promises.ts
+++ b/tests/sample_project_typescript/src/async-promises.ts
@@ -1,0 +1,438 @@
+/**
+ * Async and Promises
+ * Demonstrates TypeScript's asynchronous programming features including
+ * promises, async/await, error handling, concurrent operations, and patterns
+ */
+
+// ========== Basic Promises ==========
+export function createPromise<T>(value: T, delay: number = 100): Promise<T> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(value), delay);
+  });
+}
+
+export function createRejectedPromise(error: string, delay: number = 100): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error(error)), delay);
+  });
+}
+
+// ========== Async Functions ==========
+export async function fetchUserData(id: number): Promise<{ id: number; name: string; email: string }> {
+  // Simulate API call
+  await new Promise(resolve => setTimeout(resolve, 200));
+  
+  if (id <= 0) {
+    throw new Error("Invalid user ID");
+  }
+  
+  return {
+    id,
+    name: `User ${id}`,
+    email: `user${id}@example.com`
+  };
+}
+
+export async function fetchUserPosts(userId: number): Promise<{ id: number; title: string; content: string }[]> {
+  await new Promise(resolve => setTimeout(resolve, 150));
+  
+  return Array.from({ length: 3 }, (_, index) => ({
+    id: index + 1,
+    title: `Post ${index + 1} by User ${userId}`,
+    content: `This is the content of post ${index + 1}`
+  }));
+}
+
+// ========== Error Handling with Async/Await ==========
+export async function safeAsyncOperation<T>(
+  operation: () => Promise<T>
+): Promise<{ success: true; data: T } | { success: false; error: string }> {
+  try {
+    const data = await operation();
+    return { success: true, data };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error"
+    };
+  }
+}
+
+export async function retryOperation<T>(
+  operation: () => Promise<T>,
+  maxRetries: number = 3,
+  delay: number = 1000
+): Promise<T> {
+  let lastError: Error;
+  
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      
+      if (attempt === maxRetries) {
+        throw lastError;
+      }
+      
+      // Exponential backoff
+      await new Promise(resolve => setTimeout(resolve, delay * Math.pow(2, attempt - 1)));
+    }
+  }
+  
+  throw lastError!;
+}
+
+// ========== Promise Combinators ==========
+export async function processInParallel<T>(
+  items: T[],
+  processor: (item: T) => Promise<any>,
+  concurrency: number = 3
+): Promise<any[]> {
+  const results: any[] = [];
+  const chunks: T[][] = [];
+  
+  // Split into chunks
+  for (let i = 0; i < items.length; i += concurrency) {
+    chunks.push(items.slice(i, i + concurrency));
+  }
+  
+  // Process chunks sequentially, items within chunks in parallel
+  for (const chunk of chunks) {
+    const chunkResults = await Promise.all(chunk.map(processor));
+    results.push(...chunkResults);
+  }
+  
+  return results;
+}
+
+export async function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(`Operation timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  
+  return Promise.race([promise, timeoutPromise]);
+}
+
+// ========== Async Iterators and Generators ==========
+export async function* asyncGenerator(count: number): AsyncGenerator<number, void, unknown> {
+  for (let i = 0; i < count; i++) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    yield i;
+  }
+}
+
+export async function* fetchDataStream(urls: string[]): AsyncGenerator<string, void, unknown> {
+  for (const url of urls) {
+    // Simulate fetching data
+    await new Promise(resolve => setTimeout(resolve, 200));
+    yield `Data from ${url}`;
+  }
+}
+
+export async function consumeAsyncGenerator<T>(generator: AsyncGenerator<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const item of generator) {
+    results.push(item);
+  }
+  return results;
+}
+
+// ========== Observable Pattern ==========
+export class EventEmitter<T> {
+  private listeners: ((data: T) => void)[] = [];
+  private asyncListeners: ((data: T) => Promise<void>)[] = [];
+
+  subscribe(callback: (data: T) => void): () => void {
+    this.listeners.push(callback);
+    return () => {
+      const index = this.listeners.indexOf(callback);
+      if (index > -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+
+  subscribeAsync(callback: (data: T) => Promise<void>): () => void {
+    this.asyncListeners.push(callback);
+    return () => {
+      const index = this.asyncListeners.indexOf(callback);
+      if (index > -1) {
+        this.asyncListeners.splice(index, 1);
+      }
+    };
+  }
+
+  emit(data: T): void {
+    this.listeners.forEach(callback => callback(data));
+    // Fire async listeners but don't wait
+    this.asyncListeners.forEach(callback => callback(data).catch(console.error));
+  }
+
+  async emitAsync(data: T): Promise<void> {
+    this.listeners.forEach(callback => callback(data));
+    await Promise.all(this.asyncListeners.map(callback => callback(data)));
+  }
+}
+
+// ========== Promise Pool ==========
+export class PromisePool<T, R> {
+  private concurrency: number;
+  private tasks: (() => Promise<R>)[] = [];
+  private running: number = 0;
+  private results: R[] = [];
+  private errors: Error[] = [];
+
+  constructor(concurrency: number = 5) {
+    this.concurrency = concurrency;
+  }
+
+  add(task: () => Promise<R>): void {
+    this.tasks.push(task);
+  }
+
+  async execute(): Promise<{ results: R[]; errors: Error[] }> {
+    return new Promise((resolve) => {
+      const executeNext = () => {
+        if (this.tasks.length === 0 && this.running === 0) {
+          resolve({ results: this.results, errors: this.errors });
+          return;
+        }
+
+        while (this.running < this.concurrency && this.tasks.length > 0) {
+          const task = this.tasks.shift()!;
+          this.running++;
+
+          task()
+            .then(result => {
+              this.results.push(result);
+            })
+            .catch(error => {
+              this.errors.push(error instanceof Error ? error : new Error(String(error)));
+            })
+            .finally(() => {
+              this.running--;
+              executeNext();
+            });
+        }
+      };
+
+      executeNext();
+    });
+  }
+}
+
+// ========== Async Cache ==========
+export class AsyncCache<K, V> {
+  private cache = new Map<K, Promise<V>>();
+  private ttl: number;
+
+  constructor(ttlMs: number = 60000) {
+    this.ttl = ttlMs;
+  }
+
+  async get(key: K, factory: () => Promise<V>): Promise<V> {
+    if (this.cache.has(key)) {
+      try {
+        return await this.cache.get(key)!;
+      } catch (error) {
+        // Remove failed promise from cache
+        this.cache.delete(key);
+        throw error;
+      }
+    }
+
+    const promise = factory();
+    this.cache.set(key, promise);
+
+    // Set TTL
+    setTimeout(() => {
+      this.cache.delete(key);
+    }, this.ttl);
+
+    return promise;
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  has(key: K): boolean {
+    return this.cache.has(key);
+  }
+}
+
+// ========== Async Semaphore ==========
+export class Semaphore {
+  private permits: number;
+  private waiting: (() => void)[] = [];
+
+  constructor(permits: number) {
+    this.permits = permits;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits--;
+      return;
+    }
+
+    return new Promise<void>((resolve) => {
+      this.waiting.push(resolve);
+    });
+  }
+
+  release(): void {
+    if (this.waiting.length > 0) {
+      const next = this.waiting.shift()!;
+      next();
+    } else {
+      this.permits++;
+    }
+  }
+
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+}
+
+// ========== Worker Pattern ==========
+export class TaskQueue<T> {
+  private queue: T[] = [];
+  private processing = false;
+  private processor: (item: T) => Promise<void>;
+
+  constructor(processor: (item: T) => Promise<void>) {
+    this.processor = processor;
+  }
+
+  enqueue(item: T): void {
+    this.queue.push(item);
+    if (!this.processing) {
+      this.processQueue();
+    }
+  }
+
+  private async processQueue(): Promise<void> {
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      const item = this.queue.shift()!;
+      try {
+        await this.processor(item);
+      } catch (error) {
+        console.error("Error processing queue item:", error);
+      }
+    }
+
+    this.processing = false;
+  }
+
+  get length(): number {
+    return this.queue.length;
+  }
+
+  get isProcessing(): boolean {
+    return this.processing;
+  }
+}
+
+// ========== Stream Processing ==========
+export async function processStream<T, R>(
+  items: T[],
+  transformer: (item: T) => Promise<R>,
+  batchSize: number = 10
+): Promise<R[]> {
+  const results: R[] = [];
+  
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchResults = await Promise.all(batch.map(transformer));
+    results.push(...batchResults);
+  }
+  
+  return results;
+}
+
+// ========== Usage Examples ==========
+export const asyncExamples = {
+  // Event emitter
+  userEvents: new EventEmitter<{ userId: number; action: string }>(),
+  
+  // Promise pool
+  apiCallPool: new PromisePool<void, any>(3),
+  
+  // Async cache
+  userCache: new AsyncCache<number, { id: number; name: string }>(30000),
+  
+  // Semaphore for rate limiting
+  rateLimiter: new Semaphore(5),
+  
+  // Task queue
+  notificationQueue: new TaskQueue<{ userId: number; message: string }>(async (notification) => {
+    console.log(`Sending notification to user ${notification.userId}: ${notification.message}`);
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }),
+};
+
+// ========== Complex Async Operations ==========
+export async function fetchUserProfile(userId: number): Promise<{
+  user: { id: number; name: string; email: string };
+  posts: { id: number; title: string; content: string }[];
+}> {
+  try {
+    // Fetch user and posts in parallel
+    const [user, posts] = await Promise.all([
+      fetchUserData(userId),
+      fetchUserPosts(userId)
+    ]);
+
+    return { user, posts };
+  } catch (error) {
+    throw new Error(`Failed to fetch user profile: ${error}`);
+  }
+}
+
+export async function batchProcessUsers(userIds: number[]): Promise<any[]> {
+  // Use the promise pool to limit concurrent API calls
+  const pool = new PromisePool<void, any>(3);
+  
+  userIds.forEach(id => {
+    pool.add(async () => {
+      const profile = await fetchUserProfile(id);
+      return profile;
+    });
+  });
+
+  const { results, errors } = await pool.execute();
+  
+  if (errors.length > 0) {
+    console.warn(`${errors.length} errors occurred during batch processing:`, errors);
+  }
+  
+  return results;
+}
+
+// Initialize some examples
+asyncExamples.userEvents.subscribe((event) => {
+  console.log(`User event: ${event.action} for user ${event.userId}`);
+});
+
+// Example of using the notification queue
+asyncExamples.notificationQueue.enqueue({
+  userId: 1,
+  message: "Welcome to our platform!"
+});
+
+asyncExamples.notificationQueue.enqueue({
+  userId: 2,
+  message: "Your order has been shipped!"
+});

--- a/tests/sample_project_typescript/src/classes-inheritance.ts
+++ b/tests/sample_project_typescript/src/classes-inheritance.ts
@@ -1,0 +1,389 @@
+/**
+ * Classes and Inheritance
+ * Demonstrates TypeScript's OOP features including classes, inheritance,
+ * abstract classes, access modifiers, static members, and advanced patterns
+ */
+
+// ========== Basic Class Definition ==========
+export class Person {
+  // Public property (default)
+  public name: string;
+  
+  // Private property (only accessible within this class)
+  private _id: number;
+  
+  // Protected property (accessible in this class and subclasses)
+  protected age: number;
+  
+  // Readonly property
+  readonly birthDate: Date;
+  
+  // Static property
+  static species: string = "Homo sapiens";
+  
+  // Static method
+  static getSpecies(): string {
+    return Person.species;
+  }
+
+  constructor(name: string, age: number, id: number) {
+    this.name = name;
+    this.age = age;
+    this._id = id;
+    this.birthDate = new Date();
+  }
+
+  // Public method
+  public introduce(): string {
+    return `Hello, I'm ${this.name} and I'm ${this.age} years old.`;
+  }
+
+  // Private method
+  private validateAge(age: number): boolean {
+    return age >= 0 && age <= 150;
+  }
+
+  // Protected method
+  protected updateAge(newAge: number): void {
+    if (this.validateAge(newAge)) {
+      this.age = newAge;
+    }
+  }
+
+  // Getter
+  get id(): number {
+    return this._id;
+  }
+
+  // Setter
+  set id(value: number) {
+    if (value > 0) {
+      this._id = value;
+    }
+  }
+
+  // Method with overloads
+  greet(): string;
+  greet(formal: boolean): string;
+  greet(formal: boolean, title: string): string;
+  greet(formal?: boolean, title?: string): string {
+    const greeting = formal ? "Good day" : "Hi";
+    const nameWithTitle = title ? `${title} ${this.name}` : this.name;
+    return `${greeting}, ${nameWithTitle}!`;
+  }
+}
+
+// ========== Inheritance ==========
+export class Employee extends Person {
+  private salary: number;
+  public department: string;
+  
+  constructor(name: string, age: number, id: number, department: string, salary: number) {
+    super(name, age, id); // Call parent constructor
+    this.department = department;
+    this.salary = salary;
+  }
+
+  // Override parent method
+  public override introduce(): string {
+    return `${super.introduce()} I work in ${this.department}.`;
+  }
+
+  // New method specific to Employee
+  public work(): string {
+    return `${this.name} is working in the ${this.department} department.`;
+  }
+
+  // Access protected member from parent
+  public celebrateBirthday(): void {
+    this.updateAge(this.age + 1);
+    console.log(`Happy birthday! Now ${this.age} years old.`);
+  }
+
+  // Getter for private property
+  get monthlySalary(): number {
+    return this.salary;
+  }
+
+  // Setter with validation
+  set monthlySalary(value: number) {
+    if (value >= 0) {
+      this.salary = value;
+    } else {
+      throw new Error("Salary cannot be negative");
+    }
+  }
+}
+
+// ========== Abstract Classes ==========
+export abstract class Animal {
+  protected name: string;
+  protected age: number;
+  
+  constructor(name: string, age: number) {
+    this.name = name;
+    this.age = age;
+  }
+
+  // Concrete method
+  public sleep(): string {
+    return `${this.name} is sleeping.`;
+  }
+
+  // Abstract method (must be implemented by subclasses)
+  abstract makeSound(): string;
+  
+  // Abstract method with parameters
+  abstract move(distance: number): string;
+}
+
+// ========== Concrete Implementation of Abstract Class ==========
+export class Dog extends Animal {
+  private breed: string;
+  
+  constructor(name: string, age: number, breed: string) {
+    super(name, age);
+    this.breed = breed;
+  }
+
+  // Implementation of abstract method
+  public makeSound(): string {
+    return `${this.name} the ${this.breed} says: Woof! Woof!`;
+  }
+
+  // Implementation of abstract method
+  public move(distance: number): string {
+    return `${this.name} runs ${distance} meters.`;
+  }
+
+  // Additional method specific to Dog
+  public fetch(): string {
+    return `${this.name} fetches the ball!`;
+  }
+}
+
+export class Cat extends Animal {
+  private indoor: boolean;
+  
+  constructor(name: string, age: number, indoor: boolean = true) {
+    super(name, age);
+    this.indoor = indoor;
+  }
+
+  public makeSound(): string {
+    return `${this.name} says: Meow!`;
+  }
+
+  public move(distance: number): string {
+    const verb = this.indoor ? "walks" : "prowls";
+    return `${this.name} ${verb} ${distance} meters.`;
+  }
+
+  public climb(): string {
+    return `${this.name} climbs up high.`;
+  }
+}
+
+// ========== Interface Implementation ==========
+interface Flyable {
+  fly(height: number): string;
+  land(): string;
+}
+
+interface Swimmable {
+  swim(depth: number): string;
+  surface(): string;
+}
+
+export class Duck extends Animal implements Flyable, Swimmable {
+  constructor(name: string, age: number) {
+    super(name, age);
+  }
+
+  public makeSound(): string {
+    return `${this.name} says: Quack! Quack!`;
+  }
+
+  public move(distance: number): string {
+    return `${this.name} waddles ${distance} meters.`;
+  }
+
+  // Implement Flyable
+  public fly(height: number): string {
+    return `${this.name} flies at ${height} meters high.`;
+  }
+
+  public land(): string {
+    return `${this.name} lands gracefully.`;
+  }
+
+  // Implement Swimmable
+  public swim(depth: number): string {
+    return `${this.name} swims at ${depth} meters deep.`;
+  }
+
+  public surface(): string {
+    return `${this.name} surfaces from the water.`;
+  }
+}
+
+// ========== Generic Classes ==========
+export class Container<T> {
+  private items: T[] = [];
+
+  public add(item: T): void {
+    this.items.push(item);
+  }
+
+  public remove(item: T): boolean {
+    const index = this.items.indexOf(item);
+    if (index > -1) {
+      this.items.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+
+  public getAll(): readonly T[] {
+    return [...this.items];
+  }
+
+  public size(): number {
+    return this.items.length;
+  }
+
+  public clear(): void {
+    this.items = [];
+  }
+}
+
+// Generic class with constraints
+export class NumberContainer<T extends number> extends Container<T> {
+  public sum(): T {
+    return this.getAll().reduce((sum, item) => (sum + item) as T, 0 as T);
+  }
+
+  public average(): number {
+    const items = this.getAll();
+    return items.length > 0 ? this.sum() / items.length : 0;
+  }
+}
+
+// ========== Singleton Pattern ==========
+export class Database {
+  private static instance: Database;
+  private connections: number = 0;
+
+  private constructor() {
+    // Private constructor prevents instantiation
+  }
+
+  public static getInstance(): Database {
+    if (!Database.instance) {
+      Database.instance = new Database();
+    }
+    return Database.instance;
+  }
+
+  public connect(): string {
+    this.connections++;
+    return `Connected to database. Total connections: ${this.connections}`;
+  }
+
+  public disconnect(): string {
+    if (this.connections > 0) {
+      this.connections--;
+      return `Disconnected from database. Remaining connections: ${this.connections}`;
+    }
+    return "No active connections to disconnect.";
+  }
+}
+
+// ========== Static Class Pattern ==========
+export class MathUtils {
+  // Prevent instantiation
+  private constructor() {}
+
+  public static PI: number = Math.PI;
+  
+  public static calculateCircleArea(radius: number): number {
+    return MathUtils.PI * radius * radius;
+  }
+
+  public static calculateDistance(x1: number, y1: number, x2: number, y2: number): number {
+    return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
+  }
+
+  public static clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+  }
+}
+
+// ========== Mixins Pattern ==========
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+// Mixin function
+export function Timestamped<TBase extends Constructor>(Base: TBase) {
+  return class extends Base {
+    timestamp = Date.now();
+    
+    getTimestamp(): number {
+      return this.timestamp;
+    }
+  };
+}
+
+export function Activatable<TBase extends Constructor>(Base: TBase) {
+  return class extends Base {
+    isActive = false;
+    
+    activate(): void {
+      this.isActive = true;
+    }
+    
+    deactivate(): void {
+      this.isActive = false;
+    }
+  };
+}
+
+// Base class for mixins
+export class BaseUser {
+  constructor(public name: string) {}
+}
+
+// Apply mixins
+export const TimestampedUser = Timestamped(BaseUser);
+export const ActivatableUser = Activatable(BaseUser);
+export const EnhancedUser = Timestamped(Activatable(BaseUser));
+
+// ========== Usage Examples ==========
+export const classExamples = {
+  // Basic usage
+  person: new Person("John Doe", 30, 123),
+  employee: new Employee("Jane Smith", 28, 456, "Engineering", 75000),
+  
+  // Animals
+  dog: new Dog("Buddy", 3, "Golden Retriever"),
+  cat: new Cat("Whiskers", 2, true),
+  duck: new Duck("Quackers", 1),
+  
+  // Generic containers
+  stringContainer: new Container<string>(),
+  numberContainer: new NumberContainer<number>(),
+  
+  // Singleton
+  database: Database.getInstance(),
+  
+  // Mixins
+  timestampedUser: new TimestampedUser("Alice"),
+  enhancedUser: new EnhancedUser("Bob")
+};
+
+// Initialize some examples
+classExamples.stringContainer.add("Hello");
+classExamples.stringContainer.add("World");
+
+classExamples.numberContainer.add(10);
+classExamples.numberContainer.add(20);
+classExamples.numberContainer.add(30);

--- a/tests/sample_project_typescript/src/decorators-metadata.ts
+++ b/tests/sample_project_typescript/src/decorators-metadata.ts
@@ -1,0 +1,473 @@
+/**
+ * Decorators and Metadata
+ * Demonstrates TypeScript decorators for classes, methods, properties, and parameters
+ * Note: Requires experimentalDecorators and emitDecoratorMetadata in tsconfig.json
+ * Also requires reflect-metadata package for metadata reflection
+ */
+
+import "reflect-metadata";
+
+// ========== Metadata Keys ==========
+export const METADATA_KEYS = {
+  VALIDATION_RULES: Symbol("validation:rules"),
+  ROUTE_INFO: Symbol("route:info"),
+  INJECTABLE: Symbol("injectable"),
+  CACHE_CONFIG: Symbol("cache:config"),
+  LOG_CONFIG: Symbol("log:config"),
+  REQUIRED_ROLE: Symbol("required:role"),
+  SERIALIZABLE: Symbol("serializable"),
+  MAPPED_PROPERTY: Symbol("mapped:property")
+};
+
+// ========== Class Decorators ==========
+export function Entity(tableName?: string): ClassDecorator {
+  return function <T extends Function>(constructor: T) {
+    Reflect.defineMetadata("entity:table", tableName || constructor.name.toLowerCase(), constructor);
+    return constructor;
+  };
+}
+
+export function Injectable(): ClassDecorator {
+  return function <T extends Function>(constructor: T) {
+    Reflect.defineMetadata(METADATA_KEYS.INJECTABLE, true, constructor);
+    return constructor;
+  };
+}
+
+export function Component(config: { selector: string; template?: string }): ClassDecorator {
+  return function <T extends Function>(constructor: T) {
+    Reflect.defineMetadata("component:config", config, constructor);
+    return constructor;
+  };
+}
+
+export function Serializable(): ClassDecorator {
+  return function <T extends Function>(constructor: T) {
+    Reflect.defineMetadata(METADATA_KEYS.SERIALIZABLE, true, constructor);
+    
+    // Add serialize method to prototype if it doesn't exist
+    if (!constructor.prototype.serialize) {
+      constructor.prototype.serialize = function() {
+        const result: any = {};
+        const serializableProps = Reflect.getMetadata("serializable:properties", this.constructor) || [];
+        
+        for (const prop of serializableProps) {
+          if (this[prop] !== undefined) {
+            result[prop] = this[prop];
+          }
+        }
+        
+        return result;
+      };
+    }
+    
+    return constructor;
+  };
+}
+
+// ========== Method Decorators ==========
+export function Log(message?: string): MethodDecorator {
+  return function (target: any, propertyName: string | symbol, descriptor: PropertyDescriptor) {
+    const originalMethod = descriptor.value;
+    const className = target.constructor.name;
+    
+    descriptor.value = function (...args: any[]) {
+      console.log(`[${className}.${String(propertyName)}] ${message || 'Method called'} with args:`, args);
+      const result = originalMethod.apply(this, args);
+      console.log(`[${className}.${String(propertyName)}] Result:`, result);
+      return result;
+    };
+    
+    return descriptor;
+  };
+}
+
+export function Validate(): MethodDecorator {
+  return function (target: any, propertyName: string | symbol, descriptor: PropertyDescriptor) {
+    const originalMethod = descriptor.value;
+    
+    descriptor.value = function (...args: any[]) {
+      // Get validation rules from metadata
+      const rules = Reflect.getMetadata(METADATA_KEYS.VALIDATION_RULES, target, propertyName) || [];
+      
+      for (const rule of rules) {
+        if (!rule.validate(...args)) {
+          throw new Error(rule.message);
+        }
+      }
+      
+      return originalMethod.apply(this, args);
+    };
+    
+    return descriptor;
+  };
+}
+
+export function Cache(ttl: number = 60000): MethodDecorator {
+  const cache = new Map<string, { value: any; expires: number }>();
+  
+  return function (target: any, propertyName: string | symbol, descriptor: PropertyDescriptor) {
+    const originalMethod = descriptor.value;
+    
+    descriptor.value = function (...args: any[]) {
+      const cacheKey = `${target.constructor.name}.${String(propertyName)}:${JSON.stringify(args)}`;
+      const cached = cache.get(cacheKey);
+      
+      if (cached && Date.now() < cached.expires) {
+        console.log(`Cache hit for ${cacheKey}`);
+        return cached.value;
+      }
+      
+      const result = originalMethod.apply(this, args);
+      cache.set(cacheKey, { value: result, expires: Date.now() + ttl });
+      console.log(`Cache set for ${cacheKey}`);
+      
+      return result;
+    };
+    
+    return descriptor;
+  };
+}
+
+export function Retry(maxAttempts: number = 3, delay: number = 1000): MethodDecorator {
+  return function (target: any, propertyName: string | symbol, descriptor: PropertyDescriptor) {
+    const originalMethod = descriptor.value;
+    
+    descriptor.value = async function (...args: any[]) {
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          return await originalMethod.apply(this, args);
+        } catch (error) {
+          if (attempt === maxAttempts) {
+            throw error;
+          }
+          
+          console.log(`Attempt ${attempt} failed, retrying in ${delay}ms...`);
+          await new Promise(resolve => setTimeout(resolve, delay * attempt));
+        }
+      }
+    };
+    
+    return descriptor;
+  };
+}
+
+export function RequireRole(role: string): MethodDecorator {
+  return function (target: any, propertyName: string | symbol, descriptor: PropertyDescriptor) {
+    Reflect.defineMetadata(METADATA_KEYS.REQUIRED_ROLE, role, target, propertyName);
+    
+    const originalMethod = descriptor.value;
+    
+    descriptor.value = function (...args: any[]) {
+      const userRole = (this as any).currentUserRole;
+      const requiredRole = Reflect.getMetadata(METADATA_KEYS.REQUIRED_ROLE, target, propertyName);
+      
+      if (!userRole || userRole !== requiredRole) {
+        throw new Error(`Access denied. Required role: ${requiredRole}, current role: ${userRole}`);
+      }
+      
+      return originalMethod.apply(this, args);
+    };
+    
+    return descriptor;
+  };
+}
+
+// ========== Property Decorators ==========
+export function Column(options?: { name?: string; type?: string; nullable?: boolean }): PropertyDecorator {
+  return function (target: any, propertyKey: string | symbol) {
+    const columns = Reflect.getMetadata("entity:columns", target.constructor) || [];
+    columns.push({
+      propertyKey,
+      ...options
+    });
+    Reflect.defineMetadata("entity:columns", columns, target.constructor);
+  };
+}
+
+export function Required(): PropertyDecorator {
+  return function (target: any, propertyKey: string | symbol) {
+    const required = Reflect.getMetadata("validation:required", target.constructor) || [];
+    required.push(propertyKey);
+    Reflect.defineMetadata("validation:required", required, target.constructor);
+  };
+}
+
+export function MinLength(length: number): PropertyDecorator {
+  return function (target: any, propertyKey: string | symbol) {
+    const validations = Reflect.getMetadata("validation:rules", target.constructor) || {};
+    validations[propertyKey] = validations[propertyKey] || [];
+    validations[propertyKey].push({
+      type: "minLength",
+      value: length,
+      message: `${String(propertyKey)} must be at least ${length} characters long`
+    });
+    Reflect.defineMetadata("validation:rules", validations, target.constructor);
+  };
+}
+
+export function Max(value: number): PropertyDecorator {
+  return function (target: any, propertyKey: string | symbol) {
+    const validations = Reflect.getMetadata("validation:rules", target.constructor) || {};
+    validations[propertyKey] = validations[propertyKey] || [];
+    validations[propertyKey].push({
+      type: "max",
+      value: value,
+      message: `${String(propertyKey)} must not exceed ${value}`
+    });
+    Reflect.defineMetadata("validation:rules", validations, target.constructor);
+  };
+}
+
+export function SerializableProperty(alias?: string): PropertyDecorator {
+  return function (target: any, propertyKey: string | symbol) {
+    const serializableProps = Reflect.getMetadata("serializable:properties", target.constructor) || [];
+    serializableProps.push(propertyKey);
+    Reflect.defineMetadata("serializable:properties", serializableProps, target.constructor);
+    
+    if (alias) {
+      const aliases = Reflect.getMetadata("serializable:aliases", target.constructor) || {};
+      aliases[propertyKey] = alias;
+      Reflect.defineMetadata("serializable:aliases", aliases, target.constructor);
+    }
+  };
+}
+
+export function Computed(): PropertyDecorator {
+  return function (target: any, propertyKey: string | symbol) {
+    const computed = Reflect.getMetadata("computed:properties", target.constructor) || [];
+    computed.push(propertyKey);
+    Reflect.defineMetadata("computed:properties", computed, target.constructor);
+  };
+}
+
+// ========== Parameter Decorators ==========
+export function Inject(token?: string): ParameterDecorator {
+  return function (target: any, propertyKey: string | symbol | undefined, parameterIndex: number) {
+    const existingTokens = Reflect.getMetadata("inject:tokens", target) || [];
+    existingTokens[parameterIndex] = token;
+    Reflect.defineMetadata("inject:tokens", existingTokens, target);
+  };
+}
+
+export function ValidateParam(validator: (value: any) => boolean, message: string): ParameterDecorator {
+  return function (target: any, propertyKey: string | symbol | undefined, parameterIndex: number) {
+    const existingRules = Reflect.getMetadata(METADATA_KEYS.VALIDATION_RULES, target, propertyKey) || [];
+    existingRules.push({
+      parameterIndex,
+      validate: (args: any[]) => validator(args[parameterIndex]),
+      message
+    });
+    Reflect.defineMetadata(METADATA_KEYS.VALIDATION_RULES, existingRules, target, propertyKey);
+  };
+}
+
+// ========== Accessor Decorators ==========
+export function Getter(): MethodDecorator {
+  return function (target: any, propertyName: string | symbol, descriptor: PropertyDescriptor) {
+    Reflect.defineMetadata("accessor:type", "getter", target, propertyName);
+    return descriptor;
+  };
+}
+
+export function Setter(): MethodDecorator {
+  return function (target: any, propertyName: string | symbol, descriptor: PropertyDescriptor) {
+    Reflect.defineMetadata("accessor:type", "setter", target, propertyName);
+    return descriptor;
+  };
+}
+
+// ========== Utility Functions for Metadata ==========
+export class MetadataReader {
+  static getClassMetadata<T>(target: any, key: string | symbol): T | undefined {
+    return Reflect.getMetadata(key, target);
+  }
+
+  static getMethodMetadata<T>(target: any, method: string, key: string | symbol): T | undefined {
+    return Reflect.getMetadata(key, target, method);
+  }
+
+  static getPropertyMetadata<T>(target: any, property: string, key: string | symbol): T | undefined {
+    return Reflect.getMetadata(key, target, property);
+  }
+
+  static getAllMethodNames(target: any): string[] {
+    const methods: string[] = [];
+    let current = target.prototype;
+    
+    while (current && current !== Object.prototype) {
+      const names = Object.getOwnPropertyNames(current);
+      for (const name of names) {
+        if (name !== 'constructor' && typeof current[name] === 'function' && !methods.includes(name)) {
+          methods.push(name);
+        }
+      }
+      current = Object.getPrototypeOf(current);
+    }
+    
+    return methods;
+  }
+
+  static getValidationRules(target: any): any {
+    return Reflect.getMetadata("validation:rules", target) || {};
+  }
+
+  static getInjectableInfo(target: any): boolean {
+    return Reflect.getMetadata(METADATA_KEYS.INJECTABLE, target) || false;
+  }
+}
+
+// ========== Example Classes Using Decorators ==========
+@Entity("users")
+@Injectable()
+@Serializable()
+export class User {
+  @Column({ name: "id", type: "integer" })
+  @Required()
+  @SerializableProperty()
+  public id!: number;
+
+  @Column({ name: "username", type: "varchar" })
+  @Required()
+  @MinLength(3)
+  @SerializableProperty()
+  public username!: string;
+
+  @Column({ name: "email", type: "varchar" })
+  @Required()
+  @SerializableProperty("emailAddress")
+  public email!: string;
+
+  @Column({ name: "age", type: "integer" })
+  @Max(120)
+  @SerializableProperty()
+  public age!: number;
+
+  private password!: string;
+  public currentUserRole?: string;
+
+  constructor(id: number, username: string, email: string, age: number) {
+    this.id = id;
+    this.username = username;
+    this.email = email;
+    this.age = age;
+  }
+
+  @Log("Getting user info")
+  @Cache(30000)
+  public getInfo(): string {
+    return `User: ${this.username} (${this.email})`;
+  }
+
+  @Validate()
+  public updateAge(
+    @ValidateParam((value: number) => value > 0 && value <= 120, "Age must be between 1 and 120")
+    newAge: number
+  ): void {
+    this.age = newAge;
+  }
+
+  @RequireRole("admin")
+  public deleteUser(): string {
+    return `User ${this.username} has been deleted`;
+  }
+
+  @Retry(3, 1000)
+  public async syncWithExternalService(): Promise<string> {
+    // Simulate an operation that might fail
+    if (Math.random() > 0.7) {
+      throw new Error("External service unavailable");
+    }
+    return "Sync completed successfully";
+  }
+
+  @Computed()
+  public get isAdult(): boolean {
+    return this.age >= 18;
+  }
+}
+
+@Component({ selector: "user-service", template: "<div>User Service</div>" })
+export class UserService {
+  constructor(
+    @Inject("userRepository") private userRepo: any,
+    @Inject("logger") private logger: any
+  ) {}
+
+  @Log("Finding user by ID")
+  public async findById(id: number): Promise<User | null> {
+    // Simulate database lookup
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return new User(id, `user${id}`, `user${id}@example.com`, 25);
+  }
+}
+
+// ========== Validation Engine ==========
+export class ValidationEngine {
+  static validate(instance: any): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+    const constructor = instance.constructor;
+    
+    // Check required properties
+    const required = Reflect.getMetadata("validation:required", constructor) || [];
+    for (const prop of required) {
+      if (instance[prop] === undefined || instance[prop] === null) {
+        errors.push(`${prop} is required`);
+      }
+    }
+    
+    // Check validation rules
+    const rules = Reflect.getMetadata("validation:rules", constructor) || {};
+    for (const [prop, propRules] of Object.entries(rules)) {
+      const value = instance[prop];
+      for (const rule of (propRules as any[])) {
+        if (rule.type === "minLength" && typeof value === "string" && value.length < rule.value) {
+          errors.push(rule.message);
+        }
+        if (rule.type === "max" && typeof value === "number" && value > rule.value) {
+          errors.push(rule.message);
+        }
+      }
+    }
+    
+    return {
+      valid: errors.length === 0,
+      errors
+    };
+  }
+}
+
+// ========== Usage Examples ==========
+export const decoratorExamples = {
+  // Create a user instance
+  user: new User(1, "john_doe", "john@example.com", 30),
+  
+  // Validation examples
+  validateUser: (user: User) => ValidationEngine.validate(user),
+  
+  // Metadata reader examples
+  getEntityInfo: (target: any) => ({
+    tableName: MetadataReader.getClassMetadata(target, "entity:table"),
+    columns: MetadataReader.getClassMetadata(target, "entity:columns"),
+    isInjectable: MetadataReader.getInjectableInfo(target)
+  }),
+  
+  // Service instance
+  userService: new UserService("mockUserRepo", "mockLogger")
+};
+
+// Example usage of the decorated user
+decoratorExamples.user.currentUserRole = "admin";
+
+// This will use caching
+console.log(decoratorExamples.user.getInfo());
+
+// This will validate the parameter
+try {
+  decoratorExamples.user.updateAge(25);
+} catch (error) {
+  console.error("Validation error:", error);
+}
+
+// Get metadata about the User class
+console.log("User metadata:", decoratorExamples.getEntityInfo(User));

--- a/tests/sample_project_typescript/src/error-validation.ts
+++ b/tests/sample_project_typescript/src/error-validation.ts
@@ -1,0 +1,547 @@
+/**
+ * Error Handling and Validation
+ * Demonstrates TypeScript's error handling patterns, custom error types,
+ * type guards, assertion functions, and validation patterns
+ */
+
+// ========== Custom Error Classes ==========
+export class ApplicationError extends Error {
+  public readonly code: string;
+  public readonly timestamp: Date;
+  public readonly context?: Record<string, any>;
+
+  constructor(message: string, code: string, context?: Record<string, any>) {
+    super(message);
+    this.name = "ApplicationError";
+    this.code = code;
+    this.timestamp = new Date();
+    this.context = context;
+    
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ApplicationError);
+    }
+  }
+}
+
+export class ValidationError extends ApplicationError {
+  public readonly field?: string;
+  public readonly value?: any;
+
+  constructor(message: string, field?: string, value?: any, context?: Record<string, any>) {
+    super(message, "VALIDATION_ERROR", context);
+    this.name = "ValidationError";
+    this.field = field;
+    this.value = value;
+  }
+}
+
+export class NotFoundError extends ApplicationError {
+  public readonly resource: string;
+  public readonly identifier: any;
+
+  constructor(resource: string, identifier: any, context?: Record<string, any>) {
+    super(`${resource} with identifier "${identifier}" not found`, "NOT_FOUND", context);
+    this.name = "NotFoundError";
+    this.resource = resource;
+    this.identifier = identifier;
+  }
+}
+
+export class UnauthorizedError extends ApplicationError {
+  constructor(message: string = "Access denied", context?: Record<string, any>) {
+    super(message, "UNAUTHORIZED", context);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class NetworkError extends ApplicationError {
+  public readonly statusCode?: number;
+  public readonly url?: string;
+
+  constructor(message: string, statusCode?: number, url?: string, context?: Record<string, any>) {
+    super(message, "NETWORK_ERROR", context);
+    this.name = "NetworkError";
+    this.statusCode = statusCode;
+    this.url = url;
+  }
+}
+
+// ========== Result Pattern ==========
+export type Result<T, E = Error> = 
+  | { success: true; data: T; error?: never }
+  | { success: false; data?: never; error: E };
+
+export const Ok = <T>(data: T): Result<T, never> => ({ success: true, data });
+export const Err = <E>(error: E): Result<never, E> => ({ success: false, error });
+
+export function isOk<T, E>(result: Result<T, E>): result is { success: true; data: T } {
+  return result.success;
+}
+
+export function isErr<T, E>(result: Result<T, E>): result is { success: false; error: E } {
+  return !result.success;
+}
+
+// Result utility functions
+export function map<T, U, E>(
+  result: Result<T, E>,
+  fn: (data: T) => U
+): Result<U, E> {
+  return isOk(result) ? Ok(fn(result.data)) : result;
+}
+
+export function flatMap<T, U, E>(
+  result: Result<T, E>,
+  fn: (data: T) => Result<U, E>
+): Result<U, E> {
+  return isOk(result) ? fn(result.data) : result;
+}
+
+export function mapError<T, E, F>(
+  result: Result<T, E>,
+  fn: (error: E) => F
+): Result<T, F> {
+  return isErr(result) ? Err(fn(result.error)) : result;
+}
+
+// ========== Type Guards ==========
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+export function isNumber(value: unknown): value is number {
+  return typeof value === "number" && !isNaN(value);
+}
+
+export function isObject(value: unknown): value is object {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isArray<T>(value: unknown, elementGuard: (item: unknown) => item is T): value is T[] {
+  return Array.isArray(value) && value.every(elementGuard);
+}
+
+export function hasProperty<K extends string>(
+  obj: unknown,
+  prop: K
+): obj is Record<K, unknown> {
+  return isObject(obj) && prop in obj;
+}
+
+export function hasProperties<K extends string>(
+  obj: unknown,
+  ...props: K[]
+): obj is Record<K, unknown> {
+  return isObject(obj) && props.every(prop => prop in obj);
+}
+
+// Advanced type guards
+export function isInstanceOf<T extends new (...args: any[]) => any>(
+  constructor: T,
+  value: unknown
+): value is InstanceType<T> {
+  return value instanceof constructor;
+}
+
+export function isOneOf<T extends readonly unknown[]>(
+  values: T,
+  value: unknown
+): value is T[number] {
+  return values.includes(value);
+}
+
+// ========== Assertion Functions ==========
+export function assert(condition: any, message?: string): asserts condition {
+  if (!condition) {
+    throw new Error(message || "Assertion failed");
+  }
+}
+
+export function assertIsString(value: unknown): asserts value is string {
+  if (!isString(value)) {
+    throw new ValidationError("Expected string", "value", value);
+  }
+}
+
+export function assertIsNumber(value: unknown): asserts value is number {
+  if (!isNumber(value)) {
+    throw new ValidationError("Expected number", "value", value);
+  }
+}
+
+export function assertIsObject(value: unknown): asserts value is object {
+  if (!isObject(value)) {
+    throw new ValidationError("Expected object", "value", value);
+  }
+}
+
+export function assertHasProperty<K extends string>(
+  obj: unknown,
+  prop: K
+): asserts obj is Record<K, unknown> {
+  if (!hasProperty(obj, prop)) {
+    throw new ValidationError(`Expected property "${prop}"`, prop, obj);
+  }
+}
+
+export function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${JSON.stringify(value)}`);
+}
+
+// ========== Validation Schemas ==========
+export interface ValidationRule<T> {
+  validate: (value: T) => boolean;
+  message: string;
+}
+
+export interface Schema<T> {
+  rules: ValidationRule<T>[];
+  optional?: boolean;
+  transform?: (value: any) => T;
+}
+
+export class SchemaValidator {
+  static validate<T>(value: unknown, schema: Schema<T>): Result<T, ValidationError> {
+    // Handle optional values
+    if (value === undefined || value === null) {
+      if (schema.optional) {
+        return Ok(value as T);
+      } else {
+        return Err(new ValidationError("Value is required"));
+      }
+    }
+
+    // Transform value if transformer is provided
+    let processedValue: T;
+    if (schema.transform) {
+      try {
+        processedValue = schema.transform(value);
+      } catch (error) {
+        return Err(new ValidationError(`Transformation failed: ${error}`));
+      }
+    } else {
+      processedValue = value as T;
+    }
+
+    // Run validation rules
+    for (const rule of schema.rules) {
+      if (!rule.validate(processedValue)) {
+        return Err(new ValidationError(rule.message, "value", value));
+      }
+    }
+
+    return Ok(processedValue);
+  }
+
+  static validateObject<T extends Record<string, any>>(
+    value: unknown,
+    schemas: { [K in keyof T]: Schema<T[K]> }
+  ): Result<T, ValidationError[]> {
+    if (!isObject(value)) {
+      return Err([new ValidationError("Expected object", "root", value)]);
+    }
+
+    const result = {} as T;
+    const errors: ValidationError[] = [];
+
+    for (const [key, schema] of Object.entries(schemas)) {
+      const fieldValue = (value as any)[key];
+      const fieldResult = SchemaValidator.validate(fieldValue, schema);
+
+      if (isOk(fieldResult)) {
+        (result as any)[key] = fieldResult.data;
+      } else {
+        const error = fieldResult.error;
+        error.field = key;
+        errors.push(error);
+      }
+    }
+
+    return errors.length === 0 ? Ok(result) : Err(errors);
+  }
+}
+
+// ========== Common Validation Rules ==========
+export const ValidationRules = {
+  required: <T>(): ValidationRule<T> => ({
+    validate: (value) => value !== undefined && value !== null && value !== "",
+    message: "Value is required"
+  }),
+
+  minLength: (min: number): ValidationRule<string> => ({
+    validate: (value) => value.length >= min,
+    message: `Minimum length is ${min}`
+  }),
+
+  maxLength: (max: number): ValidationRule<string> => ({
+    validate: (value) => value.length <= max,
+    message: `Maximum length is ${max}`
+  }),
+
+  email: (): ValidationRule<string> => ({
+    validate: (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value),
+    message: "Invalid email format"
+  }),
+
+  min: (min: number): ValidationRule<number> => ({
+    validate: (value) => value >= min,
+    message: `Value must be at least ${min}`
+  }),
+
+  max: (max: number): ValidationRule<number> => ({
+    validate: (value) => value <= max,
+    message: `Value must be at most ${max}`
+  }),
+
+  regex: (pattern: RegExp, message?: string): ValidationRule<string> => ({
+    validate: (value) => pattern.test(value),
+    message: message || `Value does not match pattern ${pattern}`
+  }),
+
+  oneOf: <T>(values: T[]): ValidationRule<T> => ({
+    validate: (value) => values.includes(value),
+    message: `Value must be one of: ${values.join(", ")}`
+  }),
+
+  custom: <T>(fn: (value: T) => boolean, message: string): ValidationRule<T> => ({
+    validate: fn,
+    message
+  })
+};
+
+// ========== Safe Parsing Functions ==========
+export function safeParseInt(value: string): Result<number, ValidationError> {
+  const parsed = parseInt(value, 10);
+  if (isNaN(parsed)) {
+    return Err(new ValidationError("Invalid integer", "value", value));
+  }
+  return Ok(parsed);
+}
+
+export function safeParseFloat(value: string): Result<number, ValidationError> {
+  const parsed = parseFloat(value);
+  if (isNaN(parsed)) {
+    return Err(new ValidationError("Invalid float", "value", value));
+  }
+  return Ok(parsed);
+}
+
+export function safeParse<T>(
+  value: string,
+  parser: (str: string) => T
+): Result<T, ValidationError> {
+  try {
+    return Ok(parser(value));
+  } catch (error) {
+    return Err(new ValidationError(
+      `Parse error: ${error instanceof Error ? error.message : error}`,
+      "value",
+      value
+    ));
+  }
+}
+
+export function safeJsonParse<T = any>(json: string): Result<T, ValidationError> {
+  return safeParse(json, JSON.parse);
+}
+
+// ========== Error Boundary Pattern ==========
+export class ErrorBoundary {
+  private errorHandlers = new Map<string, (error: Error) => void>();
+  private globalHandler?: (error: Error) => void;
+
+  onError(type: string, handler: (error: Error) => void): void {
+    this.errorHandlers.set(type, handler);
+  }
+
+  onGlobalError(handler: (error: Error) => void): void {
+    this.globalHandler = handler;
+  }
+
+  handle(error: Error): void {
+    const handler = this.errorHandlers.get(error.name);
+    
+    if (handler) {
+      handler(error);
+    } else if (this.globalHandler) {
+      this.globalHandler(error);
+    } else {
+      console.error("Unhandled error:", error);
+    }
+  }
+
+  wrap<T extends (...args: any[]) => any>(fn: T): T {
+    return ((...args: any[]) => {
+      try {
+        const result = fn(...args);
+        
+        // Handle async functions
+        if (result instanceof Promise) {
+          return result.catch((error) => {
+            this.handle(error);
+            throw error;
+          });
+        }
+        
+        return result;
+      } catch (error) {
+        if (error instanceof Error) {
+          this.handle(error);
+        }
+        throw error;
+      }
+    }) as T;
+  }
+}
+
+// ========== Try-Catch Utilities ==========
+export function tryCatch<T>(fn: () => T): Result<T, Error> {
+  try {
+    return Ok(fn());
+  } catch (error) {
+    return Err(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+export async function tryCatchAsync<T>(fn: () => Promise<T>): Promise<Result<T, Error>> {
+  try {
+    const result = await fn();
+    return Ok(result);
+  } catch (error) {
+    return Err(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+// ========== Usage Examples ==========
+// Define user schema
+const userSchema = {
+  id: {
+    rules: [ValidationRules.required()],
+    transform: (value: any) => parseInt(value, 10)
+  } as Schema<number>,
+  
+  name: {
+    rules: [
+      ValidationRules.required(),
+      ValidationRules.minLength(2),
+      ValidationRules.maxLength(100)
+    ]
+  } as Schema<string>,
+  
+  email: {
+    rules: [
+      ValidationRules.required(),
+      ValidationRules.email()
+    ]
+  } as Schema<string>,
+  
+  age: {
+    rules: [
+      ValidationRules.min(0),
+      ValidationRules.max(120)
+    ],
+    optional: true,
+    transform: (value: any) => parseInt(value, 10)
+  } as Schema<number>
+};
+
+// Example functions that use error handling
+export function validateUser(userData: unknown): Result<{
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+}, ValidationError[]> {
+  return SchemaValidator.validateObject(userData, userSchema);
+}
+
+export async function fetchUser(id: number): Promise<Result<any, ApplicationError>> {
+  if (id <= 0) {
+    return Err(new ValidationError("Invalid user ID", "id", id));
+  }
+
+  // Simulate API call that might fail
+  const shouldFail = Math.random() > 0.7;
+  
+  if (shouldFail) {
+    return Err(new NetworkError("Failed to fetch user", 500, `/api/users/${id}`));
+  }
+
+  // Simulate user not found
+  if (id === 404) {
+    return Err(new NotFoundError("User", id));
+  }
+
+  return Ok({
+    id,
+    name: `User ${id}`,
+    email: `user${id}@example.com`,
+    age: 25
+  });
+}
+
+// Error boundary usage
+export const errorBoundary = new ErrorBoundary();
+
+errorBoundary.onError("ValidationError", (error) => {
+  console.error("Validation failed:", error.message);
+});
+
+errorBoundary.onError("NetworkError", (error) => {
+  console.error("Network error occurred:", error.message);
+});
+
+errorBoundary.onGlobalError((error) => {
+  console.error("Unexpected error:", error);
+});
+
+// Example wrapped function
+export const safeProcessUser = errorBoundary.wrap(async (userData: unknown) => {
+  const validationResult = validateUser(userData);
+  
+  if (isErr(validationResult)) {
+    throw new ValidationError("User validation failed", "user", userData);
+  }
+
+  const user = validationResult.data;
+  const fetchResult = await fetchUser(user.id);
+  
+  if (isErr(fetchResult)) {
+    throw fetchResult.error;
+  }
+
+  return fetchResult.data;
+});
+
+// ========== Usage Examples ==========
+export const errorHandlingExamples = {
+  // Result pattern examples
+  parseNumber: (str: string) => safeParseInt(str),
+  parseJson: (json: string) => safeJsonParse(json),
+  
+  // Validation examples
+  validUser: validateUser({
+    id: "123",
+    name: "John Doe",
+    email: "john@example.com",
+    age: "30"
+  }),
+  
+  invalidUser: validateUser({
+    id: "",
+    name: "J",
+    email: "invalid-email",
+    age: "200"
+  }),
+  
+  // Error boundary
+  errorBoundary,
+  
+  // Type guards
+  typeChecks: {
+    isString: isString("hello"),
+    isNumber: isNumber(42),
+    hasProperty: hasProperty({ name: "test" }, "name"),
+  }
+};

--- a/tests/sample_project_typescript/src/functions-generics.ts
+++ b/tests/sample_project_typescript/src/functions-generics.ts
@@ -1,0 +1,390 @@
+/**
+ * Functions and Generics
+ * Demonstrates TypeScript's function types, overloads, generics, constraints,
+ * higher-order functions, and advanced function patterns
+ */
+
+// ========== Basic Function Types ==========
+export function simpleFunction(x: number, y: number): number {
+  return x + y;
+}
+
+// Optional parameters
+export function greet(name: string, greeting?: string): string {
+  return `${greeting || "Hello"}, ${name}!`;
+}
+
+// Default parameters
+export function createUser(name: string, active: boolean = true): { name: string; active: boolean } {
+  return { name, active };
+}
+
+// Rest parameters
+export function sum(...numbers: number[]): number {
+  return numbers.reduce((total, num) => total + num, 0);
+}
+
+// ========== Function Overloads ==========
+export function parseValue(value: string): number;
+export function parseValue(value: number): string;
+export function parseValue(value: boolean): string;
+export function parseValue(value: string | number | boolean): string | number {
+  if (typeof value === "string") {
+    return parseInt(value, 10);
+  } else if (typeof value === "number") {
+    return value.toString();
+  } else {
+    return value.toString();
+  }
+}
+
+// Complex overloads
+export function processData(data: string[]): string[];
+export function processData(data: number[]): number[];
+export function processData<T>(data: T[], processor: (item: T) => T): T[];
+export function processData<T>(
+  data: T[],
+  processor?: (item: T) => T
+): T[] {
+  if (processor) {
+    return data.map(processor);
+  }
+  return [...data];
+}
+
+// ========== Arrow Functions ==========
+export const multiply = (x: number, y: number): number => x * y;
+
+export const isEven = (n: number): boolean => n % 2 === 0;
+
+// Higher-order arrow function
+export const createMultiplier = (factor: number) => (value: number) => value * factor;
+
+// ========== Generic Functions ==========
+export function identity<T>(arg: T): T {
+  return arg;
+}
+
+export function getFirstElement<T>(array: T[]): T | undefined {
+  return array[0];
+}
+
+// Generic with multiple type parameters
+export function merge<T, U>(obj1: T, obj2: U): T & U {
+  return { ...obj1, ...obj2 };
+}
+
+// Generic with default type parameter
+export function createArray<T = string>(length: number, defaultValue: T): T[] {
+  return Array(length).fill(defaultValue);
+}
+
+// ========== Generic Constraints ==========
+// Constraint using extends
+export function getProperty<T, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+
+// Constraint with interface
+interface Lengthwise {
+  length: number;
+}
+
+export function logLength<T extends Lengthwise>(arg: T): T {
+  console.log(arg.length);
+  return arg;
+}
+
+// Constraint with conditional types
+export function processItem<T extends string | number>(
+  item: T
+): T extends string ? string : number {
+  if (typeof item === "string") {
+    return item.toUpperCase() as T extends string ? string : number;
+  }
+  return (item * 2) as T extends string ? string : number;
+}
+
+// ========== Advanced Generic Patterns ==========
+// Generic factory function
+export interface Constructable<T = {}> {
+  new (...args: any[]): T;
+}
+
+export function createInstance<T>(constructor: Constructable<T>, ...args: any[]): T {
+  return new constructor(...args);
+}
+
+// Generic with constraint and default
+export function sortBy<T, K extends keyof T = keyof T>(
+  array: T[],
+  key: K,
+  ascending: boolean = true
+): T[] {
+  return array.sort((a, b) => {
+    const valueA = a[key];
+    const valueB = b[key];
+    
+    if (valueA < valueB) return ascending ? -1 : 1;
+    if (valueA > valueB) return ascending ? 1 : -1;
+    return 0;
+  });
+}
+
+// ========== Function Types ==========
+export type UnaryFunction<T, R> = (arg: T) => R;
+export type BinaryFunction<T, U, R> = (arg1: T, arg2: U) => R;
+export type Predicate<T> = (arg: T) => boolean;
+export type Mapper<T, R> = (item: T, index: number, array: T[]) => R;
+
+// Function that accepts function types
+export function pipe<T, R1, R2>(
+  input: T,
+  fn1: UnaryFunction<T, R1>,
+  fn2: UnaryFunction<R1, R2>
+): R2 {
+  return fn2(fn1(input));
+}
+
+// ========== Higher-Order Functions ==========
+export function memoize<T extends (...args: any[]) => any>(fn: T): T {
+  const cache = new Map();
+  
+  return ((...args: any[]) => {
+    const key = JSON.stringify(args);
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+    const result = fn(...args);
+    cache.set(key, result);
+    return result;
+  }) as T;
+}
+
+export function debounce<T extends (...args: any[]) => any>(
+  fn: T,
+  delay: number
+): T {
+  let timeoutId: NodeJS.Timeout;
+  
+  return ((...args: any[]) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(...args), delay);
+  }) as T;
+}
+
+export function throttle<T extends (...args: any[]) => any>(
+  fn: T,
+  limit: number
+): T {
+  let inThrottle: boolean;
+  
+  return ((...args: any[]) => {
+    if (!inThrottle) {
+      fn(...args);
+      inThrottle = true;
+      setTimeout(() => inThrottle = false, limit);
+    }
+  }) as T;
+}
+
+// ========== Generic Data Structures ==========
+export class Stack<T> {
+  private items: T[] = [];
+
+  push(item: T): void {
+    this.items.push(item);
+  }
+
+  pop(): T | undefined {
+    return this.items.pop();
+  }
+
+  peek(): T | undefined {
+    return this.items[this.items.length - 1];
+  }
+
+  isEmpty(): boolean {
+    return this.items.length === 0;
+  }
+
+  size(): number {
+    return this.items.length;
+  }
+}
+
+export class Queue<T> {
+  private items: T[] = [];
+
+  enqueue(item: T): void {
+    this.items.push(item);
+  }
+
+  dequeue(): T | undefined {
+    return this.items.shift();
+  }
+
+  front(): T | undefined {
+    return this.items[0];
+  }
+
+  isEmpty(): boolean {
+    return this.items.length === 0;
+  }
+
+  size(): number {
+    return this.items.length;
+  }
+}
+
+// Generic with multiple constraints
+export interface Comparable<T> {
+  compareTo(other: T): number;
+}
+
+export class PriorityQueue<T extends Comparable<T>> {
+  private items: T[] = [];
+
+  enqueue(item: T): void {
+    this.items.push(item);
+    this.items.sort((a, b) => a.compareTo(b));
+  }
+
+  dequeue(): T | undefined {
+    return this.items.shift();
+  }
+
+  peek(): T | undefined {
+    return this.items[0];
+  }
+
+  isEmpty(): boolean {
+    return this.items.length === 0;
+  }
+}
+
+// ========== Utility Functions with Generics ==========
+export function arrayChunk<T>(array: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
+}
+
+export function arrayUnique<T>(array: T[]): T[] {
+  return [...new Set(array)];
+}
+
+export function arrayGroupBy<T, K extends string | number | symbol>(
+  array: T[],
+  keyFn: (item: T) => K
+): Record<K, T[]> {
+  return array.reduce((groups, item) => {
+    const key = keyFn(item);
+    groups[key] = groups[key] || [];
+    groups[key]!.push(item);
+    return groups;
+  }, {} as Record<K, T[]>);
+}
+
+// Curried functions
+export const curriedAdd = (x: number) => (y: number) => x + y;
+export const curriedFilter = <T>(predicate: Predicate<T>) => (array: T[]) => 
+  array.filter(predicate);
+
+// ========== Generic Utility Types Functions ==========
+export function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K> {
+  const result = {} as Pick<T, K>;
+  keys.forEach(key => {
+    result[key] = obj[key];
+  });
+  return result;
+}
+
+export function omit<T, K extends keyof T>(obj: T, ...keys: K[]): Omit<T, K> {
+  const result = { ...obj };
+  keys.forEach(key => {
+    delete result[key];
+  });
+  return result as Omit<T, K>;
+}
+
+export function deepClone<T>(obj: T): T {
+  if (obj === null || typeof obj !== "object") {
+    return obj;
+  }
+  
+  if (obj instanceof Date) {
+    return new Date(obj.getTime()) as T;
+  }
+  
+  if (obj instanceof Array) {
+    return obj.map(item => deepClone(item)) as T;
+  }
+  
+  if (typeof obj === "object") {
+    const copy = {} as T;
+    Object.keys(obj).forEach(key => {
+      (copy as any)[key] = deepClone((obj as any)[key]);
+    });
+    return copy;
+  }
+  
+  return obj;
+}
+
+// ========== Function Composition ==========
+export function compose<T, R1, R2>(
+  fn1: (arg: T) => R1,
+  fn2: (arg: R1) => R2
+): (arg: T) => R2;
+export function compose<T, R1, R2, R3>(
+  fn1: (arg: T) => R1,
+  fn2: (arg: R1) => R2,
+  fn3: (arg: R2) => R3
+): (arg: T) => R3;
+export function compose(...fns: Function[]) {
+  return (arg: any) => fns.reduce((result, fn) => fn(result), arg);
+}
+
+// ========== Usage Examples ==========
+export const functionExamples = {
+  // Basic functions
+  basicSum: sum(1, 2, 3, 4, 5),
+  parsedString: parseValue("123"),
+  parsedNumber: parseValue(456),
+  
+  // Generics
+  identityString: identity("hello"),
+  identityNumber: identity(42),
+  mergedObject: merge({ name: "John" }, { age: 30 }),
+  
+  // Data structures
+  numberStack: new Stack<number>(),
+  stringQueue: new Queue<string>(),
+  
+  // Higher-order functions
+  double: createMultiplier(2),
+  memoizedFib: memoize((n: number): number => {
+    if (n <= 1) return n;
+    return functionExamples.memoizedFib(n - 1) + functionExamples.memoizedFib(n - 2);
+  }),
+  
+  // Array utilities
+  chunkedArray: arrayChunk([1, 2, 3, 4, 5, 6, 7], 3),
+  uniqueArray: arrayUnique([1, 2, 2, 3, 3, 3, 4]),
+  groupedItems: arrayGroupBy(
+    [{ type: "fruit", name: "apple" }, { type: "fruit", name: "banana" }, { type: "vegetable", name: "carrot" }],
+    item => item.type
+  )
+};
+
+// Initialize some examples
+functionExamples.numberStack.push(1);
+functionExamples.numberStack.push(2);
+functionExamples.numberStack.push(3);
+
+functionExamples.stringQueue.enqueue("first");
+functionExamples.stringQueue.enqueue("second");
+functionExamples.stringQueue.enqueue("third");

--- a/tests/sample_project_typescript/src/index.ts
+++ b/tests/sample_project_typescript/src/index.ts
@@ -1,0 +1,405 @@
+/**
+ * Main Entry Point
+ * Imports and demonstrates usage of all TypeScript modules in the sample project
+ * This file serves as the primary entry point and integration test for all features
+ */
+
+// Import all modules to demonstrate the complete TypeScript feature set
+import * as TypesInterfaces from './types-interfaces';
+import * as ClassesInheritance from './classes-inheritance';
+import * as FunctionsGenerics from './functions-generics';
+import * as AsyncPromises from './async-promises';
+import * as DecoratorsMetadata from './decorators-metadata';
+import * as ModulesNamespaces from './modules-namespaces';
+import * as AdvancedTypes from './advanced-types';
+import * as ErrorValidation from './error-validation';
+import * as UtilitiesHelpers from './utilities-helpers';
+
+// Import specific examples for demonstration
+import { User, Shape, calculateArea } from './types-interfaces';
+import { Person, Employee, Dog } from './classes-inheritance';
+import { Stack, Queue, memoize } from './functions-generics';
+import { EventEmitter, PromisePool } from './async-promises';
+import { ValidationError, Result, Ok, Err } from './error-validation';
+import { StringUtils, ArrayUtils, ObjectUtils } from './utilities-helpers';
+
+/**
+ * Main application class demonstrating all TypeScript features
+ */
+export class TypeScriptShowcase {
+  private eventEmitter = new EventEmitter<{ action: string; data: any }>();
+  private promisePool = new PromisePool(5);
+  private userCache = new Map<number, User>();
+
+  constructor() {
+    this.initializeEventHandlers();
+    console.log('TypeScript Showcase initialized');
+  }
+
+  /**
+   * Demonstrates basic types and interfaces
+   */
+  public demonstrateBasicTypes(): void {
+    console.log('\n=== Demonstrating Basic Types ===');
+    
+    // Create a user with proper typing
+    const user: User = {
+      id: 1,
+      name: "Alice Johnson",
+      email: "alice@example.com",
+      createdAt: new Date(),
+      preferences: {
+        theme: "dark",
+        notifications: true,
+        language: "en"
+      }
+    };
+
+    // Demonstrate shape calculation with discriminated unions
+    const shapes: Shape[] = [
+      { kind: "circle", radius: 5 },
+      { kind: "rectangle", width: 10, height: 6 },
+      { kind: "triangle", base: 8, height: 4 }
+    ];
+
+    const areas = shapes.map(calculateArea);
+    console.log('User:', user.name, user.email);
+    console.log('Shape areas:', areas);
+
+    // Cache the user
+    this.userCache.set(user.id, user);
+  }
+
+  /**
+   * Demonstrates classes and inheritance
+   */
+  public demonstrateClassesInheritance(): void {
+    console.log('\n=== Demonstrating Classes & Inheritance ===');
+
+    // Create instances of different classes
+    const person = new Person("John Doe", 30, 123);
+    const employee = new Employee("Jane Smith", 28, 456, "Engineering", 75000);
+    const dog = new Dog("Buddy", 3, "Golden Retriever");
+
+    console.log(person.introduce());
+    console.log(employee.introduce()); // Uses overridden method
+    console.log(employee.work());
+    console.log(dog.makeSound());
+    console.log(dog.move(10));
+
+    // Demonstrate polymorphism
+    const animals = [dog];
+    animals.forEach(animal => {
+      console.log(animal.sleep()); // Inherited method
+    });
+
+    // Use static methods
+    console.log('Species:', Person.getSpecies());
+  }
+
+  /**
+   * Demonstrates functions and generics
+   */
+  public demonstrateFunctionsGenerics(): void {
+    console.log('\n=== Demonstrating Functions & Generics ===');
+
+    // Generic data structures
+    const stringStack = new Stack<string>();
+    const numberQueue = new Queue<number>();
+
+    stringStack.push("Hello");
+    stringStack.push("World");
+    numberQueue.enqueue(1);
+    numberQueue.enqueue(2);
+    numberQueue.enqueue(3);
+
+    console.log('Stack peek:', stringStack.peek());
+    console.log('Queue dequeue:', numberQueue.dequeue());
+    console.log('Queue size:', numberQueue.size());
+
+    // Memoized function
+    const memoizedFib = memoize((n: number): number => {
+      if (n <= 1) return n;
+      return memoizedFib(n - 1) + memoizedFib(n - 2);
+    });
+
+    console.log('Fibonacci(10):', memoizedFib(10));
+  }
+
+  /**
+   * Demonstrates async programming patterns
+   */
+  public async demonstrateAsyncPatterns(): Promise<void> {
+    console.log('\n=== Demonstrating Async Patterns ===');
+
+    // Event emitter example
+    this.eventEmitter.emit({ action: 'user_login', data: { userId: 1 } });
+
+    // Promise pool example
+    const tasks = Array.from({ length: 10 }, (_, i) => 
+      () => this.simulateAsyncTask(`Task ${i + 1}`)
+    );
+
+    tasks.forEach(task => this.promisePool.add(task));
+    const results = await this.promisePool.execute();
+    
+    console.log(`Completed ${results.results.length} tasks, ${results.errors.length} errors`);
+
+    // Async generator example
+    console.log('Processing async stream:');
+    for await (const item of this.asyncGenerator(3)) {
+      console.log('  Generated:', item);
+    }
+  }
+
+  /**
+   * Demonstrates error handling and validation
+   */
+  public demonstrateErrorHandling(): void {
+    console.log('\n=== Demonstrating Error Handling ===');
+
+    // Result pattern example
+    const validationResult = this.validateUserData({
+      id: "123",
+      name: "John Doe",
+      email: "john@example.com",
+      age: "30"
+    });
+
+    if (validationResult.success) {
+      console.log('Validation succeeded:', validationResult.data.name);
+    } else {
+      console.log('Validation failed:', validationResult.error.map(e => e.message));
+    }
+
+    // Error handling with custom errors
+    try {
+      this.riskyOperation();
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        console.log('Caught validation error:', error.message);
+      }
+    }
+  }
+
+  /**
+   * Demonstrates utility functions
+   */
+  public demonstrateUtilities(): void {
+    console.log('\n=== Demonstrating Utilities ===');
+
+    // String utilities
+    const camelCased = StringUtils.camelCase("hello-world-example");
+    const kebabCased = StringUtils.kebabCase("HelloWorldExample");
+    console.log('CamelCase:', camelCased);
+    console.log('KebabCase:', kebabCased);
+
+    // Array utilities
+    const chunked = ArrayUtils.chunk([1, 2, 3, 4, 5, 6, 7], 3);
+    const unique = ArrayUtils.unique([1, 2, 2, 3, 3, 3, 4]);
+    console.log('Chunked:', chunked);
+    console.log('Unique:', unique);
+
+    // Object utilities
+    const deepValue = ObjectUtils.get(
+      { user: { profile: { name: 'Deep Value' } } },
+      'user.profile.name'
+    );
+    console.log('Deep value:', deepValue);
+
+    // Grouped data
+    const grouped = ArrayUtils.groupBy(
+      [
+        { type: 'fruit', name: 'apple' },
+        { type: 'fruit', name: 'banana' },
+        { type: 'vegetable', name: 'carrot' }
+      ],
+      item => item.type
+    );
+    console.log('Grouped:', grouped);
+  }
+
+  /**
+   * Demonstrates advanced types
+   */
+  public demonstrateAdvancedTypes(): void {
+    console.log('\n=== Demonstrating Advanced Types ===');
+
+    // Using advanced type utilities
+    const userPaths: AdvancedTypes.Paths<User>[] = [
+      "name",
+      "email",
+      "preferences.theme",
+      "preferences.notifications"
+    ];
+
+    console.log('Available user paths:', userPaths);
+
+    // Branded types example
+    const userId = AdvancedTypes.createUserId(123);
+    const email = AdvancedTypes.createEmail("user@example.com");
+    
+    console.log('Branded types created:', { userId, email });
+
+    // Template literal types
+    const apiUrl: AdvancedTypes.ApiUrl<"users", "GET"> = "GET /api/users";
+    console.log('API URL:', apiUrl);
+  }
+
+  /**
+   * Demonstrates decorator usage (if decorators are enabled)
+   */
+  public demonstrateDecorators(): void {
+    console.log('\n=== Demonstrating Decorators ===');
+
+    // Create decorated user instance
+    const decoratedUser = new DecoratorsMetadata.User(1, "decorated_user", "user@example.com", 25);
+    decoratedUser.currentUserRole = "admin";
+
+    // This will use caching decorator
+    console.log('User info (cached):', decoratedUser.getInfo());
+    console.log('User info (from cache):', decoratedUser.getInfo());
+
+    // This will use validation decorator
+    try {
+      decoratedUser.updateAge(30);
+      console.log('Age updated successfully');
+    } catch (error) {
+      console.log('Age update failed:', error);
+    }
+  }
+
+  /**
+   * Demonstrates module and namespace usage
+   */
+  public demonstrateModulesNamespaces(): void {
+    console.log('\n=== Demonstrating Modules & Namespaces ===');
+
+    // Using namespace utilities
+    const vector2D = new ModulesNamespaces.MathUtils.Vector2D(3, 4);
+    const magnitude = vector2D.magnitude();
+    console.log(`Vector magnitude: ${magnitude}`);
+
+    // Using nested namespaces
+    const binaryTree = new ModulesNamespaces.DataStructures.Trees.BinaryTree<number>();
+    binaryTree.insert(5);
+    binaryTree.insert(3);
+    binaryTree.insert(7);
+    console.log('Binary tree created and populated');
+
+    // Constants from nested namespace
+    console.log('Golden ratio:', ModulesNamespaces.MathUtils.Constants.GOLDEN_RATIO);
+  }
+
+  /**
+   * Runs all demonstrations
+   */
+  public async runAllDemonstrations(): Promise<void> {
+    console.log('🚀 Starting TypeScript Feature Showcase\n');
+
+    try {
+      this.demonstrateBasicTypes();
+      this.demonstrateClassesInheritance();
+      this.demonstrateFunctionsGenerics();
+      await this.demonstrateAsyncPatterns();
+      this.demonstrateErrorHandling();
+      this.demonstrateUtilities();
+      this.demonstrateAdvancedTypes();
+      this.demonstrateDecorators();
+      this.demonstrateModulesNamespaces();
+
+      console.log('\n✅ All TypeScript features demonstrated successfully!');
+    } catch (error) {
+      console.error('❌ Error during demonstration:', error);
+    }
+  }
+
+  // Private helper methods
+  private initializeEventHandlers(): void {
+    this.eventEmitter.subscribe((event) => {
+      console.log(`Event: ${event.action}`, event.data);
+    });
+  }
+
+  private async simulateAsyncTask(name: string): Promise<string> {
+    await new Promise(resolve => setTimeout(resolve, Math.random() * 100));
+    return `${name} completed`;
+  }
+
+  private async* asyncGenerator(count: number): AsyncGenerator<string> {
+    for (let i = 0; i < count; i++) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+      yield `Item ${i + 1}`;
+    }
+  }
+
+  private validateUserData(data: any): Result<any, ValidationError[]> {
+    // Simple validation for demonstration
+    const errors: ValidationError[] = [];
+    
+    if (!data.name || data.name.length < 2) {
+      errors.push(new ValidationError("Name must be at least 2 characters", "name", data.name));
+    }
+    
+    if (!data.email || !data.email.includes('@')) {
+      errors.push(new ValidationError("Invalid email format", "email", data.email));
+    }
+
+    return errors.length === 0 ? Ok(data) : Err(errors);
+  }
+
+  private riskyOperation(): void {
+    // Simulate a risky operation that might throw
+    if (Math.random() > 0.5) {
+      throw new ValidationError("Random validation failure");
+    }
+  }
+}
+
+// Main execution
+async function main(): Promise<void> {
+  const showcase = new TypeScriptShowcase();
+  await showcase.runAllDemonstrations();
+
+  // Additional integration examples
+  console.log('\n=== Integration Examples ===');
+
+  // Complex type usage
+  type UserUpdate = AdvancedTypes.DeepPartial<User>;
+  const userUpdate: UserUpdate = {
+    preferences: {
+      theme: "light"
+    }
+  };
+  console.log('User update:', userUpdate);
+
+  // Utility function chaining
+  const processedText = StringUtils.camelCase(
+    StringUtils.truncate("hello-world-example-text", 15)
+  );
+  console.log('Processed text:', processedText);
+
+  // Error handling with utilities
+  const parseResult = ErrorValidation.safeParseInt("42");
+  if (ErrorValidation.isOk(parseResult)) {
+    console.log('Parsed number:', parseResult.data);
+  }
+}
+
+// Export everything for external usage
+export * from './types-interfaces';
+export * from './classes-inheritance';
+export * from './functions-generics';
+export * from './async-promises';
+export * from './decorators-metadata';
+export * from './modules-namespaces';
+export * from './advanced-types';
+export * from './error-validation';
+export * from './utilities-helpers';
+
+// Run the main function if this is the entry point
+if (require.main === module) {
+  main().catch(console.error);
+}
+
+export default TypeScriptShowcase;

--- a/tests/sample_project_typescript/src/modules-namespaces.ts
+++ b/tests/sample_project_typescript/src/modules-namespaces.ts
@@ -1,0 +1,452 @@
+/**
+ * Modules and Namespaces
+ * Demonstrates TypeScript's module system, imports/exports, namespaces,
+ * ambient declarations, and advanced module patterns
+ */
+
+// ========== Basic Exports ==========
+export const MODULE_VERSION = "1.0.0";
+export const DEFAULT_CONFIG = {
+  debug: false,
+  timeout: 5000,
+  retries: 3
+};
+
+// Named export
+export function calculateSum(a: number, b: number): number {
+  return a + b;
+}
+
+// Export with alias
+export { calculateSum as add };
+
+// Multiple exports
+export const PI = Math.PI;
+export const E = Math.E;
+
+// ========== Default Export ==========
+class DefaultLogger {
+  private prefix: string;
+  
+  constructor(prefix: string = "LOG") {
+    this.prefix = prefix;
+  }
+  
+  log(message: string): void {
+    console.log(`[${this.prefix}] ${message}`);
+  }
+  
+  error(message: string): void {
+    console.error(`[${this.prefix}] ERROR: ${message}`);
+  }
+}
+
+export default DefaultLogger;
+
+// ========== Re-exports ==========
+// Re-export everything from types-interfaces
+export * from './types-interfaces';
+
+// Re-export specific items with aliases
+export { 
+  Person as BasePerson, 
+  Employee as StaffMember 
+} from './classes-inheritance';
+
+// Re-export default with a name
+export { default as Logger } from './modules-namespaces';
+
+// ========== Namespace Declarations ==========
+export namespace MathUtils {
+  export interface Point2D {
+    x: number;
+    y: number;
+  }
+  
+  export interface Point3D extends Point2D {
+    z: number;
+  }
+  
+  export class Vector2D implements Point2D {
+    constructor(public x: number, public y: number) {}
+    
+    add(other: Vector2D): Vector2D {
+      return new Vector2D(this.x + other.x, this.y + other.y);
+    }
+    
+    magnitude(): number {
+      return Math.sqrt(this.x * this.x + this.y * this.y);
+    }
+  }
+  
+  export class Vector3D implements Point3D {
+    constructor(public x: number, public y: number, public z: number) {}
+    
+    add(other: Vector3D): Vector3D {
+      return new Vector3D(this.x + other.x, this.y + other.y, this.z + other.z);
+    }
+    
+    magnitude(): number {
+      return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+    }
+  }
+  
+  export function distance2D(p1: Point2D, p2: Point2D): number {
+    const dx = p1.x - p2.x;
+    const dy = p1.y - p2.y;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+  
+  export function distance3D(p1: Point3D, p2: Point3D): number {
+    const dx = p1.x - p2.x;
+    const dy = p1.y - p2.y;
+    const dz = p1.z - p2.z;
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  }
+  
+  export namespace Constants {
+    export const GOLDEN_RATIO = 1.618033988749895;
+    export const EULER_CONSTANT = 0.5772156649015329;
+    export const SQRT_2 = Math.sqrt(2);
+  }
+}
+
+// Nested namespace
+export namespace DataStructures {
+  export namespace Trees {
+    export interface TreeNode<T> {
+      value: T;
+      left?: TreeNode<T>;
+      right?: TreeNode<T>;
+    }
+    
+    export class BinaryTree<T> {
+      constructor(public root?: TreeNode<T>) {}
+      
+      insert(value: T): void {
+        this.root = this.insertNode(this.root, value);
+      }
+      
+      private insertNode(node: TreeNode<T> | undefined, value: T): TreeNode<T> {
+        if (!node) {
+          return { value };
+        }
+        
+        // Simple insertion based on string comparison
+        if (String(value) < String(node.value)) {
+          node.left = this.insertNode(node.left, value);
+        } else {
+          node.right = this.insertNode(node.right, value);
+        }
+        
+        return node;
+      }
+    }
+  }
+  
+  export namespace Graphs {
+    export interface Edge<T> {
+      from: T;
+      to: T;
+      weight?: number;
+    }
+    
+    export class Graph<T> {
+      private adjacencyList: Map<T, T[]> = new Map();
+      
+      addVertex(vertex: T): void {
+        if (!this.adjacencyList.has(vertex)) {
+          this.adjacencyList.set(vertex, []);
+        }
+      }
+      
+      addEdge(from: T, to: T): void {
+        this.addVertex(from);
+        this.addVertex(to);
+        this.adjacencyList.get(from)!.push(to);
+      }
+      
+      getNeighbors(vertex: T): T[] {
+        return this.adjacencyList.get(vertex) || [];
+      }
+      
+      getVertices(): T[] {
+        return Array.from(this.adjacencyList.keys());
+      }
+    }
+  }
+}
+
+// ========== Module Augmentation ==========
+// Extending existing modules
+declare global {
+  interface String {
+    toTitleCase(): string;
+    truncate(length: number): string;
+  }
+  
+  interface Array<T> {
+    chunk(size: number): T[][];
+    unique(): T[];
+  }
+}
+
+// Implement the extensions
+String.prototype.toTitleCase = function(): string {
+  return this.replace(/\w\S*/g, (txt) => 
+    txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+  );
+};
+
+String.prototype.truncate = function(length: number): string {
+  return this.length > length ? this.substring(0, length) + '...' : this.toString();
+};
+
+Array.prototype.chunk = function<T>(this: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < this.length; i += size) {
+    chunks.push(this.slice(i, i + size));
+  }
+  return chunks;
+};
+
+Array.prototype.unique = function<T>(this: T[]): T[] {
+  return [...new Set(this)];
+};
+
+// ========== Ambient Declarations ==========
+// Declare external libraries or global variables
+declare global {
+  var GLOBAL_CONFIG: {
+    apiUrl: string;
+    version: string;
+    features: string[];
+  };
+}
+
+// Ambient module declaration
+declare module "fictional-library" {
+  export interface Config {
+    apiKey: string;
+    endpoint: string;
+  }
+  
+  export class Client {
+    constructor(config: Config);
+    request(path: string): Promise<any>;
+  }
+  
+  export function initialize(config: Config): Client;
+}
+
+// Declare a module with wildcard
+declare module "*.json" {
+  const value: any;
+  export default value;
+}
+
+declare module "*.svg" {
+  const content: string;
+  export default content;
+}
+
+// ========== Conditional Exports ==========
+export interface DatabaseConnection {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  query(sql: string): Promise<any[]>;
+}
+
+// Different implementations based on environment
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+export const createDatabaseConnection = (): DatabaseConnection => {
+  if (isDevelopment) {
+    return new MockDatabaseConnection();
+  } else {
+    return new ProductionDatabaseConnection();
+  }
+};
+
+class MockDatabaseConnection implements DatabaseConnection {
+  async connect(): Promise<void> {
+    console.log("Connected to mock database");
+  }
+  
+  async disconnect(): Promise<void> {
+    console.log("Disconnected from mock database");
+  }
+  
+  async query(sql: string): Promise<any[]> {
+    console.log(`Mock query: ${sql}`);
+    return [{ id: 1, name: "Mock Data" }];
+  }
+}
+
+class ProductionDatabaseConnection implements DatabaseConnection {
+  async connect(): Promise<void> {
+    console.log("Connected to production database");
+  }
+  
+  async disconnect(): Promise<void> {
+    console.log("Disconnected from production database");
+  }
+  
+  async query(sql: string): Promise<any[]> {
+    console.log(`Production query: ${sql}`);
+    // Would connect to real database
+    return [];
+  }
+}
+
+// ========== Dynamic Imports ==========
+export async function loadModule(moduleName: string): Promise<any> {
+  try {
+    switch (moduleName) {
+      case 'math':
+        return await import('./functions-generics');
+      case 'classes':
+        return await import('./classes-inheritance');
+      case 'types':
+        return await import('./types-interfaces');
+      default:
+        throw new Error(`Module ${moduleName} not found`);
+    }
+  } catch (error) {
+    console.error(`Failed to load module ${moduleName}:`, error);
+    throw error;
+  }
+}
+
+// Dynamic import with type assertion
+export async function loadTypedModule<T>(): Promise<T> {
+  const module = await import('./types-interfaces');
+  return module as T;
+}
+
+// ========== Module Factory Pattern ==========
+export interface ModuleConfig {
+  name: string;
+  version: string;
+  dependencies?: string[];
+}
+
+export abstract class BaseModule {
+  constructor(protected config: ModuleConfig) {}
+  
+  abstract initialize(): Promise<void>;
+  abstract cleanup(): Promise<void>;
+  
+  getConfig(): ModuleConfig {
+    return this.config;
+  }
+}
+
+export class FeatureModule extends BaseModule {
+  private isInitialized = false;
+  
+  async initialize(): Promise<void> {
+    console.log(`Initializing ${this.config.name} v${this.config.version}`);
+    
+    if (this.config.dependencies) {
+      for (const dep of this.config.dependencies) {
+        await this.loadDependency(dep);
+      }
+    }
+    
+    this.isInitialized = true;
+  }
+  
+  async cleanup(): Promise<void> {
+    console.log(`Cleaning up ${this.config.name}`);
+    this.isInitialized = false;
+  }
+  
+  private async loadDependency(name: string): Promise<void> {
+    console.log(`Loading dependency: ${name}`);
+    // Simulate loading dependency
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  
+  isReady(): boolean {
+    return this.isInitialized;
+  }
+}
+
+// ========== Barrel Exports ==========
+// This file can serve as a barrel export for the entire project
+export {
+  // Re-export all from other modules to create a single entry point
+  createUser,
+  greet,
+  sum
+} from './functions-generics';
+
+export {
+  EventEmitter,
+  PromisePool,
+  AsyncCache
+} from './async-promises';
+
+// ========== Triple-Slash Directives ==========
+/// <reference types="node" />
+/// <reference lib="es2020" />
+
+// ========== Usage Examples ==========
+export const moduleExamples = {
+  // Math utilities
+  vector2D: new MathUtils.Vector2D(3, 4),
+  vector3D: new MathUtils.Vector3D(1, 2, 3),
+  distance: MathUtils.distance2D({ x: 0, y: 0 }, { x: 3, y: 4 }),
+  
+  // Data structures
+  binaryTree: new DataStructures.Trees.BinaryTree<number>(),
+  graph: new DataStructures.Graphs.Graph<string>(),
+  
+  // String extensions (using global augmentation)
+  titleCase: "hello world".toTitleCase(),
+  truncated: "This is a very long string".truncate(10),
+  
+  // Array extensions
+  chunked: [1, 2, 3, 4, 5, 6].chunk(2),
+  uniqueArray: [1, 2, 2, 3, 3, 3].unique(),
+  
+  // Module factory
+  featureModule: new FeatureModule({
+    name: "SampleFeature",
+    version: "1.0.0",
+    dependencies: ["core", "utils"]
+  }),
+  
+  // Database connection
+  dbConnection: createDatabaseConnection()
+};
+
+// Initialize examples
+moduleExamples.binaryTree.insert(5);
+moduleExamples.binaryTree.insert(3);
+moduleExamples.binaryTree.insert(7);
+
+moduleExamples.graph.addVertex("A");
+moduleExamples.graph.addVertex("B");
+moduleExamples.graph.addEdge("A", "B");
+
+// Constants from nested namespace
+export const mathConstants = {
+  goldenRatio: MathUtils.Constants.GOLDEN_RATIO,
+  eulerConstant: MathUtils.Constants.EULER_CONSTANT,
+  sqrt2: MathUtils.Constants.SQRT_2
+};
+
+// ========== Module Types ==========
+export type ModuleLoader = (name: string) => Promise<any>;
+export type ModuleRegistry = Map<string, BaseModule>;
+
+export interface ModuleSystem {
+  register(name: string, module: BaseModule): void;
+  unregister(name: string): void;
+  get(name: string): BaseModule | undefined;
+  has(name: string): boolean;
+  initialize(): Promise<void>;
+  shutdown(): Promise<void>;
+}

--- a/tests/sample_project_typescript/src/types-interfaces.ts
+++ b/tests/sample_project_typescript/src/types-interfaces.ts
@@ -1,0 +1,198 @@
+/**
+ * Basic Types and Interfaces
+ * Demonstrates TypeScript's core type system including primitives,
+ * interfaces, type aliases, unions, intersections, and advanced type patterns
+ */
+
+// ========== Primitive Types ==========
+export const stringValue: string = "Hello TypeScript";
+export const numberValue: number = 42;
+export const booleanValue: boolean = true;
+export const nullValue: null = null;
+export const undefinedValue: undefined = undefined;
+export const symbolValue: symbol = Symbol("unique");
+export const bigintValue: bigint = 100n;
+
+// ========== Array and Tuple Types ==========
+export const numberArray: number[] = [1, 2, 3, 4];
+export const stringArray: Array<string> = ["a", "b", "c"];
+export const mixedTuple: [string, number, boolean] = ["hello", 42, true];
+export const namedTuple: [name: string, age: number] = ["Alice", 30];
+
+// ========== Object Types ==========
+export const basicObject: { name: string; age: number } = {
+  name: "John",
+  age: 25
+};
+
+// ========== Interface Definitions ==========
+export interface User {
+  readonly id: number;
+  name: string;
+  email?: string; // Optional property
+  readonly createdAt: Date;
+  preferences: UserPreferences;
+}
+
+export interface UserPreferences {
+  theme: "light" | "dark";
+  notifications: boolean;
+  language: string;
+}
+
+// Interface inheritance
+export interface AdminUser extends User {
+  permissions: string[];
+  lastLogin?: Date;
+}
+
+// Interface with index signature
+export interface Dictionary<T = any> {
+  [key: string]: T;
+}
+
+// Interface with call signature
+export interface StringProcessor {
+  (input: string): string;
+  description: string;
+}
+
+// Interface with construct signature
+export interface Constructable {
+  new (name: string): { name: string };
+}
+
+// ========== Type Aliases ==========
+export type Status = "pending" | "approved" | "rejected";
+export type ID = string | number;
+export type EventHandler<T> = (event: T) => void;
+
+// Generic type alias
+export type Response<T> = {
+  data: T;
+  error: string | null;
+  timestamp: Date;
+};
+
+// Mapped type alias
+export type Optional<T> = {
+  [K in keyof T]?: T[K];
+};
+
+// ========== Union Types ==========
+export type StringOrNumber = string | number;
+export type Theme = "light" | "dark" | "auto";
+
+export function formatValue(value: StringOrNumber): string {
+  if (typeof value === "string") {
+    return value.toUpperCase();
+  }
+  return value.toString();
+}
+
+// Discriminated union
+export type Shape = 
+  | { kind: "circle"; radius: number }
+  | { kind: "rectangle"; width: number; height: number }
+  | { kind: "triangle"; base: number; height: number };
+
+export function calculateArea(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle":
+      return Math.PI * shape.radius ** 2;
+    case "rectangle":
+      return shape.width * shape.height;
+    case "triangle":
+      return (shape.base * shape.height) / 2;
+    default:
+      const _exhaustive: never = shape;
+      throw new Error(`Unhandled shape: ${_exhaustive}`);
+  }
+}
+
+// ========== Intersection Types ==========
+export type PersonalInfo = {
+  name: string;
+  age: number;
+};
+
+export type ContactInfo = {
+  email: string;
+  phone: string;
+};
+
+export type Employee = PersonalInfo & ContactInfo & {
+  employeeId: string;
+  department: string;
+};
+
+// ========== Conditional Types ==========
+export type NonNullable<T> = T extends null | undefined ? never : T;
+export type ArrayElement<T> = T extends (infer U)[] ? U : never;
+
+// ========== Template Literal Types ==========
+export type EventName<T extends string> = `on${Capitalize<T>}`;
+export type CSSProperty = `--${string}`;
+
+// ========== Utility Types Usage ==========
+export type PartialUser = Partial<User>;
+export type RequiredUser = Required<User>;
+export type UserEmail = Pick<User, "email">;
+export type UserWithoutId = Omit<User, "id">;
+export type UserKeys = keyof User;
+export type UserValues = User[keyof User];
+
+// ========== Complex Type Examples ==========
+export interface GenericRepository<T, K extends keyof T> {
+  findById(id: T[K]): Promise<T | null>;
+  findAll(): Promise<T[]>;
+  create(entity: Omit<T, K>): Promise<T>;
+  update(id: T[K], updates: Partial<T>): Promise<T>;
+  delete(id: T[K]): Promise<void>;
+}
+
+// Recursive type
+export interface TreeNode<T> {
+  value: T;
+  children: TreeNode<T>[];
+  parent?: TreeNode<T>;
+}
+
+// Function type with overloads
+export interface Logger {
+  (message: string): void;
+  (level: "info" | "warn" | "error", message: string): void;
+  (level: "info" | "warn" | "error", message: string, data: any): void;
+}
+
+// ========== Implementation Examples ==========
+const user: User = {
+  id: 1,
+  name: "Alice Johnson",
+  email: "alice@example.com",
+  createdAt: new Date(),
+  preferences: {
+    theme: "dark",
+    notifications: true,
+    language: "en"
+  }
+};
+
+const adminUser: AdminUser = {
+  ...user,
+  permissions: ["read", "write", "delete"],
+  lastLogin: new Date()
+};
+
+const shapes: Shape[] = [
+  { kind: "circle", radius: 5 },
+  { kind: "rectangle", width: 10, height: 6 },
+  { kind: "triangle", base: 8, height: 4 }
+];
+
+export const typeExamples = {
+  user,
+  adminUser,
+  shapes,
+  areas: shapes.map(calculateArea)
+};

--- a/tests/sample_project_typescript/src/utilities-helpers.ts
+++ b/tests/sample_project_typescript/src/utilities-helpers.ts
@@ -1,0 +1,670 @@
+/**
+ * Utilities and Helpers
+ * Demonstrates common utility functions, type helpers, and patterns
+ * used in TypeScript projects for enhanced development experience
+ */
+
+// ========== String Utilities ==========
+export const StringUtils = {
+  /**
+   * Capitalizes the first letter of a string
+   */
+  capitalize: (str: string): string => 
+    str.charAt(0).toUpperCase() + str.slice(1).toLowerCase(),
+
+  /**
+   * Converts string to camelCase
+   */
+  camelCase: (str: string): string =>
+    str.replace(/[-_\s]+(.)?/g, (_, char) => (char ? char.toUpperCase() : '')),
+
+  /**
+   * Converts string to kebab-case
+   */
+  kebabCase: (str: string): string =>
+    str.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`).replace(/^-/, ''),
+
+  /**
+   * Converts string to snake_case
+   */
+  snakeCase: (str: string): string =>
+    str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`).replace(/^_/, ''),
+
+  /**
+   * Truncates a string to specified length with ellipsis
+   */
+  truncate: (str: string, length: number, suffix: string = '...'): string =>
+    str.length <= length ? str : str.slice(0, length) + suffix,
+
+  /**
+   * Removes extra whitespace and trims
+   */
+  normalize: (str: string): string =>
+    str.replace(/\s+/g, ' ').trim(),
+
+  /**
+   * Pluralizes a word (simple English rules)
+   */
+  pluralize: (word: string, count: number = 2): string => {
+    if (count === 1) return word;
+    if (word.endsWith('y')) return word.slice(0, -1) + 'ies';
+    if (word.endsWith('s') || word.endsWith('x') || word.endsWith('ch') || word.endsWith('sh')) {
+      return word + 'es';
+    }
+    return word + 's';
+  }
+};
+
+// ========== Array Utilities ==========
+export const ArrayUtils = {
+  /**
+   * Chunks array into smaller arrays of specified size
+   */
+  chunk: <T>(array: T[], size: number): T[][] => {
+    const chunks: T[][] = [];
+    for (let i = 0; i < array.length; i += size) {
+      chunks.push(array.slice(i, i + size));
+    }
+    return chunks;
+  },
+
+  /**
+   * Removes duplicate values from array
+   */
+  unique: <T>(array: T[]): T[] => [...new Set(array)],
+
+  /**
+   * Groups array items by a key function
+   */
+  groupBy: <T, K extends string | number | symbol>(
+    array: T[],
+    keyFn: (item: T) => K
+  ): Record<K, T[]> => {
+    return array.reduce((groups, item) => {
+      const key = keyFn(item);
+      groups[key] = groups[key] || [];
+      groups[key]!.push(item);
+      return groups;
+    }, {} as Record<K, T[]>);
+  },
+
+  /**
+   * Flattens nested arrays by one level
+   */
+  flatten: <T>(array: (T | T[])[]): T[] => array.flat() as T[],
+
+  /**
+   * Deeply flattens nested arrays
+   */
+  flattenDeep: <T>(array: any[]): T[] => {
+    return array.reduce((acc, val) => 
+      Array.isArray(val) ? acc.concat(ArrayUtils.flattenDeep(val)) : acc.concat(val), []
+    );
+  },
+
+  /**
+   * Shuffles array elements randomly
+   */
+  shuffle: <T>(array: T[]): T[] => {
+    const result = [...array];
+    for (let i = result.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [result[i], result[j]] = [result[j]!, result[i]!];
+    }
+    return result;
+  },
+
+  /**
+   * Returns random element from array
+   */
+  sample: <T>(array: T[]): T | undefined => {
+    return array[Math.floor(Math.random() * array.length)];
+  },
+
+  /**
+   * Returns multiple random elements from array
+   */
+  sampleSize: <T>(array: T[], n: number): T[] => {
+    const shuffled = ArrayUtils.shuffle(array);
+    return shuffled.slice(0, Math.min(n, array.length));
+  }
+};
+
+// ========== Object Utilities ==========
+export const ObjectUtils = {
+  /**
+   * Deep clones an object
+   */
+  deepClone: <T>(obj: T): T => {
+    if (obj === null || typeof obj !== 'object') return obj;
+    if (obj instanceof Date) return new Date(obj.getTime()) as unknown as T;
+    if (obj instanceof Array) return obj.map(item => ObjectUtils.deepClone(item)) as unknown as T;
+    if (typeof obj === 'object') {
+      const copy = {} as T;
+      Object.keys(obj).forEach(key => {
+        (copy as any)[key] = ObjectUtils.deepClone((obj as any)[key]);
+      });
+      return copy;
+    }
+    return obj;
+  },
+
+  /**
+   * Merges objects deeply
+   */
+  deepMerge: <T extends Record<string, any>, U extends Record<string, any>>(
+    target: T,
+    source: U
+  ): T & U => {
+    const result = { ...target } as T & U;
+    
+    Object.keys(source).forEach(key => {
+      if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+        if (result[key as keyof (T & U)] && typeof result[key as keyof (T & U)] === 'object') {
+          (result as any)[key] = ObjectUtils.deepMerge(
+            result[key as keyof (T & U)] as any,
+            source[key]
+          );
+        } else {
+          (result as any)[key] = ObjectUtils.deepClone(source[key]);
+        }
+      } else {
+        (result as any)[key] = source[key];
+      }
+    });
+    
+    return result;
+  },
+
+  /**
+   * Picks specified keys from object
+   */
+  pick: <T extends Record<string, any>, K extends keyof T>(
+    obj: T,
+    keys: K[]
+  ): Pick<T, K> => {
+    const result = {} as Pick<T, K>;
+    keys.forEach(key => {
+      if (key in obj) {
+        result[key] = obj[key];
+      }
+    });
+    return result;
+  },
+
+  /**
+   * Omits specified keys from object
+   */
+  omit: <T extends Record<string, any>, K extends keyof T>(
+    obj: T,
+    keys: K[]
+  ): Omit<T, K> => {
+    const result = { ...obj };
+    keys.forEach(key => {
+      delete result[key];
+    });
+    return result as Omit<T, K>;
+  },
+
+  /**
+   * Gets nested value from object using dot notation
+   */
+  get: <T>(obj: any, path: string, defaultValue?: T): T | undefined => {
+    const keys = path.split('.');
+    let result = obj;
+    
+    for (const key of keys) {
+      if (result == null || typeof result !== 'object') {
+        return defaultValue;
+      }
+      result = result[key];
+    }
+    
+    return result !== undefined ? result : defaultValue;
+  },
+
+  /**
+   * Sets nested value in object using dot notation
+   */
+  set: (obj: any, path: string, value: any): void => {
+    const keys = path.split('.');
+    const lastKey = keys.pop()!;
+    let current = obj;
+    
+    for (const key of keys) {
+      if (!(key in current) || typeof current[key] !== 'object') {
+        current[key] = {};
+      }
+      current = current[key];
+    }
+    
+    current[lastKey] = value;
+  },
+
+  /**
+   * Checks if object has nested property
+   */
+  has: (obj: any, path: string): boolean => {
+    const keys = path.split('.');
+    let current = obj;
+    
+    for (const key of keys) {
+      if (current == null || typeof current !== 'object' || !(key in current)) {
+        return false;
+      }
+      current = current[key];
+    }
+    
+    return true;
+  }
+};
+
+// ========== Function Utilities ==========
+export const FunctionUtils = {
+  /**
+   * Debounces function execution
+   */
+  debounce: <T extends (...args: any[]) => any>(
+    fn: T,
+    delay: number
+  ): ((...args: Parameters<T>) => void) => {
+    let timeoutId: NodeJS.Timeout;
+    return (...args: Parameters<T>) => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => fn(...args), delay);
+    };
+  },
+
+  /**
+   * Throttles function execution
+   */
+  throttle: <T extends (...args: any[]) => any>(
+    fn: T,
+    limit: number
+  ): ((...args: Parameters<T>) => void) => {
+    let inThrottle: boolean;
+    return (...args: Parameters<T>) => {
+      if (!inThrottle) {
+        fn(...args);
+        inThrottle = true;
+        setTimeout(() => (inThrottle = false), limit);
+      }
+    };
+  },
+
+  /**
+   * Memoizes function results
+   */
+  memoize: <T extends (...args: any[]) => any>(fn: T): T => {
+    const cache = new Map();
+    return ((...args: any[]) => {
+      const key = JSON.stringify(args);
+      if (cache.has(key)) {
+        return cache.get(key);
+      }
+      const result = fn(...args);
+      cache.set(key, result);
+      return result;
+    }) as T;
+  },
+
+  /**
+   * Creates a curried version of function
+   */
+  curry: <T extends (...args: any[]) => any>(
+    fn: T,
+    arity: number = fn.length
+  ): any => {
+    return (...args: any[]) => {
+      if (args.length >= arity) {
+        return fn(...args);
+      }
+      return FunctionUtils.curry(fn.bind(null, ...args), arity - args.length);
+    };
+  },
+
+  /**
+   * Composes functions from right to left
+   */
+  compose: <T>(...fns: Function[]): (arg: T) => any => {
+    return (arg: T) => fns.reduceRight((result, fn) => fn(result), arg);
+  },
+
+  /**
+   * Pipes functions from left to right
+   */
+  pipe: <T>(...fns: Function[]): (arg: T) => any => {
+    return (arg: T) => fns.reduce((result, fn) => fn(result), arg);
+  }
+};
+
+// ========== Date Utilities ==========
+export const DateUtils = {
+  /**
+   * Formats date to ISO string with timezone
+   */
+  toISOString: (date: Date): string => date.toISOString(),
+
+  /**
+   * Formats date to readable string
+   */
+  format: (date: Date, locale: string = 'en-US'): string => 
+    date.toLocaleDateString(locale),
+
+  /**
+   * Gets difference between dates in various units
+   */
+  diff: (date1: Date, date2: Date, unit: 'days' | 'hours' | 'minutes' | 'seconds' = 'days'): number => {
+    const diffMs = Math.abs(date1.getTime() - date2.getTime());
+    switch (unit) {
+      case 'seconds': return Math.floor(diffMs / 1000);
+      case 'minutes': return Math.floor(diffMs / (1000 * 60));
+      case 'hours': return Math.floor(diffMs / (1000 * 60 * 60));
+      case 'days': return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    }
+  },
+
+  /**
+   * Adds time to date
+   */
+  add: (date: Date, amount: number, unit: 'days' | 'hours' | 'minutes' | 'seconds'): Date => {
+    const result = new Date(date);
+    switch (unit) {
+      case 'seconds': result.setSeconds(result.getSeconds() + amount); break;
+      case 'minutes': result.setMinutes(result.getMinutes() + amount); break;
+      case 'hours': result.setHours(result.getHours() + amount); break;
+      case 'days': result.setDate(result.getDate() + amount); break;
+    }
+    return result;
+  },
+
+  /**
+   * Checks if date is between two dates
+   */
+  isBetween: (date: Date, start: Date, end: Date): boolean =>
+    date >= start && date <= end,
+
+  /**
+   * Gets start of day
+   */
+  startOfDay: (date: Date): Date => {
+    const result = new Date(date);
+    result.setHours(0, 0, 0, 0);
+    return result;
+  },
+
+  /**
+   * Gets end of day
+   */
+  endOfDay: (date: Date): Date => {
+    const result = new Date(date);
+    result.setHours(23, 59, 59, 999);
+    return result;
+  }
+};
+
+// ========== Number Utilities ==========
+export const NumberUtils = {
+  /**
+   * Clamps number between min and max
+   */
+  clamp: (value: number, min: number, max: number): number =>
+    Math.min(Math.max(value, min), max),
+
+  /**
+   * Rounds to specified decimal places
+   */
+  round: (value: number, decimals: number = 0): number =>
+    Math.round(value * Math.pow(10, decimals)) / Math.pow(10, decimals),
+
+  /**
+   * Generates random number between min and max
+   */
+  random: (min: number, max: number): number =>
+    Math.random() * (max - min) + min,
+
+  /**
+   * Generates random integer between min and max (inclusive)
+   */
+  randomInt: (min: number, max: number): number =>
+    Math.floor(Math.random() * (max - min + 1)) + min,
+
+  /**
+   * Checks if number is in range
+   */
+  inRange: (value: number, min: number, max: number): boolean =>
+    value >= min && value <= max,
+
+  /**
+   * Converts number to percentage string
+   */
+  toPercent: (value: number, decimals: number = 2): string =>
+    `${NumberUtils.round(value * 100, decimals)}%`,
+
+  /**
+   * Formats number with thousands separators
+   */
+  format: (value: number, locale: string = 'en-US'): string =>
+    value.toLocaleString(locale)
+};
+
+// ========== Type Utilities ==========
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+export type DeepRequired<T> = {
+  [P in keyof T]-?: T[P] extends object ? DeepRequired<T[P]> : T[P];
+};
+
+export type KeysOfType<T, U> = {
+  [K in keyof T]: T[K] extends U ? K : never;
+}[keyof T];
+
+export type Writeable<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
+export type OptionalExcept<T, K extends keyof T> = Partial<T> & Pick<T, K>;
+
+export type RequiredExcept<T, K extends keyof T> = Required<Omit<T, K>> & Partial<Pick<T, K>>;
+
+// ========== Validation Helpers ==========
+export const ValidationHelpers = {
+  /**
+   * Email validation
+   */
+  isEmail: (value: string): boolean =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value),
+
+  /**
+   * URL validation
+   */
+  isUrl: (value: string): boolean => {
+    try {
+      new URL(value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  /**
+   * UUID validation
+   */
+  isUuid: (value: string): boolean =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value),
+
+  /**
+   * Credit card number validation (Luhn algorithm)
+   */
+  isCreditCard: (value: string): boolean => {
+    const num = value.replace(/\D/g, '');
+    if (num.length < 13 || num.length > 19) return false;
+    
+    let sum = 0;
+    let isEven = false;
+    
+    for (let i = num.length - 1; i >= 0; i--) {
+      let digit = parseInt(num[i]!);
+      
+      if (isEven) {
+        digit *= 2;
+        if (digit > 9) digit -= 9;
+      }
+      
+      sum += digit;
+      isEven = !isEven;
+    }
+    
+    return sum % 10 === 0;
+  },
+
+  /**
+   * Strong password validation
+   */
+  isStrongPassword: (value: string): boolean => {
+    const minLength = value.length >= 8;
+    const hasLower = /[a-z]/.test(value);
+    const hasUpper = /[A-Z]/.test(value);
+    const hasNumber = /\d/.test(value);
+    const hasSpecial = /[!@#$%^&*(),.?":{}|<>]/.test(value);
+    
+    return minLength && hasLower && hasUpper && hasNumber && hasSpecial;
+  }
+};
+
+// ========== Color Utilities ==========
+export const ColorUtils = {
+  /**
+   * Converts hex to RGB
+   */
+  hexToRgb: (hex: string): { r: number; g: number; b: number } | null => {
+    const match = hex.match(/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i);
+    return match ? {
+      r: parseInt(match[1]!, 16),
+      g: parseInt(match[2]!, 16),
+      b: parseInt(match[3]!, 16)
+    } : null;
+  },
+
+  /**
+   * Converts RGB to hex
+   */
+  rgbToHex: (r: number, g: number, b: number): string => {
+    const componentToHex = (c: number) => {
+      const hex = c.toString(16);
+      return hex.length === 1 ? '0' + hex : hex;
+    };
+    return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
+  },
+
+  /**
+   * Lightens a color by percentage
+   */
+  lighten: (hex: string, percent: number): string => {
+    const rgb = ColorUtils.hexToRgb(hex);
+    if (!rgb) return hex;
+    
+    const factor = 1 + percent / 100;
+    return ColorUtils.rgbToHex(
+      Math.min(255, Math.round(rgb.r * factor)),
+      Math.min(255, Math.round(rgb.g * factor)),
+      Math.min(255, Math.round(rgb.b * factor))
+    );
+  }
+};
+
+// ========== Performance Utilities ==========
+export const PerformanceUtils = {
+  /**
+   * Measures execution time of a function
+   */
+  measure: async <T>(fn: () => T | Promise<T>): Promise<{ result: T; duration: number }> => {
+    const start = performance.now();
+    const result = await fn();
+    const end = performance.now();
+    return { result, duration: end - start };
+  },
+
+  /**
+   * Creates a performance timer
+   */
+  timer: () => {
+    const start = performance.now();
+    return {
+      stop: () => performance.now() - start,
+      lap: () => {
+        const current = performance.now();
+        return current - start;
+      }
+    };
+  },
+
+  /**
+   * Batches synchronous operations
+   */
+  batch: <T, R>(
+    items: T[],
+    processor: (batch: T[]) => R[],
+    batchSize: number = 100
+  ): R[] => {
+    const results: R[] = [];
+    for (let i = 0; i < items.length; i += batchSize) {
+      const batch = items.slice(i, i + batchSize);
+      results.push(...processor(batch));
+    }
+    return results;
+  }
+};
+
+// ========== Usage Examples ==========
+export const utilityExamples = {
+  // String utilities
+  camelCased: StringUtils.camelCase("hello-world-example"),
+  kebabCased: StringUtils.kebabCase("HelloWorldExample"),
+  truncated: StringUtils.truncate("This is a very long string", 15),
+  
+  // Array utilities
+  chunked: ArrayUtils.chunk([1, 2, 3, 4, 5, 6, 7], 3),
+  unique: ArrayUtils.unique([1, 2, 2, 3, 3, 3, 4]),
+  grouped: ArrayUtils.groupBy(
+    [{ type: 'fruit', name: 'apple' }, { type: 'vegetable', name: 'carrot' }],
+    item => item.type
+  ),
+  
+  // Object utilities
+  picked: ObjectUtils.pick({ a: 1, b: 2, c: 3 }, ['a', 'c']),
+  deepValue: ObjectUtils.get({ user: { profile: { name: 'John' } } }, 'user.profile.name'),
+  
+  // Function utilities
+  debouncedLog: FunctionUtils.debounce((message: string) => console.log(message), 1000),
+  memoizedFib: FunctionUtils.memoize((n: number): number => {
+    if (n <= 1) return n;
+    return utilityExamples.memoizedFib(n - 1) + utilityExamples.memoizedFib(n - 2);
+  }),
+  
+  // Date utilities
+  futureDate: DateUtils.add(new Date(), 7, 'days'),
+  daysDiff: DateUtils.diff(new Date('2023-12-31'), new Date('2023-01-01')),
+  
+  // Number utilities
+  clamped: NumberUtils.clamp(150, 0, 100),
+  rounded: NumberUtils.round(3.14159, 2),
+  percentage: NumberUtils.toPercent(0.85),
+  
+  // Validation
+  emailValid: ValidationHelpers.isEmail('user@example.com'),
+  strongPassword: ValidationHelpers.isStrongPassword('StrongPass123!'),
+  
+  // Colors
+  rgbColor: ColorUtils.hexToRgb('#ff0000'),
+  lighterColor: ColorUtils.lighten('#ff0000', 20)
+};
+
+// Initialize some examples
+console.log('Utility examples initialized:', {
+  camelCased: utilityExamples.camelCased,
+  chunked: utilityExamples.chunked,
+  deepValue: utilityExamples.deepValue
+});

--- a/tests/sample_project_typescript/tsconfig.json
+++ b/tests/sample_project_typescript/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strictPropertyInitialization": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
This pull request adds a new TypeScript sample project under samples/typescript, expanding the test coverage and showcasing recommended project structure and configuration for TypeScript-based setups.

Key changes:

Introduced sample_project_typescript with minimal, clean structure.

Added relevant configuration files (tsconfig.json, basic scripts) to illustrate best practices.

Included basic test cases to ensure smooth integration with the existing test pipeline.

This serves as a reference implementation for future TypeScript samples and improves overall framework consistency.

fixes: #97 