### PR TITLE
Generate default .env on first cgc config show run

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -315,8 +315,29 @@ def reset_config():
     console.print("[cyan]Note: Database credentials were preserved[/cyan]")
 
 
+
+def ensure_config_file():
+    """
+    Create default .env config file on first run if it does not exist.
+    """
+    ensure_config_dir()
+
+    if CONFIG_FILE.exists():
+        return False  # file already exists
+
+    save_config(DEFAULT_CONFIG.copy(), preserve_db_credentials=False)
+    return True  # file was created
+
+
+
+
 def show_config():
     """Display current configuration in a nice table."""
+    created = ensure_config_file()
+    if created:
+        console.print(
+            f"[green]🆕 Created default configuration at {CONFIG_FILE}[/green]\n"
+        )
     config = load_config()
     
     # Separate database credentials from configuration


### PR DESCRIPTION
### Fix: Auto-generate .env on first `cgc config show`

This PR updates `cgc config show` to automatically create a default
`~/.codegraphcontext/.env` file on first run if it does not exist.

Fixes #506 

- Uses existing default configuration values
- Allows users to edit the config file directly
- Does not overwrite existing configurations
- Keeps behavior backward compatible

#### How to test
1. `rm -rf ~/.codegraphcontext`
2. Run `cgc config show`
3. Verify `.env` is created and editable
<img width="1376" height="810" alt="image" src="https://github.com/user-attachments/assets/32cfcfbd-3d9e-42c2-bfcf-14dc0f8f4a84" />
