### PR TITLE
Remove function-assigned variables from graph variable nodes

### DIFF
--- a/src/codegraphcontext/tools/languages/javascript.py
+++ b/src/codegraphcontext/tools/languages/javascript.py
@@ -501,9 +501,12 @@ class JavascriptTreeSitterParser:
                 if value_node:
                     value_type = value_node.type
 
+                    # --- Skip variables that are assigned a function ---
+                    if value_type in ("function_expression", "arrow_function"):
+                        continue
+
                     # --- Handle various assignment types ---
-                    if value_type in ("function_expression", "arrow_function", "call_expression"):
-                        # Try to get function name (if anonymous, use variable name)
+                    if value_type == "call_expression":
                         func_name_node = value_node.child_by_field_name("name")
                         func_name = (
                             self._get_node_text(func_name_node) 


### PR DESCRIPTION
This PR improves the JavaScript parser by filtering out variables that are assigned a function definition (either a function_expression or an arrow_function) so that such functions appear only as Function nodes in the Neo4j graph — not duplicated as Variable nodes.

Problem :
Previously, variables that held function definitions (like below) were being added to the graph as both:
a Function node, and
a Variable node.

