### PR TITLE
feat: add Kiro support to cgc mcp setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Use CodeGraphContext as a **powerful command-line toolkit** for code analysis:
 
 #### 🤖 Mode 2: MCP Server (AI-Powered)
 Use CodeGraphContext as an **MCP server** for AI assistants:
-- Connect to AI IDEs (VS Code, Cursor, Windsurf, Claude, etc.)
+- Connect to AI IDEs (VS Code, Cursor, Windsurf, Claude, Kiro, etc.)
 - Let AI agents query your codebase using natural language
 - Automatic code understanding and relationship analysis
 - Perfect for AI-assisted development workflows
@@ -309,6 +309,7 @@ cgc help
     *   Cline
     *   RooCode
     *   Amazon Q Developer
+    *   Kiro
 
     Upon successful configuration, `cgc mcp setup` will generate and place the necessary configuration files:
     *   It creates an `mcp.json` file in your current directory for reference.

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -76,7 +76,7 @@ cgc doctor
 
 ## Step 4: Configure AI Assistant (For MCP Users)
 
-If you plan to use CodeGraphContext with **Cursor**, **Claude**, or **VS Code**, you must configure the MCP server.
+If you plan to use CodeGraphContext with **Cursor**, **Claude**, **VS Code**, or **Kiro**, you must configure the MCP server.
 
 1.  **Run the MCP wizard:**
     ```bash
@@ -84,7 +84,7 @@ If you plan to use CodeGraphContext with **Cursor**, **Claude**, or **VS Code**,
     ```
 
 2.  **What it does:**
-    *   🔍 **Asks you to choose** your IDE from a supported list (Cursor, VS Code, Claude, Windsurf, Cline, etc.).
+    *   🔍 **Asks you to choose** your IDE from a supported list (Cursor, VS Code, Claude, Windsurf, Cline, Kiro, etc.).
     *   ⚙️ **Updates** the configuration file (e.g., `mcp.json`) to invoke `cgc`.
     *   🔐 **Saves** local database credentials so the AI can connect.
 

--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -114,7 +114,7 @@ def _configure_ide(mcp_config):
     questions = [
         {
             "type": "confirm",
-            "message": "Automatically configure your IDE/CLI (VS Code, Cursor, Windsurf, Claude, Gemini, Cline, RooCode, ChatGPT Codex, Amazon Q Developer, Aider)?",
+            "message": "Automatically configure your IDE/CLI (VS Code, Cursor, Windsurf, Claude, Gemini, Cline, RooCode, ChatGPT Codex, Amazon Q Developer, Aider, Kiro)?",
             "name": "configure_ide",
             "default": True,
         }
@@ -128,7 +128,7 @@ def _configure_ide(mcp_config):
         {
             "type": "list",
             "message": "Choose your IDE/CLI to configure:",
-            "choices": ["VS Code", "Cursor", "Windsurf", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "RooCode", "Amazon Q Developer", "JetBrainsAI", "Aider", "None of the above"],
+            "choices": ["VS Code", "Cursor", "Windsurf", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "RooCode", "Amazon Q Developer", "JetBrainsAI", "Aider", "Kiro", "None of the above"],
             "name": "ide_choice",
         }
     ]
@@ -140,7 +140,7 @@ def _configure_ide(mcp_config):
         return
 
 
-    if ide_choice in ["VS Code", "Cursor/CLI", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "Windsurf", "RooCode", "Amazon Q Developer , JetBrainsAI", "Aider"]:
+    if ide_choice in ["VS Code", "Cursor/CLI", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "Windsurf", "RooCode", "Amazon Q Developer , JetBrainsAI", "Aider", "Kiro"]:
         console.print(f"\n[bold cyan]Configuring for {ide_choice}...[/bold cyan]")
 
         if ide_choice == "Amazon Q Developer":
@@ -198,6 +198,11 @@ def _configure_ide(mcp_config):
                 Path.home() / "Library" / "Application Support" / "aider" / "settings.json",
                 Path.home() / "AppData" / "Roaming" / "aider" / "settings.json",
                 Path.home() / ".config" / "Aider" / "User" / "settings.json",
+            ],
+            "Kiro": [
+                Path.home() / ".kiro" / "settings" / "mcp.json",                                   # macOS / Linux / Windows (user-level global)
+                Path.home() / ".config" / "kiro" / "settings" / "mcp.json",                         # Linux (XDG config)
+                Path.home() / "AppData" / "Roaming" / "Kiro" / "settings" / "mcp.json",             # Windows
             ]
         }
 


### PR DESCRIPTION
## Summary
- Adds **Kiro** as a supported IDE/CLI in `cgc mcp setup` wizard
- Adds Kiro config paths for macOS/Linux (`~/.kiro/settings/mcp.json`), Linux XDG, and Windows
- Updates README and installation docs to mention Kiro

Closes #612

## Test plan
- [x] Kiro appears in confirmation prompt, IDE choices list, and if-check
- [x] Config paths for all 3 platforms (macOS/Linux global, Linux XDG, Windows) are defined
- [x] Happy path: selecting Kiro with `~/.kiro/settings/` existing writes valid MCP JSON config
- [x] Fallback: selecting Kiro with no directory shows the manual config message
- [x] All 13 unit/integration tests pass (e2e failure is pre-existing, unrelated to this change)