### PR TITLE
Add Ruby :Module nodes and Class→Module INCLUDES relationships

### DIFF
--- a/tests/sample_project_ruby/tests/test_mixins.py
+++ b/tests/sample_project_ruby/tests/test_mixins.py
@@ -1,0 +1,23 @@
+def test_ruby_class_includes_module(graph):
+    # Check that the module node exists
+    rows = graph.query('MATCH (:Module {name:"Flyable"}) RETURN 1 AS ok LIMIT 1')
+    assert rows, "Expected a Module node named 'Flyable' but none was found."
+
+    # Check that the class node exists
+    rows = graph.query('MATCH (:Class {name:"Bird"}) RETURN 1 AS ok LIMIT 1')
+    assert rows, "Expected a Class node named 'Bird' but none was found."
+
+    # Check that the INCLUDES relationship exists between Bird and Flyable
+    rows = graph.query('''
+        MATCH (:Class {name:"Bird"})-[:INCLUDES]->(:Module {name:"Flyable"})
+        RETURN count(*) AS c
+    ''')
+    assert rows and rows[0]["c"] > 0, \
+        "Expected an INCLUDES relationship from Class 'Bird' to Module 'Flyable', but none was found."
+
+
+def test_module_is_unique(graph):
+    # Ensure only one Module node named 'Flyable' exists
+    rows = graph.query('MATCH (m:Module {name:"Flyable"}) RETURN count(m) AS c')
+    assert rows and rows[0]["c"] == 1, \
+        f"Expected exactly one Module node named 'Flyable', but found {rows[0]['c'] if rows else 0}."


### PR DESCRIPTION
This PR adds Ruby Module support to CodeGraphContext, enabling detection of module declarations and include statements within classes, and modeling them as (:Class)-[:INCLUDES]->(:Module) relationships.

1. Ruby Parser (ruby.py)
- Added _find_modules() and _find_module_inclusions() to extract module definitions and class mixin usages.
- Parsing output now returns two new keys:
-- "modules" — module definitions
-- "module_inclusions" — class → module include relations
- Modules are identified by name + language, consistent with existing node conventions.

2. Graph Builder (graph_builder.py)
- Added support for the :Module node type (schema constraint + item_mappings).
- Implemented persistence of Module nodes uniquely by (name, lang).
- Added handling of "module_inclusions" to create:
(:Class)-[:INCLUDES]->(:Module)
- This slightly extends the issue spec by ensuring Module deduplication—aligned with the project's existing design for other node types.

3. Tests
Added tests/sample_project_ruby/tests/test_mixins.py, which verifies:
- Module nodes are created
- Class includes are correctly represented as INCLUDES edges
- Modules are created uniquely across the project

Closes #358 