### PR TITLE
Fixes: Text Overlapping issues resolved

### DIFF
--- a/website/src/components/DemoSection.tsx
+++ b/website/src/components/DemoSection.tsx
@@ -33,7 +33,7 @@ const DemoSection = () => {
     <section className="py-20 px-4 bg-gradient-to-b from-background to-secondary/10">
       <div className="container mx-auto max-w-7xl">
         <div className="text-center mb-16">
-          <h2 className="text-2xl sm:text-3xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-primary via-primary to-accent bg-clip-text text-transparent">
+          <h2 className="text-2xl sm:text-3xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-primary via-primary to-accent bg-clip-text text-transparent py-2">
             See CodeGraphContext in Action
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto mb-12">

--- a/website/src/components/ExamplesSection.tsx
+++ b/website/src/components/ExamplesSection.tsx
@@ -46,7 +46,7 @@ const ExamplesSection = () => {
     <section className="py-24 px-4">
       <div className="container mx-auto max-w-6xl">
         <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-primary via-primary to-accent bg-clip-text text-transparent">
+          <h2 className="text-4xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-primary via-primary to-accent bg-clip-text text-transparent py-2">
             Natural Language Interface
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto">

--- a/website/src/components/HeroSection.tsx
+++ b/website/src/components/HeroSection.tsx
@@ -70,7 +70,7 @@ const HeroSection = () => {
             Version {version} • MIT License
           </Badge>
           
-          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-bold mb-6 bg-gradient-to-r from-purple-700 via-indigo-700 to-purple-900 dark:bg-gradient-primary bg-clip-text text-transparent leading-tight tracking-tight drop-shadow-[0_2px_8px_rgba(0,0,0,0.15)]">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-bold mb-6 bg-gradient-to-r from-purple-700 via-indigo-700 to-purple-900 dark:bg-gradient-primary bg-clip-text py-2 text-transparent leading-tight tracking-tight drop-shadow-[0_2px_8px_rgba(0,0,0,0.15)]">
             CodeGraphContext
           </h1>
           

--- a/website/src/components/ShowStarGraph.tsx
+++ b/website/src/components/ShowStarGraph.tsx
@@ -59,7 +59,7 @@ export default function ShowStarGraph() {
             <div className="flex items-center justify-center gap-2 mb-4">
               <Star className="h-6 w-6 text-yellow-500 fill-yellow-500" />
 
-              <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-primary via-primary to-accent bg-clip-text text-transparent">
+              <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-primary via-primary to-accent bg-clip-text text-transparent py-2">
                 Star History
               </h2>
               <TrendingUp className="h-6 w-6 text-green-500" />

--- a/website/src/components/TestimonialSection.tsx
+++ b/website/src/components/TestimonialSection.tsx
@@ -51,7 +51,7 @@ export default function TestimonialSection() {
     <section className="py-24 px-4">
       <div className="container mx-auto max-w-6xl">
         <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-primary via-primary to-accent bg-clip-text text-transparent">
+          <h2 className="text-4xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-primary via-primary to-accent bg-clip-text text-transparent py-2">
             What teams are saying
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
@@ -111,7 +111,7 @@ export default function TestimonialSection() {
         {/* Right: Testimonial content */}
         <Card className="dark:bg-gradient-card dark:bg-card/50 dark:border-border/30 bg-white/95 border-gray-200/50 shadow-sm">
           <CardHeader>
-            <CardTitle className="text-3xl md:text-4xl font-bold bg-gradient-primary bg-clip-text text-transparent">
+            <CardTitle className="text-3xl md:text-4xl font-bold bg-gradient-primary bg-clip-text text-transparent py-2">
               Teams love the experience
             </CardTitle>
             <CardDescription className="text-base md:text-lg dark:text-muted-foreground text-gray-600">


### PR DESCRIPTION
fixes #300 

fixed the text overlapping issues :
- issue was with the clipped text which was used over the transparent text color
- improved this for whole page as many headings were having the same issue.

- below is the glimpse of what i fixed:

<img width="450" height="95" alt="Screenshot 2025-10-06 201518" src="https://github.com/user-attachments/assets/ac2ed948-630d-4c72-879b-c1cd2e5881c2" />
<img width="436" height="96" alt="Screenshot 2025-10-06 175435" src="https://github.com/user-attachments/assets/8c8a463b-1e95-431b-a989-e64008131f45" />
