### PR TITLE
Fix Swift symbol indexing queries for current grammar

### DIFF
--- a/src/codegraphcontext/tools/languages/swift.py
+++ b/src/codegraphcontext/tools/languages/swift.py
@@ -9,27 +9,32 @@ SWIFT_QUERIES = {
         [
             (function_declaration
                 name: (simple_identifier) @name
-                parameters: (parameter)* @params
             ) @function_node
-            (init_declaration
-                parameters: (parameter)* @params
-            ) @init_node
+            (init_declaration) @init_node
         ]
     """,
     "classes": """
         [
             (class_declaration
+                declaration_kind: "class"
                 name: (type_identifier) @name
             ) @class
-            (struct_declaration
+            (class_declaration
+                declaration_kind: "struct"
                 name: (type_identifier) @name
             ) @struct
-            (enum_declaration
+            (class_declaration
+                declaration_kind: "enum"
                 name: (type_identifier) @name
             ) @enum
-            (protocol_declaration
+            (class_declaration
+                declaration_kind: "protocol"
                 name: (type_identifier) @name
             ) @protocol
+            (class_declaration
+                declaration_kind: "actor"
+                name: (type_identifier) @name
+            ) @class
         ]
     """,
     "imports": """
@@ -41,13 +46,13 @@ SWIFT_QUERIES = {
     "variables": """
         [
             (property_declaration
-                (pattern) @pattern
-            ) @variable
-            (constant_declaration
-                (pattern_binding
-                    pattern: (simple_identifier) @name
+                name: (pattern
+                    bound_identifier: (simple_identifier) @name
                 )
-            ) @constant
+            ) @variable
+            (property_declaration
+                name: (pattern) @pattern
+            ) @variable
         ]
     """,
 }

--- a/tests/unit/parsers/test_swift_parser.py
+++ b/tests/unit/parsers/test_swift_parser.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.tools.languages.swift import SwiftTreeSitterParser
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+@pytest.fixture(scope="module")
+def swift_parser():
+    manager = get_tree_sitter_manager()
+    if not manager.is_language_available("swift"):
+        pytest.skip("Swift tree-sitter grammar is not available in this environment")
+
+    wrapper = MagicMock()
+    wrapper.language_name = "swift"
+    wrapper.language = manager.get_language_safe("swift")
+    wrapper.parser = manager.create_parser("swift")
+    return SwiftTreeSitterParser(wrapper)
+
+
+def test_parse_swift_declarations_with_current_grammar(swift_parser, temp_test_dir):
+    code = """
+import Foundation
+
+struct MetricTracker {
+    let sampleCount: Int
+    func record(value: Int) {
+        print(value)
+    }
+}
+
+enum ProcessingState {
+    case idle
+    case running
+}
+
+actor TaskWorker {
+    func compute() {}
+}
+
+class GenericController {
+    let name: String
+
+    init(name: String) {
+        self.name = name
+    }
+
+    func track() {
+        print(name)
+    }
+}
+"""
+    f = temp_test_dir / "sample.swift"
+    f.write_text(code)
+
+    result = swift_parser.parse(f)
+
+    assert len(result["functions"]) >= 4
+    assert any(item["name"] == "MetricTracker" for item in result["structs"])
+    assert any(item["name"] == "ProcessingState" for item in result["enums"])
+    assert any(item["name"] == "TaskWorker" for item in result["classes"])
+    assert any(item["name"] == "GenericController" for item in result["classes"])
+    assert len(result["imports"]) == 1
+    assert any(item["name"] == "sampleCount" for item in result["variables"])


### PR DESCRIPTION
## Summary
This PR is now **Swift-only** and addresses issue #636.

## What changed
- Updated Swift tree-sitter queries in `src/codegraphcontext/tools/languages/swift.py` to match the current grammar:
  - removed invalid `parameters` constraints from function/init patterns
  - aligned type declarations to `class_declaration` + `declaration_kind` captures (`class`, `struct`, `enum`, `protocol`, `actor`)
  - replaced invalid variable query patterns with `property_declaration` captures
- Added regression test in `tests/unit/parsers/test_swift_parser.py`.

## Explicitly removed from this PR
- FalkorDB/fulltext fallback changes in `code_finder.py`
- `tests/unit/tools/test_code_finder.py`

## Validation
- `PYTHONPATH=src uv run pytest tests/unit/parsers/test_swift_parser.py -q`

Closes #636
