### PR TITLE
Fix footer email alignment

### DIFF
--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -237,14 +237,14 @@ const Footer = () => {
           {/* Right Side: Contact + Newsletter */}
           <div className="flex-1 flex flex-col sm:flex-row gap-12">
             {/* Contact */}
-            <div className="w-56">
+            <div className="w-full sm:w-64 lg:w-72">
               <h4 className="font-semibold mb-4">Contact</h4>
               <div className="space-y-5 text-muted-foreground">
-                <div className="flex items-start gap-3">
-                  <Mail className="h-5 w-5 mt-1 text-primary" />
+                <div className="flex items-center gap-3">
+                  <Mail className="h-5 w-5 text-primary shrink-0" />
                   <a
                     href="mailto:shashankshekharsingh1205@gmail.com"
-                    className="hover:text-foreground transition-smooth text-sm break-all"
+                    className="hover:text-foreground transition-smooth text-sm whitespace-nowrap"
                   >
                     shashankshekharsingh1205@gmail.com
                   </a>


### PR DESCRIPTION
### Fix
- Kept footer contact email on a single line
- Prevented overlap with Newsletter section on desktop
- Improved alignment between mail icon and email text

### Result
Footer layout is now clean and responsive across mobile and desktop.
<img width="372" height="801" alt="Screenshot 2026-01-09 001209" src="https://github.com/user-attachments/assets/c502f66c-585b-47d1-9806-62d6f264e264" />
<img width="1811" height="492" alt="Screenshot 2026-01-09 001226" src="https://github.com/user-attachments/assets/96a2b6b9-b7eb-4cee-8539-eca3935c1431" />

Fixes #499 
