### PR TITLE
fix(typescript): improve TypeScript parser for code graph generation

### DIFF
--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -262,3 +262,13 @@ def main(
         console.print("👉 Run [cyan]cgc help[/cyan] to see all available commands.\n")
         console.print("👉 Run [cyan]cgc --version[/cyan] to check the version.\n")
         console.print("👉 Running [green]codegraphcontext [white]works the same as using [green]cgc")
+@app.command()
+def index_sample():
+    """
+
+    Index a sample project for testing or CI purposes.
+    """
+    _load_credentials()
+    from pathlib import Path
+    sample_path= Path(__file__).parent.parent / "tests" /"sample_project_typescript"
+    index_helper(str(sample_path))


### PR DESCRIPTION
Fixes #339 

Added pre-scan improvement in `pre_scan_typescript`
CALLS, IMPORTS, INHERITS are captured
Parser output for `test/sample_project_typescript` is validated
<img width="1789" height="646" alt="Screenshot (118)" src="https://github.com/user-attachments/assets/758cc6d0-c58b-4610-914b-ed93b11ff0bf" />

Files with their class definitions

<img width="1798" height="650" alt="Screenshot (116)" src="https://github.com/user-attachments/assets/f99000ca-99e4-4c05-80a0-3c2c1081510a" />

Modules imported by the Files

<img width="1805" height="663" alt="Screenshot (115)" src="https://github.com/user-attachments/assets/5a2c525f-a75a-46e1-ad16-8fc01ec0a632" />

Functions and Classes defined with CONTAINS relation

<img width="1794" height="712" alt="Screenshot (113)" src="https://github.com/user-attachments/assets/33e01842-a6b2-45ef-89fe-deff985a3fd1" />

Class node shows connection with Files via CONTAINS

<img width="1802" height="407" alt="Screenshot (117)" src="https://github.com/user-attachments/assets/1341e2eb-1076-40a0-abdb-d312cd082f3b" />

All the relationships (CONTAINS, CALLS, IMPORTS) with counts 
