### PR TITLE
Add clickable GitHub commit links to bundle cards

### DIFF
--- a/website/src/components/BundleGeneratorSection.tsx
+++ b/website/src/components/BundleGeneratorSection.tsx
@@ -280,7 +280,16 @@ const BundleGeneratorSection = () => {
                                         <strong>Generated:</strong> {new Date(generationStatus.bundle.generated_at).toLocaleDateString()}
                                     </div>
                                     <div>
-                                        <strong>Commit:</strong> {generationStatus.bundle.commit}
+                                      <strong>Commit:</strong>{' '}
+                                      <a
+                                        href={`https://github.com/${generationStatus.repository}/commit/${generationStatus.bundle.commit}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="font-mono text-purple-500 hover:underline inline-flex items-center gap-1"
+                                      >
+                                      {generationStatus.bundle.commit}
+                                      <ExternalLink className="h-3 w-3" />
+                                        </a>
                                     </div>
                                 </div>
                             )}

--- a/website/src/components/BundleRegistrySection.tsx
+++ b/website/src/components/BundleRegistrySection.tsx
@@ -288,9 +288,20 @@ const BundleRegistrySection = () => {
                                         {bundle.version && (
                                             <Badge variant="secondary">v{bundle.version}</Badge>
                                         )}
-                                        <Badge variant="secondary" className="font-mono">
-                                            {bundle.commit}
-                                        </Badge>
+                                        <a href={`https://github.com/${bundle.repo}/commit/${bundle.commit}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="inline-flex items-center gap-1"
+                                        >
+                                       <Badge
+                                       variant="secondary"
+                                       className="font-mono cursor-pointer hover:bg-muted"
+                                        >
+                                       {bundle.commit}
+                                       <ExternalLink className="h-3 w-3 ml-1" />
+                                       </Badge>
+                                       </a>
+
                                     </div>
 
                                     {/* Download Button */}


### PR DESCRIPTION
Fixes #553

Adds a clickable GitHub commit link to each bundle card.
This allows users to directly navigate to the exact commit used
to generate a bundle.

Note: Local development uses mock bundle data, while production
uses real indexed bundles with valid commit hashes.
<img width="1919" height="966" alt="Screenshot 2026-02-06 230913" src="https://github.com/user-attachments/assets/e5fb1336-d991-4832-bbbc-a6256913315f" />
