### PR TITLE
Subtle bug in modules and imports

### DIFF
--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -1691,6 +1691,12 @@ def analyze_dependencies(
         
         if not results.get('importers') and not results.get('imports'):
             console.print(f"[yellow]No dependency information found for '{target}'[/yellow]")
+            exports_found = results.get('exports', [])
+            if exports_found:
+                console.print(f"[dim]Found {len(exports_found)} export(s) but no files import this module.[/dim]")
+                console.print("[dim]Run [bold]cgc index . --force[/bold] to re-index so import and export module names match, then try again.[/dim]")
+            else:
+                console.print("[dim]Tip: For JavaScript, try an export name (e.g. exportedFunction), import alias (e.g. defaultExport), or module path. Run [bold]cgc index . --force[/bold] after code or CGC updates.[/dim]")
             return
         
         # Check if visual mode is enabled

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -626,6 +626,8 @@ class CodeFinder:
     def find_module_dependencies(self, module_name: str) -> Dict[str, Any]:
         """Find all dependencies and dependents of a module, searching by module name, export names, and import aliases (PR #530)."""
         with self.driver.session() as session:
+            # Four strategies below; results are merged and deduplicated in Python.
+            # Future optimization: combine into a single Cypher query with UNION for fewer round trips.
             # Strategy 1: Direct module name match
             importers_by_module = session.run("""
                 MATCH (file:File)-[imp:IMPORTS]->(module:Module {name: $module_name})
@@ -642,23 +644,27 @@ class CodeFinder:
                 LIMIT 50
             """, module_name=module_name)
 
-            # Strategy 2: Search by export name - find modules that export this name
-            importers_by_export = session.run("""
-                MATCH (export:Export {name: $module_name})
-                MATCH (module:Module)-[:EXPORTS]->(export)
-                MATCH (file:File)-[imp:IMPORTS]->(module)
-                OPTIONAL MATCH (repo:Repository)-[:CONTAINS]->(file)
-                RETURN DISTINCT
-                    file.path as importer_file_path,
-                    imp.line_number as import_line_number,
-                    imp.imported_name as imported_name,
-                    imp.alias as import_alias,
-                    file.is_dependency as file_is_dependency,
-                    repo.name as repository_name,
-                    'export_name' as match_type
-                ORDER BY file.is_dependency ASC, file.path
-                LIMIT 50
-            """, module_name=module_name)
+            # Strategy 2: Search by export name. Skip when module_name is "default" because all
+            # default exports have name='default', which would match every default export in the graph.
+            if module_name != "default":
+                importers_by_export = session.run("""
+                    MATCH (export:Export {name: $module_name})
+                    MATCH (module:Module)-[:EXPORTS]->(export)
+                    MATCH (file:File)-[imp:IMPORTS]->(module)
+                    OPTIONAL MATCH (repo:Repository)-[:CONTAINS]->(file)
+                    RETURN DISTINCT
+                        file.path as importer_file_path,
+                        imp.line_number as import_line_number,
+                        imp.imported_name as imported_name,
+                        imp.alias as import_alias,
+                        file.is_dependency as file_is_dependency,
+                        repo.name as repository_name,
+                        'export_name' as match_type
+                    ORDER BY file.is_dependency ASC, file.path
+                    LIMIT 50
+                """, module_name=module_name)
+            else:
+                importers_by_export = iter([])
 
             # Strategy 3: Search by import alias
             importers_by_alias = session.run("""

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -624,25 +624,92 @@ class CodeFinder:
             return result.data()
     
     def find_module_dependencies(self, module_name: str) -> Dict[str, Any]:
-        """Find all dependencies and dependents of a module"""
+        """Find all dependencies and dependents of a module, searching by module name, export names, and import aliases (PR #530)."""
         with self.driver.session() as session:
-            # Find files that import this module (who imports this module)
-            importers_result = session.run("""
+            # Strategy 1: Direct module name match
+            importers_by_module = session.run("""
                 MATCH (file:File)-[imp:IMPORTS]->(module:Module {name: $module_name})
                 OPTIONAL MATCH (repo:Repository)-[:CONTAINS]->(file)
                 RETURN DISTINCT
                     file.path as importer_file_path,
                     imp.line_number as import_line_number,
+                    imp.imported_name as imported_name,
+                    imp.alias as import_alias,
                     file.is_dependency as file_is_dependency,
-                    repo.name as repository_name
+                    repo.name as repository_name,
+                    'direct_module' as match_type
                 ORDER BY file.is_dependency ASC, file.path
                 LIMIT 50
             """, module_name=module_name)
-            
+
+            # Strategy 2: Search by export name - find modules that export this name
+            importers_by_export = session.run("""
+                MATCH (export:Export {name: $module_name})
+                MATCH (module:Module)-[:EXPORTS]->(export)
+                MATCH (file:File)-[imp:IMPORTS]->(module)
+                OPTIONAL MATCH (repo:Repository)-[:CONTAINS]->(file)
+                RETURN DISTINCT
+                    file.path as importer_file_path,
+                    imp.line_number as import_line_number,
+                    imp.imported_name as imported_name,
+                    imp.alias as import_alias,
+                    file.is_dependency as file_is_dependency,
+                    repo.name as repository_name,
+                    'export_name' as match_type
+                ORDER BY file.is_dependency ASC, file.path
+                LIMIT 50
+            """, module_name=module_name)
+
+            # Strategy 3: Search by import alias
+            importers_by_alias = session.run("""
+                MATCH (file:File)-[imp:IMPORTS]->(module:Module)
+                WHERE imp.alias = $module_name
+                OPTIONAL MATCH (repo:Repository)-[:CONTAINS]->(file)
+                RETURN DISTINCT
+                    file.path as importer_file_path,
+                    imp.line_number as import_line_number,
+                    imp.imported_name as imported_name,
+                    imp.alias as import_alias,
+                    file.is_dependency as file_is_dependency,
+                    repo.name as repository_name,
+                    'import_alias' as match_type
+                ORDER BY file.is_dependency ASC, file.path
+                LIMIT 50
+            """, module_name=module_name)
+
+            # Strategy 4: Search by imported_name on IMPORTS relationship
+            importers_by_imported_name = session.run("""
+                MATCH (file:File)-[imp:IMPORTS]->(module:Module)
+                WHERE imp.imported_name = $module_name
+                OPTIONAL MATCH (repo:Repository)-[:CONTAINS]->(file)
+                RETURN DISTINCT
+                    file.path as importer_file_path,
+                    imp.line_number as import_line_number,
+                    imp.imported_name as imported_name,
+                    imp.alias as import_alias,
+                    file.is_dependency as file_is_dependency,
+                    repo.name as repository_name,
+                    'imported_name' as match_type
+                ORDER BY file.is_dependency ASC, file.path
+                LIMIT 50
+            """, module_name=module_name)
+
+            # Combine results from all strategies, deduplicate by (path, line_number)
+            all_importers = []
+            seen_paths = set()
+            for result_set in [importers_by_module, importers_by_export, importers_by_alias, importers_by_imported_name]:
+                for record in result_set:
+                    record_dict = dict(record)
+                    key = (record_dict.get('importer_file_path'), record_dict.get('import_line_number'))
+                    if key not in seen_paths:
+                        seen_paths.add(key)
+                        all_importers.append(record_dict)
+
             # Find modules that are imported by files that also import the target module
-            # This helps understand what this module is typically used with
             imports_result = session.run("""
-                MATCH (file:File)-[:IMPORTS]->(target_module:Module {name: $module_name})
+                MATCH (file:File)-[:IMPORTS]->(target_module:Module)
+                WHERE target_module.name = $module_name
+                   OR (target_module)-[:EXPORTS]->(:Export {name: $module_name})
                 MATCH (file)-[imp:IMPORTS]->(other_module:Module)
                 WHERE other_module <> target_module
                 RETURN DISTINCT
@@ -651,11 +718,28 @@ class CodeFinder:
                 ORDER BY other_module.name
                 LIMIT 50
             """, module_name=module_name)
-            
+
+            # Find exports from modules matching the search term
+            exports_result = session.run("""
+                MATCH (export:Export)
+                WHERE export.name = $module_name OR export.original_name = $module_name
+                OPTIONAL MATCH (module:Module)-[:EXPORTS]->(export)
+                RETURN DISTINCT
+                    export.name as export_name,
+                    export.original_name as original_name,
+                    export.is_default as is_default,
+                    export.file_path as file_path,
+                    export.line_number as line_number,
+                    module.name as module_name
+                ORDER BY export.file_path, export.line_number
+                LIMIT 20
+            """, module_name=module_name)
+
             return {
                 "module_name": module_name,
-                "importers": [dict(record) for record in importers_result],
-                "imports": [dict(record) for record in imports_result]
+                "importers": all_importers,
+                "imports": [dict(record) for record in imports_result],
+                "exports": [dict(record) for record in exports_result],
             }
     
     def find_variable_usage_scope(self, variable_name: str, path: str = None) -> Dict[str, Any]:
@@ -828,7 +912,7 @@ class CodeFinder:
                 results = self.find_module_dependencies(target)
                 return {
                     "query_type": "module_dependencies", "target": target, "results": results,
-                    "summary": f"Module '{target}' is imported by {len(results['imported_by_files'])} files"
+                    "summary": f"Module '{target}' is imported by {len(results.get('importers', []))} files"
                 }
             
             elif query_type in ["variable_scope", "var_scope", "variable_usage_scope"]:

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -138,6 +138,7 @@ class GraphBuilder:
                 session.run("CREATE CONSTRAINT macro_unique IF NOT EXISTS FOR (m:Macro) REQUIRE (m.name, m.path, m.line_number) IS UNIQUE")
                 session.run("CREATE CONSTRAINT variable_unique IF NOT EXISTS FOR (v:Variable) REQUIRE (v.name, v.path, v.line_number) IS UNIQUE")
                 session.run("CREATE CONSTRAINT module_name IF NOT EXISTS FOR (m:Module) REQUIRE m.name IS UNIQUE")
+                session.run("CREATE CONSTRAINT export_unique IF NOT EXISTS FOR (e:Export) REQUIRE (e.name, e.module_name, e.file_path) IS UNIQUE")
                 session.run("CREATE CONSTRAINT struct_cpp IF NOT EXISTS FOR (cstruct: Struct) REQUIRE (cstruct.name, cstruct.path, cstruct.line_number) IS UNIQUE")
                 session.run("CREATE CONSTRAINT enum_cpp IF NOT EXISTS FOR (cenum: Enum) REQUIRE (cenum.name, cenum.path, cenum.line_number) IS UNIQUE")
                 session.run("CREATE CONSTRAINT union_cpp IF NOT EXISTS FOR (cunion: Union) REQUIRE (cunion.name, cunion.path, cunion.line_number) IS UNIQUE")
@@ -257,7 +258,6 @@ class GraphBuilder:
 
     # First pass to add file and its contents
     def add_file_to_graph(self, file_data: Dict, repo_name: str, imports_map: dict):
-        info_logger("Executing add_file_to_graph with my change!")
         """Adds a file and its contents within a single, unified session."""
         file_path_str = str(Path(file_data['path']).resolve())
         file_name = Path(file_path_str).name
@@ -369,20 +369,27 @@ class GraphBuilder:
 
             # Handle imports and create IMPORTS relationships
             for imp in file_data.get('imports', []):
-                info_logger(f"Processing import: {imp}")
                 lang = file_data.get('lang')
                 if lang == 'javascript':
-                    # New, correct logic for JS
-                    module_name = imp.get('source')
-                    if not module_name: continue
-
-                    # Use a map for relationship properties to handle optional alias and line_number
+                    raw_source = imp.get('source')
+                    if not raw_source:
+                        continue
+                    # Unify Module name with export: use repo-relative path so
+                    # "who imports this module" finds the same Module as export name search.
+                    if raw_source.startswith('.'):
+                        try:
+                            resolved = (file_path_obj.parent / raw_source).resolve()
+                            rel = resolved.relative_to(repo_path_obj)
+                            module_name = './' + str(rel).replace('\\', '/')
+                        except (ValueError, OSError):
+                            module_name = raw_source
+                    else:
+                        module_name = raw_source
                     rel_props = {'imported_name': imp.get('name', '*')}
                     if imp.get('alias'):
                         rel_props['alias'] = imp.get('alias')
                     if imp.get('line_number'):
                         rel_props['line_number'] = imp.get('line_number')
-
                     session.run("""
                         MATCH (f:File {path: $path})
                         MERGE (m:Module {name: $module_name})
@@ -411,6 +418,38 @@ class GraphBuilder:
                         SET r += $rel_props
                     """, path=file_path_str, rel_props=rel_props, **imp)
 
+            # Handle exports for JavaScript modules (PR #530 / issue #495)
+            exports_list = file_data.get('exports', [])
+            lang = file_data.get('lang')
+            for export in exports_list:
+                if lang == 'javascript':
+                    try:
+                        file_obj = Path(file_path_str)
+                        repo_path = repo_result['path'] if repo_result else str(repo_path_obj)
+                        repo_obj = Path(repo_path)
+                        rel_path = file_obj.relative_to(repo_obj)
+                        module_name = './' + str(rel_path).replace('\\', '/')
+                    except (ValueError, KeyError, TypeError):
+                        module_name = './' + Path(file_path_str).name
+                    session.run("""
+                        MATCH (f:File {path: $file_path})
+                        MERGE (m:Module {name: $module_name})
+                        MERGE (e:Export {name: $export_name, module_name: $module_name, file_path: $file_path})
+                        SET e.original_name = $original_name,
+                            e.is_default = $is_default,
+                            e.line_number = $line_number,
+                            e.lang = $lang
+                        MERGE (m)-[:EXPORTS]->(e)
+                        MERGE (f)-[:CONTAINS]->(e)
+                    """,
+                        file_path=file_path_str,
+                        module_name=module_name,
+                        export_name=export.get('name'),
+                        original_name=export.get('original_name') or export.get('name'),
+                        is_default=export.get('is_default', False),
+                        line_number=export.get('line_number'),
+                        lang=export.get('lang'),
+                    )
 
             # Handle CONTAINS relationship between class to their children like variables
             for func in file_data.get('functions', []):

--- a/src/codegraphcontext/tools/languages/javascript.py
+++ b/src/codegraphcontext/tools/languages/javascript.py
@@ -96,6 +96,9 @@ JS_QUERIES = {
             function: (identifier) @require_call (#eq? @require_call "require")
         ) @import
     """,
+    "exports": """
+        (export_statement) @export
+    """,
     "calls": """
         (call_expression function: (identifier) @name)
         (call_expression function: (member_expression property: (property_identifier) @name))
@@ -178,6 +181,7 @@ class JavascriptTreeSitterParser:
         functions = self._find_functions(root_node)
         classes = self._find_classes(root_node)
         imports = self._find_imports(root_node)
+        exports = self._find_exports(root_node)
         function_calls = self._find_calls(root_node)
         variables = self._find_variables(root_node)
 
@@ -187,6 +191,7 @@ class JavascriptTreeSitterParser:
             "classes": classes,
             "variables": variables,
             "imports": imports,
+            "exports": exports,
             "function_calls": function_calls,
             "is_dependency": is_dependency,
             "lang": self.language_name,
@@ -459,6 +464,130 @@ class JavascriptTreeSitterParser:
 
         return imports
 
+    def _find_exports(self, root_node):
+        """Extract export statements from JavaScript code (PR #530 / issue #495)."""
+        exports = []
+        query_str = JS_QUERIES['exports']
+        for node, capture_name in execute_query(self.language, query_str, root_node):
+            if capture_name != 'export':
+                continue
+            line_number = node.start_point[0] + 1
+            # Check if this is a default export (keyword 'default' in children)
+            has_default = any(
+                c.type == 'identifier' and self._get_node_text(c) == 'default'
+                for c in node.children
+            )
+            if not has_default:
+                has_default = any(
+                    getattr(c, 'type', None) == 'default' for c in node.children
+                )
+
+            for child in node.children:
+                is_default_keyword = (
+                    (child.type == 'identifier' and self._get_node_text(child) == 'default')
+                    or child.type == 'default'
+                )
+                if is_default_keyword:
+                    default_export_node = None
+                    for sibling in node.children:
+                        if sibling.type in (
+                            'function_declaration', 'class_declaration', 'identifier',
+                            'arrow_function', 'function_expression', 'lexical_declaration',
+                        ):
+                            if sibling != child:
+                                default_export_node = sibling
+                                break
+                    export_name = 'default'
+                    original_name = None
+                    if default_export_node:
+                        if default_export_node.type == 'function_declaration':
+                            name_node = default_export_node.child_by_field_name('name')
+                            original_name = self._get_node_text(name_node) if name_node else 'default'
+                        elif default_export_node.type == 'class_declaration':
+                            name_node = default_export_node.child_by_field_name('name')
+                            original_name = self._get_node_text(name_node) if name_node else 'default'
+                        elif default_export_node.type == 'identifier':
+                            original_name = self._get_node_text(default_export_node)
+                        elif default_export_node.type == 'lexical_declaration':
+                            for dec in default_export_node.children:
+                                if dec.type == 'variable_declarator':
+                                    name_node = dec.child_by_field_name('name')
+                                    if name_node:
+                                        original_name = self._get_node_text(name_node)
+                                        break
+                                    break
+                    exports.append({
+                        'name': export_name,
+                        'original_name': original_name or 'default',
+                        'is_default': True,
+                        'line_number': line_number,
+                        'lang': self.language_name,
+                    })
+                    break
+                elif child.type == 'function_declaration' and not has_default:
+                    name_node = child.child_by_field_name('name')
+                    if name_node:
+                        export_name = self._get_node_text(name_node)
+                        exports.append({
+                            'name': export_name,
+                            'original_name': export_name,
+                            'is_default': False,
+                            'line_number': line_number,
+                            'lang': self.language_name,
+                        })
+                elif child.type == 'class_declaration' and not has_default:
+                    name_node = child.child_by_field_name('name')
+                    if name_node:
+                        export_name = self._get_node_text(name_node)
+                        exports.append({
+                            'name': export_name,
+                            'original_name': export_name,
+                            'is_default': False,
+                            'line_number': line_number,
+                            'lang': self.language_name,
+                        })
+                elif child.type == 'lexical_declaration' and not has_default:
+                    for declarator in child.children:
+                        if declarator.type == 'variable_declarator':
+                            name_node = declarator.child_by_field_name('name')
+                            if name_node and name_node.type == 'identifier':
+                                export_name = self._get_node_text(name_node)
+                                exports.append({
+                                    'name': export_name,
+                                    'original_name': export_name,
+                                    'is_default': False,
+                                    'line_number': line_number,
+                                    'lang': self.language_name,
+                                })
+                elif child.type == 'variable_declaration' and not has_default:
+                    for declarator in child.children:
+                        if declarator.type == 'variable_declarator':
+                            name_node = declarator.child_by_field_name('name')
+                            if name_node and name_node.type == 'identifier':
+                                export_name = self._get_node_text(name_node)
+                                exports.append({
+                                    'name': export_name,
+                                    'original_name': export_name,
+                                    'is_default': False,
+                                    'line_number': line_number,
+                                    'lang': self.language_name,
+                                })
+                elif child.type == 'export_clause':
+                    for specifier in child.children:
+                        if specifier.type == 'export_specifier':
+                            name_node = specifier.child_by_field_name('name')
+                            alias_node = specifier.child_by_field_name('alias')
+                            if name_node:
+                                original_name = self._get_node_text(name_node).strip('"\'')
+                                export_name = self._get_node_text(alias_node).strip('"\'') if alias_node else original_name
+                                exports.append({
+                                    'name': export_name,
+                                    'original_name': original_name,
+                                    'is_default': False,
+                                    'line_number': line_number,
+                                    'lang': self.language_name,
+                                })
+        return exports
 
     def _find_calls(self, root_node):
         calls = []

--- a/src/codegraphcontext/tools/languages/javascript.py
+++ b/src/codegraphcontext/tools/languages/javascript.py
@@ -514,7 +514,6 @@ class JavascriptTreeSitterParser:
                                     name_node = dec.child_by_field_name('name')
                                     if name_node:
                                         original_name = self._get_node_text(name_node)
-                                        break
                                     break
                     exports.append({
                         'name': export_name,
@@ -546,20 +545,7 @@ class JavascriptTreeSitterParser:
                             'line_number': line_number,
                             'lang': self.language_name,
                         })
-                elif child.type == 'lexical_declaration' and not has_default:
-                    for declarator in child.children:
-                        if declarator.type == 'variable_declarator':
-                            name_node = declarator.child_by_field_name('name')
-                            if name_node and name_node.type == 'identifier':
-                                export_name = self._get_node_text(name_node)
-                                exports.append({
-                                    'name': export_name,
-                                    'original_name': export_name,
-                                    'is_default': False,
-                                    'line_number': line_number,
-                                    'lang': self.language_name,
-                                })
-                elif child.type == 'variable_declaration' and not has_default:
+                elif child.type in ('lexical_declaration', 'variable_declaration') and not has_default:
                     for declarator in child.children:
                         if declarator.type == 'variable_declarator':
                             name_node = declarator.child_by_field_name('name')

--- a/tests/integration/test_export_graph.py
+++ b/tests/integration/test_export_graph.py
@@ -1,0 +1,61 @@
+"""
+Integration tests for JavaScript export handling: parser output -> graph_builder contract.
+
+Verifies that the export structure produced by the JavaScript parser matches what
+graph_builder.add_file_to_graph() expects when creating Export nodes and Module-EXPORTS
+relationships. Full flow (storage in Neo4j/FalkorDB) is covered by e2e when a DB is available.
+"""
+
+import pytest
+from pathlib import Path
+
+from codegraphcontext.tools.languages.javascript import JavascriptTreeSitterParser
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+@pytest.fixture(scope="module")
+def js_parser():
+    from unittest.mock import MagicMock
+    manager = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "javascript"
+    wrapper.language = manager.get_language_safe("javascript")
+    wrapper.parser = manager.create_parser("javascript")
+    return JavascriptTreeSitterParser(wrapper)
+
+
+@pytest.fixture(scope="module")
+def javascript_sample_project():
+    path = Path(__file__).parent.parent / "fixtures" / "sample_projects" / "sample_project_javascript"
+    if not path.exists():
+        pytest.skip("JavaScript sample project not found")
+    return path
+
+
+def test_export_shape_matches_graph_builder_contract(js_parser, javascript_sample_project):
+    """
+    Parser exports must include name, original_name, is_default, line_number, lang
+    so graph_builder can create Export nodes and EXPORTS relationships correctly.
+    """
+    path = javascript_sample_project / "exporter.js"
+    if not path.exists():
+        pytest.skip("exporter.js not found")
+    result = js_parser.parse(path)
+    exports = result.get("exports", [])
+    assert len(exports) > 0
+    for e in exports:
+        assert "name" in e, "graph_builder expects export_name"
+        assert "original_name" in e, "graph_builder expects original_name"
+        assert "is_default" in e, "graph_builder expects is_default"
+        assert "line_number" in e, "graph_builder expects line_number"
+        assert "lang" in e, "graph_builder expects lang"
+        assert e["lang"] == "javascript"
+
+
+def test_graph_builder_export_keys_contract():
+    """
+    Document the contract: graph_builder expects each export to have
+    name, original_name, is_default, line_number, lang (module_name is computed from file path).
+    """
+    expected = {"name", "original_name", "is_default", "line_number", "lang"}
+    assert expected == {"name", "original_name", "is_default", "line_number", "lang"}

--- a/tests/unit/parsers/test_javascript_parser.py
+++ b/tests/unit/parsers/test_javascript_parser.py
@@ -1,0 +1,68 @@
+"""Unit tests for JavaScript parser: exports and parse() structure."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+from codegraphcontext.tools.languages.javascript import JavascriptTreeSitterParser
+
+
+@pytest.fixture(scope="class")
+def parser():
+    manager = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "javascript"
+    wrapper.language = manager.get_language_safe("javascript")
+    wrapper.parser = manager.create_parser("javascript")
+    return JavascriptTreeSitterParser(wrapper)
+
+
+def test_parse_returns_exports_key(parser, javascript_sample_project):
+    """Parse exporter.js and assert 'exports' key is present with entries."""
+    path = javascript_sample_project / "exporter.js"
+    if not path.exists():
+        pytest.skip("exporter.js fixture not found")
+    result = parser.parse(path)
+    assert "exports" in result
+    assert isinstance(result["exports"], list)
+
+
+def test_find_exports_named_and_default(parser, javascript_sample_project):
+    """Exporter.js has named exports and a default export; all should be found (PR #530 shape)."""
+    path = javascript_sample_project / "exporter.js"
+    if not path.exists():
+        pytest.skip("exporter.js fixture not found")
+    result = parser.parse(path)
+    exports = result["exports"]
+    names = {e["name"] for e in exports}
+    # Named: exportedFunction, ExportedClass, exportedVariable
+    assert "exportedFunction" in names
+    assert "ExportedClass" in names
+    assert "exportedVariable" in names
+    # Default export: stored as name 'default' with optional original_name
+    assert "default" in names
+
+
+def test_find_exports_original_name_and_is_default(parser, javascript_sample_project):
+    """Exports should have original_name and is_default (PR #530)."""
+    path = javascript_sample_project / "exporter.js"
+    if not path.exists():
+        pytest.skip("exporter.js fixture not found")
+    result = parser.parse(path)
+    for e in result["exports"]:
+        assert "line_number" in e
+        assert e.get("lang") == "javascript"
+        assert "original_name" in e
+        assert "is_default" in e
+
+
+def test_parse_importer_imports(parser, javascript_sample_project):
+    """Importer.js imports from ./exporter.js; imports list should reflect that."""
+    path = javascript_sample_project / "importer.js"
+    if not path.exists():
+        pytest.skip("importer.js fixture not found")
+    result = parser.parse(path)
+    assert "imports" in result
+    imports = result["imports"]
+    sources = [i["source"] for i in imports]
+    assert "./exporter.js" in sources


### PR DESCRIPTION
## Summary

Fixes #495 - `cgc analyze deps` now supports finding JavaScript module dependencies by export names, not just module paths.

## Problem

Previously, `cgc analyze deps` could only find dependencies by exact module path (e.g., `./exporter.js`). It failed when searching by:
- Export names (e.g., `exportedFunction`, `ExportedClass`)
- Import aliases (e.g., `defaultExport`)
- Default exports

This happened because:
1. JavaScript exports were parsed but not stored in the graph database
2. The search logic only looked for Module nodes by name

## Solution

### Phase 1: Track Exports

**File: `src/codegraphcontext/tools/languages/javascript.py`**
- Added `_find_exports()` method to parse export statements
- Handles: `export default`, `export function/class`, `export const/let/var`, `export { name1, name2 }`
- Updated `parse()` to include exports in returned dictionary

**File: `src/codegraphcontext/tools/graph_builder.py`**
- Added Export node schema constraint in `create_schema()`
- Modified `add_file_to_graph()` to create Export nodes for JavaScript files
- Links Export nodes to Module nodes via EXPORTS relationship
- Uses relative paths for module names to match import references

### Phase 2: Enhanced Search

**File: `src/codegraphcontext/tools/code_finder.py`**
- Refactored `find_module_dependencies()` with 4 search strategies:
  1. Direct module name match (existing)
  2. Export name → Module via Export nodes (new)
  3. Import alias matching (new)
  4. Imported name matching (new)
- Combines and deduplicates results from all strategies
- Added export information to query results

## Testing

Tested with `tests/sample_project_javascript`

## Screenshots

<img width="983" height="200" alt="Screenshot 2026-01-18 230240" src="https://github.com/user-attachments/assets/c264a09a-cbcc-4bd2-8411-6d4325e4bd53" />
<img width="964" height="120" alt="Screenshot 2026-01-18 230252" src="https://github.com/user-attachments/assets/9a3c2019-a33e-40c3-8621-b778d7f75c90" />
<img width="1004" height="346" alt="image" src="https://github.com/user-attachments/assets/a22e7bde-c23a-4cd6-b82a-de300d0ef200" />
