### PR TITLE
Add INDEX_SOURCE config to control source code storage

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -38,6 +38,7 @@ DEFAULT_CONFIG = {
     "PARALLEL_WORKERS": "4",
     "CACHE_ENABLED": "true",
     "IGNORE_DIRS": "node_modules,venv,.venv,env,.env,dist,build,target,out,.git,.idea,.vscode,__pycache__",
+    "INDEX_SOURCE": "false",
 }
 
 # Configuration key descriptions
@@ -60,6 +61,7 @@ CONFIG_DESCRIPTIONS = {
     "PARALLEL_WORKERS": "Number of parallel indexing workers",
     "CACHE_ENABLED": "Enable caching for faster re-indexing",
     "IGNORE_DIRS": "Comma-separated list of directory names to ignore during indexing",
+    "INDEX_SOURCE": "Store full source code in graph database (recommended false)",
 }
 
 # Valid values for each config key
@@ -73,6 +75,7 @@ CONFIG_VALIDATORS = {
     "IGNORE_HIDDEN_FILES": ["true", "false"],
     "ENABLE_AUTO_WATCH": ["true", "false"],
     "CACHE_ENABLED": ["true", "false"],
+    "INDEX_SOURCE": ["true", "false"],
 }
 
 

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -15,8 +15,6 @@ from tree_sitter import Language, Parser
 from ..utils.tree_sitter_manager import get_tree_sitter_manager
 from ..cli.config_manager import get_config_value
 
-INDEX_SOURCE = (get_config_value("INDEX_SOURCE") or "false").lower() == "true"
-
 
 class TreeSitterParser:
     """A generic parser wrapper for a specific language using tree-sitter."""
@@ -150,7 +148,7 @@ class GraphBuilder:
                 session.run("""
                     CREATE FULLTEXT INDEX code_search_index IF NOT EXISTS 
                     FOR (n:Function|Class|Variable) 
-                    ON EACH [n.name, n.source, n.docstring]
+                    ON EACH [n.name, coalesce(n.source, ''), coalesce(n.docstring, '')]
                 """ )
                 
                 info_logger("Database schema verified/created successfully")
@@ -332,12 +330,7 @@ class GraphBuilder:
                         SET n += $props
                         MERGE (f)-[:CONTAINS]->(n)
                     """
-                    # Respect INDEX_SOURCE config
-                    if not INDEX_SOURCE:
-                        item = item.copy()
-                        item.pop("source", None)
-                        item.pop("source_code", None)
-                        item.pop("docstring", None)
+
                     session.run(query, file_path=file_path_str, name=item['name'], line_number=item['line_number'], props=item)
                     
                     if label == 'Function':
@@ -807,15 +800,23 @@ class GraphBuilder:
 
         debug_log(f"[parse_file] Starting parsing for: {file_path} with {parser.language_name} parser")
         try:
+            index_source = (get_config_value("INDEX_SOURCE") or "false").lower() == "true"
             if parser.language_name == 'python':
                 is_notebook = file_path.suffix == '.ipynb'
-                file_data = parser.parse(file_path, is_dependency, is_notebook=is_notebook)
+                file_data = parser.parse(
+                    file_path,
+                    is_dependency,
+                    is_notebook=is_notebook,
+                    index_source=index_source
+                )
             else:
-                file_data = parser.parse(file_path, is_dependency)
+                file_data = parser.parse(
+                    file_path,
+                    is_dependency,
+                    index_source=index_source
+                )
             file_data['repo_path'] = str(repo_path)
-            debug_log(f"[parse_file] Successfully parsed: {file_path}")
             return file_data
-            
         except Exception as e:
             error_logger(f"Error parsing {file_path} with {parser.language_name} parser: {e}")
             debug_log(f"[parse_file] Error parsing {file_path}: {e}")

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -15,6 +15,9 @@ from tree_sitter import Language, Parser
 from ..utils.tree_sitter_manager import get_tree_sitter_manager
 from ..cli.config_manager import get_config_value
 
+INDEX_SOURCE = (get_config_value("INDEX_SOURCE") or "false").lower() == "true"
+
+
 class TreeSitterParser:
     """A generic parser wrapper for a specific language using tree-sitter."""
 
@@ -329,6 +332,12 @@ class GraphBuilder:
                         SET n += $props
                         MERGE (f)-[:CONTAINS]->(n)
                     """
+                    # Respect INDEX_SOURCE config
+                    if not INDEX_SOURCE:
+                        item = item.copy()
+                        item.pop("source", None)
+                        item.pop("source_code", None)
+                        item.pop("docstring", None)
                     session.run(query, file_path=file_path_str, name=item['name'], line_number=item['line_number'], props=item)
                     
                     if label == 'Function':


### PR DESCRIPTION
## Add INDEX_SOURCE configuration flag

Closes #513

### What this PR does
- Adds a new `INDEX_SOURCE` configuration flag (default: `false`)
- When `false`, graph structure is indexed without storing full source code
- When `true`, full source code for functions is stored in the graph

### Why this is useful
- Reduces database size for large repositories
- Allows users to choose between lightweight graph-only indexing and full source storage
- Keeps default behavior safe and efficient

### Verification
- Tested using FalkorDB Lite on WSL (no Neo4j required)
- Verified that:
  - `INDEX_SOURCE=false` → `f.source = null`
  - `INDEX_SOURCE=true` → full function source stored
- Validated using repository-scoped Cypher queries via CLI

### Notes
- Docstrings remain embedded in `source` (existing behavior)
<img width="1912" height="891" alt="Screenshot 2026-01-14 114607" src="https://github.com/user-attachments/assets/6ab961d5-12a2-4b17-a7a2-84b6e776caf8" />
<img width="1919" height="950" alt="Screenshot 2026-01-14 112923" src="https://github.com/user-attachments/assets/7c9e3676-7ca8-49cb-8577-18294c2fe182" />
