### PR TITLE
Add Docker packaging for CodeGraphContext CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+.git
+.github
+.gitignore
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.whl
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+
+# Build output
+build/
+dist/
+*.egg-info/
+.venv/
+env/
+venv/
+
+# Environment and local config
+.env
+.env.*
+*.log
+
+# Node / frontend artifacts
+node_modules/
+website/node_modules/
+website/.next/
+
+# Documentation and tests (not required at runtime)
+docs/
+tests/
+images/
+scripts/
+organizer/
+website/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.6
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /opt/codegraphcontext
+
+# Install system build dependencies required for Python packages like tree-sitter.
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential \
+        libffi-dev \
+        libssl-dev \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy only the files required to install the package to leverage Docker layer caching.
+COPY pyproject.toml README.md LICENSE MANIFEST.in ./
+COPY src/ ./src/
+
+# Install the CodeGraphContext package into the image.
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir .
+
+# Drop privileges for runtime safety and create a writable workspace.
+RUN useradd --create-home --shell /bin/bash cgc
+USER cgc
+WORKDIR /workspace
+
+# Expose the CLI as the container entrypoint. Commands can be passed as arguments.
+ENTRYPOINT ["cgc"]
+CMD ["--help"]
+

--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ If you’re using CodeGraphContext in your project, feel free to open a PR and a
 
 3.  **Start:** `cgc start`
 
+## Docker Image
+
+- Build locally with `docker build -t codegraphcontext:latest .`
+- Run commands through Docker while mounting your workspace and configuration:
+
+  ```bash
+  docker run --rm -it \
+    -v "$PWD":/workspace \
+    -v "$HOME/.codegraphcontext":/home/cgc/.codegraphcontext \
+    codegraphcontext:latest setup
+  ```
+
+- Instructions for publishing the container to Docker Hub are documented in [`docs/docker.md`](docs/docker.md).
+
 ## Ignoring Files (`.cgcignore`)
 
 You can tell CodeGraphContext to ignore specific files and directories by creating a `.cgcignore` file in the root of your project. This file uses the same syntax as `.gitignore`.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,79 @@
+# Docker Support
+
+This repository now ships with a first-class Docker image so that the CLI can
+run without requiring a local Python toolchain. The Dockerfile lives at the
+repository root and installs the published package together with its
+dependencies.
+
+## Build the image locally
+
+```bash
+docker build -t codegraphcontext:latest .
+```
+
+To speed up builds in CI/CD you can take advantage of Docker layer caching. The
+Dockerfile copies only the files required to install the package before running
+`pip install .`, so subsequent builds after small source changes remain fast.
+
+## Run CodeGraphContext via Docker
+
+Run the CLI by mounting your project and the CodeGraphContext configuration
+directory into the container:
+
+```bash
+docker run --rm -it \
+  -v "$PWD":/workspace \
+  -v "$HOME/.codegraphcontext":/home/cgc/.codegraphcontext \
+  codegraphcontext:latest setup
+```
+
+The image uses `cgc` as the entrypoint, so any subcommand can be passed
+directly, for example:
+
+```bash
+docker run --rm -it \
+  -v "$PWD":/workspace \
+  -v "$HOME/.codegraphcontext":/home/cgc/.codegraphcontext \
+  --env NEO4J_URI=bolt://neo4j:7687 \
+  --env NEO4J_USERNAME=neo4j \
+  --env NEO4J_PASSWORD=changeme \
+  codegraphcontext:latest start
+```
+
+> **Note:** Mounting `~/.codegraphcontext` ensures that credentials saved by
+> `cgc setup` persist across container runs. If you prefer managing
+> credentials through environment variables, omit the volume and pass the
+> variables with `--env` or `--env-file`.
+
+## Publish to Docker Hub
+
+1. Build the image with the package version tag:
+
+   ```bash
+   APP_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+   docker build -t codegraphcontext:$APP_VERSION .
+   ```
+
+2. Tag the image for Docker Hub (replace `shashankss1205` with the Docker Hub
+   namespace you own):
+
+   ```bash
+   docker tag codegraphcontext:$APP_VERSION shashankss1205/codegraphcontext:$APP_VERSION
+   docker tag codegraphcontext:$APP_VERSION shashankss1205/codegraphcontext:latest
+   ```
+
+3. Authenticate and push:
+
+   ```bash
+   docker login
+   docker push shashankss1205/codegraphcontext:$APP_VERSION
+   docker push shashankss1205/codegraphcontext:latest
+   ```
+
+After the image has been published you can pull it directly:
+
+```bash
+docker pull shashankss1205/codegraphcontext:latest
+docker run --rm -it shashankss1205/codegraphcontext:latest --help
+```
+


### PR DESCRIPTION
## Summary
- add a Dockerfile and .dockerignore so the CLI can run without a local Python toolchain
- document building, running, and publishing the container image
- validate the image with a local docker build

Closes #391

## Testing
- docker build -t codegraphcontext-test:latest .
- docker run --rm codegraphcontext-test:latest --help
- pytest  # failed: server fixture requires NEO4J_* credentials