### PR TITLE
Add repo links to pre-index repos

### DIFF
--- a/website/src/components/BundleRegistrySection.tsx
+++ b/website/src/components/BundleRegistrySection.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Search, Download, Package, Calendar, HardDrive, Star, Loader2 } from 'lucide-react';
+import { Search, Download, Package, Calendar, HardDrive, Star, Loader2, ExternalLink } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 interface Bundle {
@@ -239,7 +239,15 @@ const BundleRegistrySection = () => {
                                         <div className="flex-1">
                                             <CardTitle className="text-lg">{bundle.name}</CardTitle>
                                             <CardDescription className="text-sm mt-1">
-                                                {bundle.repo}
+                                                <a
+                                                    href={`https://github.com/${bundle.repo}`}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="inline-flex items-center gap-1 text-muted-foreground hover:text-primary transition-colors underline underline-offset-2"
+                                                >
+                                                    {bundle.repo}
+                                                    <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+                                                </a>
                                             </CardDescription>
                                         </div>
                                         {bundle.category && (


### PR DESCRIPTION
## GitHub links (issue #552 )
In `BundleRegistrySection.tsx`, each project’s repo in Pre-indexed Repositories is now a link to its GitHub repo:
 - The repo text (e.g. `tiangolo/fastapi`) is a text link to "https://github.com/tiangolo/fastapi".
 - A small ExternalLink icon is shown next to the repo text.
 - Styling: text-muted-foreground, hover:text-primary, and underline so it’s clearly clickable.
 
 ## SS - 
 
<img width="1919" height="973" alt="image" src="https://github.com/user-attachments/assets/83333808-e61a-451c-b66e-d4f157032060" />
