### PR TITLE
Updated README.md Dependencies Section #404

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ If you’re using CodeGraphContext in your project, feel free to open a PR and a
 - `python-dotenv>=1.0.0`
 - `tree-sitter==0.20.4`
 - `tree-sitter-languages==1.10.2`
+- `pyyaml`
+- `pytest`
+- `nbformat`
+- `nbconvert>=7.16.6`
+- `pathspec>=0.12.1`
 
 ## Getting Started
 


### PR DESCRIPTION
Added the following 5 missing packages:

pyyaml
pytest
nbformat
nbconvert>=7.16.6
pathspec>=0.12.1

All other packages were already correctly listed with their proper versions!