### PR TITLE
added support for typescript

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -154,8 +154,8 @@ class MCPServer:
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "package_name": {"type": "string", "description": "Name of the package to add (e.g., 'requests', 'express', 'iniparser')."},
-                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "java", "c"]},
+                        "package_name": {"type": "string", "description": "Name of the package to add (e.g., 'requests', 'express', 'moment', 'lodash')."},
+                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "typescript", "java", "c"]},
                         "is_dependency": {"type": "boolean", "description": "Mark as a dependency.", "default": True}
                     },
                     "required": ["package_name", "language"]


### PR DESCRIPTION
**Add support for TypeScript language package resolution**

Fixes #321

Summary:
This PR adds support for TypeScript packages to the add_package_to_graph tool, enabling discovery and indexing of TypeScript libraries from npm node_modules.

Changes:
- package_resolver.py: Added _get_typescript_package_path() function that:
  - Searches for TypeScript packages in local node_modules directory
  - Falls back to global npm packages using npm root -g
  - Reuses the same logic as JavaScript packages since TypeScript packages are distributed via npm
  - Returns the resolved package path when found

- server.py: Updated add_package_to_graph tool to accept "typescript" as a language option in the enum
