### PR TITLE
fix:issue-447 : Change Command from cgc start to cgc mcp start

### DIFF
--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -26,7 +26,7 @@ def _generate_mcp_json(creds):
     if "python" in Path(cgc_path).name:
         # fallback to running as module if no cgc binary is found
         command = cgc_path
-        args = ["-m", "cgc", "start"]
+        args = ["-m", "cgc", "mcp", "start"]
     else:
         command = cgc_path
         args = ["mcp","start"]


### PR DESCRIPTION
added mcp args to the function in setup_wizard.py that genrates client config.all new configs will use the correct cmd structure
Closes #447 