### PR TITLE
[Feature] Add support for .hh C++ header extension

### DIFF
--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -105,6 +105,7 @@ class GraphBuilder:
             '.cpp': TreeSitterParser('cpp'),
             '.h': TreeSitterParser('cpp'),
             '.hpp': TreeSitterParser('cpp'),
+            '.hh': TreeSitterParser('cpp'),
             '.rs': TreeSitterParser('rust'),
             '.c': TreeSitterParser('c'),
             # '.h': TreeSitterParser('c'), # Need to write an algo for distinguishing C vs C++ headers
@@ -209,6 +210,9 @@ class GraphBuilder:
         if '.hpp' in files_by_lang:
             from .languages import cpp as cpp_lang_module
             imports_map.update(cpp_lang_module.pre_scan_cpp(files_by_lang['.hpp'], self.parsers['.hpp']))
+        if '.hh' in files_by_lang:
+            from .languages import cpp as cpp_lang_module
+            imports_map.update(cpp_lang_module.pre_scan_cpp(files_by_lang['.hh'], self.parsers['.hh']))
         if '.rs' in files_by_lang:
             from .languages import rust as rust_lang_module
             imports_map.update(rust_lang_module.pre_scan_rust(files_by_lang['.rs'], self.parsers['.rs']))


### PR DESCRIPTION
## Summary
This PR adds support for the .hh C++ header file extension as requested in issue #469.

## Changes Made
- Added .hh extension to the parsers dictionary in graph_builder.py
- Added .hh extension handling in the _pre_scan_for_imports method

## Background
The .hh extension is a common C++ header file extension used in many projects, particularly those following modern C++ conventions. While .h and .hpp are already supported, .hh was missing from the supported extensions.

## Technical Details
The .hh extension is now treated the same way as .h and .hpp extensions:
- It uses the TreeSitterParser with 'cpp' language
- Files with .hh extension are included in the pre-scan for imports
- All existing C++ parsing capabilities apply to .hh files

## Testing
The change follows the exact same pattern as existing .h and .hpp extensions, ensuring consistent behavior across all C++ header file types.

Closes #469