### PR TITLE
feat: Add remote/hosted FalkorDB support over TCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,15 @@ PYTHONDONTWRITEBYTECODE=1
 # Optional: Custom workspace path
 # WORKSPACE_PATH=/workspace
 
+# Remote FalkorDB Configuration (if using a hosted/remote FalkorDB instance)
+# Set DATABASE_TYPE=falkordb-remote to use these, or just set FALKORDB_HOST
+# and it will be auto-detected.
+# FALKORDB_HOST=your-falkordb-host.example.com
+# FALKORDB_PORT=6379
+# FALKORDB_PASSWORD=your_password_here
+# FALKORDB_USERNAME=default
+# FALKORDB_SSL=true
+# FALKORDB_GRAPH_NAME=codegraph
+
 # Optional: Database selection
-# DATABASE_TYPE=falkordb  # or neo4j
+# DATABASE_TYPE=falkordb  # or falkordb-remote or neo4j

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,15 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV CGC_HOME=/root/.codegraphcontext
 
+# Remote FalkorDB connection (set at runtime via docker run -e or docker-compose)
+# ENV DATABASE_TYPE=falkordb-remote
+# ENV FALKORDB_HOST=
+# ENV FALKORDB_PORT=6379
+# ENV FALKORDB_PASSWORD=
+# ENV FALKORDB_USERNAME=
+# ENV FALKORDB_SSL=false
+# ENV FALKORDB_GRAPH_NAME=codegraph
+
 # Expose port for potential web interface (future use)
 EXPOSE 8080
 

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -14,6 +14,14 @@ services:
       - cgc-data:/root/.codegraphcontext
     environment:
       - PYTHONUNBUFFERED=1
+      # Uncomment and set these to use a remote FalkorDB instance:
+      # - DATABASE_TYPE=falkordb-remote
+      # - FALKORDB_HOST=your-falkordb-host.example.com
+      # - FALKORDB_PORT=6379
+      # - FALKORDB_PASSWORD=your_password
+      # - FALKORDB_USERNAME=default
+      # - FALKORDB_SSL=true
+      # - FALKORDB_GRAPH_NAME=codegraph
     stdin_open: true
     tty: true
     command: bash

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -291,8 +291,17 @@ def _load_credentials():
             console.print("[cyan]Using database: Neo4j[/cyan]")
         else:
             console.print("[yellow]⚠ DEFAULT_DATABASE=neo4j but credentials not found. Falling back to FalkorDB.[/yellow]")
+    elif default_db == "falkordb-remote":
+        host = os.environ.get("FALKORDB_HOST")
+        if host:
+            console.print(f"[cyan]Using database: FalkorDB Remote ({host})[/cyan]")
+        else:
+            console.print("[yellow]⚠ DATABASE_TYPE=falkordb-remote but FALKORDB_HOST not set.[/yellow]")
     else:
-        console.print("[cyan]Using database: FalkorDB[/cyan]")
+        if os.environ.get("FALKORDB_HOST"):
+            console.print(f"[cyan]Using database: FalkorDB Remote ({os.environ.get('FALKORDB_HOST')})[/cyan]")
+        else:
+            console.print("[cyan]Using database: FalkorDB[/cyan]")
 
 # ============================================================================
 # CONFIG COMMAND GROUP
@@ -352,9 +361,9 @@ def config_db(backend: str = typer.Argument(..., help="Database backend: 'neo4j'
         cgc config db falkordb
     """
     backend = backend.lower()
-    if backend not in ['falkordb', 'neo4j']:
+    if backend not in ['falkordb', 'falkordb-remote', 'neo4j']:
         console.print(f"[bold red]Invalid backend: {backend}[/bold red]")
-        console.print("Must be 'falkordb' or 'neo4j'")
+        console.print("Must be 'falkordb', 'falkordb-remote', or 'neo4j'")
         raise typer.Exit(code=1)
     
     config_manager.set_config_value("DEFAULT_DATABASE", backend)

--- a/src/codegraphcontext/core/database_falkordb_remote.py
+++ b/src/codegraphcontext/core/database_falkordb_remote.py
@@ -1,0 +1,197 @@
+# src/codegraphcontext/core/database_falkordb_remote.py
+"""
+This module provides a thread-safe singleton manager for connecting to a
+remote/hosted FalkorDB instance over TCP.
+
+Unlike database_falkordb.py (which uses an embedded FalkorDB Lite via Unix sockets
+and subprocesses), this module connects to an external FalkorDB server using
+standard TCP connections. This is suitable for hosted FalkorDB instances
+(e.g., FalkorDB Cloud) or self-hosted remote servers.
+
+Configuration is read from environment variables:
+- FALKORDB_HOST: Hostname of the FalkorDB server (required)
+- FALKORDB_PORT: Port number (default: 6379)
+- FALKORDB_PASSWORD: Authentication password (optional)
+- FALKORDB_USERNAME: Authentication username (optional, default: None)
+- FALKORDB_SSL: Enable SSL/TLS (default: false)
+- FALKORDB_GRAPH_NAME: Graph name to use (default: codegraph)
+"""
+import os
+import atexit
+import threading
+from typing import Optional, Tuple
+
+from codegraphcontext.utils.debug_log import info_logger, error_logger
+
+# Reuse the Neo4j-compatible wrapper classes from the embedded FalkorDB module
+from codegraphcontext.core.database_falkordb import (
+    FalkorDBDriverWrapper,
+    FalkorDBSessionWrapper,
+    FalkorDBResultWrapper,
+)
+
+
+class FalkorDBRemoteManager:
+    """
+    Manages a remote FalkorDB database connection as a singleton.
+    Connects via TCP — no subprocess, no Unix socket.
+    """
+    _instance = None
+    _driver = None
+    _graph = None
+    _lock = threading.Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super(FalkorDBRemoteManager, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if hasattr(self, '_initialized'):
+            return
+
+        self.host = os.getenv('FALKORDB_HOST', 'localhost')
+        self.port = int(os.getenv('FALKORDB_PORT', '6379'))
+        self.password = os.getenv('FALKORDB_PASSWORD') or None
+        self.username = os.getenv('FALKORDB_USERNAME') or None
+        self.ssl = os.getenv('FALKORDB_SSL', 'false').lower() in ('true', '1', 'yes')
+        self.graph_name = os.getenv('FALKORDB_GRAPH_NAME', 'codegraph')
+        self._initialized = True
+
+        atexit.register(self.shutdown)
+
+    def get_driver(self):
+        """
+        Gets the remote FalkorDB connection, creating it if necessary.
+        Thread-safe.
+
+        Returns:
+            A FalkorDBDriverWrapper that provides a Neo4j-like session interface.
+        """
+        if self._driver is None:
+            with self._lock:
+                if self._driver is None:
+                    try:
+                        from falkordb import FalkorDB
+
+                        info_logger(
+                            f"Connecting to remote FalkorDB at {self.host}:{self.port} "
+                            f"(ssl={self.ssl})"
+                        )
+
+                        kwargs = {
+                            'host': self.host,
+                            'port': self.port,
+                        }
+                        if self.password:
+                            kwargs['password'] = self.password
+                        if self.username:
+                            kwargs['username'] = self.username
+                        if self.ssl:
+                            kwargs['ssl'] = True
+
+                        self._driver = FalkorDB(**kwargs)
+                        self._graph = self._driver.select_graph(self.graph_name)
+
+                        # Verify connectivity
+                        self._graph.query("RETURN 1")
+                        info_logger("Remote FalkorDB connection established successfully")
+                        info_logger(f"Graph name: {self.graph_name}")
+
+                    except ImportError as e:
+                        error_logger(
+                            "FalkorDB client is not installed. Install it with:\n"
+                            "  pip install falkordb"
+                        )
+                        raise ValueError("FalkorDB client missing.") from e
+                    except Exception as e:
+                        error_logger(f"Failed to connect to remote FalkorDB: {e}")
+                        raise
+
+        return FalkorDBDriverWrapper(self._graph)
+
+    def close_driver(self):
+        """Closes the connection."""
+        self._driver = None
+        self._graph = None
+
+    def shutdown(self):
+        """Clean up on exit. No subprocess to kill for remote connections."""
+        self.close_driver()
+
+    def is_connected(self) -> bool:
+        """Checks if the database connection is currently active."""
+        if self._graph is None:
+            return False
+        try:
+            self._graph.query("RETURN 1")
+            return True
+        except Exception:
+            return False
+
+    def get_backend_type(self) -> str:
+        """Returns the database backend type."""
+        return 'falkordb-remote'
+
+    @staticmethod
+    def validate_config() -> Tuple[bool, Optional[str]]:
+        """
+        Validates remote FalkorDB configuration.
+
+        Returns:
+            Tuple[bool, Optional[str]]: (is_valid, error_message)
+        """
+        host = os.getenv('FALKORDB_HOST')
+        if not host:
+            return False, "FALKORDB_HOST environment variable is not set."
+
+        port_str = os.getenv('FALKORDB_PORT', '6379')
+        try:
+            port = int(port_str)
+            if not (1 <= port <= 65535):
+                return False, f"FALKORDB_PORT must be between 1 and 65535, got {port}."
+        except ValueError:
+            return False, f"FALKORDB_PORT must be a number, got '{port_str}'."
+
+        return True, None
+
+    @staticmethod
+    def test_connection() -> Tuple[bool, Optional[str]]:
+        """
+        Tests the remote FalkorDB connection.
+        """
+        try:
+            from falkordb import FalkorDB
+        except ImportError:
+            return False, (
+                "FalkorDB client is not installed.\n"
+                "Install it with: pip install falkordb"
+            )
+
+        host = os.getenv('FALKORDB_HOST')
+        if not host:
+            return False, "FALKORDB_HOST is not set."
+
+        port = int(os.getenv('FALKORDB_PORT', '6379'))
+        password = os.getenv('FALKORDB_PASSWORD') or None
+        username = os.getenv('FALKORDB_USERNAME') or None
+        ssl = os.getenv('FALKORDB_SSL', 'false').lower() in ('true', '1', 'yes')
+        graph_name = os.getenv('FALKORDB_GRAPH_NAME', 'codegraph')
+
+        try:
+            kwargs = {'host': host, 'port': port}
+            if password:
+                kwargs['password'] = password
+            if username:
+                kwargs['username'] = username
+            if ssl:
+                kwargs['ssl'] = True
+
+            db = FalkorDB(**kwargs)
+            graph = db.select_graph(graph_name)
+            graph.query("RETURN 1")
+            return True, None
+        except Exception as e:
+            return False, f"Connection failed: {e}"

--- a/tests/unit/core/test_database_falkordb_remote.py
+++ b/tests/unit/core/test_database_falkordb_remote.py
@@ -1,0 +1,378 @@
+
+import os
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+
+class TestFalkorDBRemoteManager:
+    """
+    Unit tests for the FalkorDBRemoteManager class.
+    Mocks the FalkorDB client to test logic without a real remote DB.
+    """
+
+    def _reset_singleton(self):
+        """Reset the singleton so each test starts fresh."""
+        from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+        FalkorDBRemoteManager._instance = None
+        FalkorDBRemoteManager._driver = None
+        FalkorDBRemoteManager._graph = None
+        # Remove _initialized from any lingering instance
+        if FalkorDBRemoteManager._instance and hasattr(FalkorDBRemoteManager._instance, '_initialized'):
+            del FalkorDBRemoteManager._instance._initialized
+
+    def setup_method(self):
+        self._reset_singleton()
+
+    def teardown_method(self):
+        self._reset_singleton()
+
+    def test_initialization_defaults(self):
+        """Test default config values when no env vars are set."""
+        env = {
+            'FALKORDB_HOST': 'myhost.example.com',
+        }
+        # Clear all FALKORDB_ env vars first
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update(env)
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+
+            assert manager.host == 'myhost.example.com'
+            assert manager.port == 6379
+            assert manager.password is None
+            assert manager.username is None
+            assert manager.ssl is False
+            assert manager.graph_name == 'codegraph'
+
+    def test_initialization_custom_values(self):
+        """Test that all env vars are correctly read."""
+        env = {
+            'FALKORDB_HOST': 'remote.falkordb.io',
+            'FALKORDB_PORT': '16379',
+            'FALKORDB_PASSWORD': 'secret123',
+            'FALKORDB_USERNAME': 'admin',
+            'FALKORDB_SSL': 'true',
+            'FALKORDB_GRAPH_NAME': 'mygraph',
+        }
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update(env)
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+
+            assert manager.host == 'remote.falkordb.io'
+            assert manager.port == 16379
+            assert manager.password == 'secret123'
+            assert manager.username == 'admin'
+            assert manager.ssl is True
+            assert manager.graph_name == 'mygraph'
+
+    def test_ssl_variations(self):
+        """Test various truthy values for FALKORDB_SSL."""
+        for val in ('true', 'True', 'TRUE', '1', 'yes', 'YES'):
+            clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+            clean_env.update({'FALKORDB_HOST': 'h', 'FALKORDB_SSL': val})
+            with patch.dict(os.environ, clean_env, clear=True):
+                from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+                self._reset_singleton()
+                manager = FalkorDBRemoteManager()
+                assert manager.ssl is True, f"Expected ssl=True for FALKORDB_SSL={val}"
+
+        for val in ('false', '0', 'no', ''):
+            clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+            clean_env.update({'FALKORDB_HOST': 'h', 'FALKORDB_SSL': val})
+            with patch.dict(os.environ, clean_env, clear=True):
+                from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+                self._reset_singleton()
+                manager = FalkorDBRemoteManager()
+                assert manager.ssl is False, f"Expected ssl=False for FALKORDB_SSL={val}"
+
+    def test_get_driver_connects_with_correct_params(self):
+        """Test that get_driver() calls FalkorDB with the right kwargs."""
+        env = {
+            'FALKORDB_HOST': 'remote.host',
+            'FALKORDB_PORT': '6380',
+            'FALKORDB_PASSWORD': 'pass',
+            'FALKORDB_USERNAME': 'user',
+            'FALKORDB_SSL': 'true',
+            'FALKORDB_GRAPH_NAME': 'testgraph',
+        }
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update(env)
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+
+            mock_falkordb_cls = MagicMock()
+            mock_db_instance = MagicMock()
+            mock_graph = MagicMock()
+            mock_falkordb_cls.return_value = mock_db_instance
+            mock_db_instance.select_graph.return_value = mock_graph
+
+            with patch('falkordb.FalkorDB', mock_falkordb_cls):
+                driver_wrapper = manager.get_driver()
+
+            mock_falkordb_cls.assert_called_once_with(
+                host='remote.host',
+                port=6380,
+                password='pass',
+                username='user',
+                ssl=True,
+            )
+            mock_db_instance.select_graph.assert_called_once_with('testgraph')
+            mock_graph.query.assert_called_once_with("RETURN 1")
+
+            # Returns a FalkorDBDriverWrapper
+            from codegraphcontext.core.database_falkordb import FalkorDBDriverWrapper
+            assert isinstance(driver_wrapper, FalkorDBDriverWrapper)
+
+    def test_get_driver_minimal_params(self):
+        """Test get_driver with only host set (no password/username/ssl)."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'simple.host'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+
+            mock_falkordb_cls = MagicMock()
+            mock_db = MagicMock()
+            mock_graph = MagicMock()
+            mock_falkordb_cls.return_value = mock_db
+            mock_db.select_graph.return_value = mock_graph
+
+            with patch('falkordb.FalkorDB', mock_falkordb_cls):
+                manager.get_driver()
+
+            # Should NOT include password, username, or ssl
+            mock_falkordb_cls.assert_called_once_with(
+                host='simple.host',
+                port=6379,
+            )
+
+    def test_get_driver_singleton_reuses_connection(self):
+        """Test that calling get_driver() twice doesn't create a second connection."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'h'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+
+            mock_falkordb_cls = MagicMock()
+            mock_db = MagicMock()
+            mock_graph = MagicMock()
+            mock_falkordb_cls.return_value = mock_db
+            mock_db.select_graph.return_value = mock_graph
+
+            with patch('falkordb.FalkorDB', mock_falkordb_cls):
+                d1 = manager.get_driver()
+                d2 = manager.get_driver()
+
+            # FalkorDB constructor called only once
+            assert mock_falkordb_cls.call_count == 1
+
+    def test_is_connected_true(self):
+        """Test is_connected returns True when graph query succeeds."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'h'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+            mock_graph = MagicMock()
+            manager._graph = mock_graph
+
+            assert manager.is_connected() is True
+            mock_graph.query.assert_called_with("RETURN 1")
+
+    def test_is_connected_false_no_graph(self):
+        """Test is_connected returns False when graph is None."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'h'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+            assert manager.is_connected() is False
+
+    def test_is_connected_false_on_exception(self):
+        """Test is_connected returns False when query raises."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'h'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+            mock_graph = MagicMock()
+            mock_graph.query.side_effect = ConnectionError("disconnected")
+            manager._graph = mock_graph
+
+            assert manager.is_connected() is False
+
+    def test_get_backend_type(self):
+        """Test backend type string."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'h'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+            assert manager.get_backend_type() == 'falkordb-remote'
+
+    def test_close_driver(self):
+        """Test close_driver clears internal state."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'h'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+            manager._driver = MagicMock()
+            manager._graph = MagicMock()
+
+            manager.close_driver()
+            assert manager._driver is None
+            assert manager._graph is None
+
+    def test_validate_config_no_host(self):
+        """Test validate_config fails when FALKORDB_HOST not set."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+            valid, error = FalkorDBRemoteManager.validate_config()
+            assert valid is False
+            assert 'FALKORDB_HOST' in error
+
+    def test_validate_config_valid(self):
+        """Test validate_config succeeds with host set."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'myhost'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+            valid, error = FalkorDBRemoteManager.validate_config()
+            assert valid is True
+            assert error is None
+
+    def test_validate_config_bad_port(self):
+        """Test validate_config fails with non-numeric port."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'h', 'FALKORDB_PORT': 'abc'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+            valid, error = FalkorDBRemoteManager.validate_config()
+            assert valid is False
+            assert 'number' in error
+
+    def test_get_driver_import_error(self):
+        """Test that missing falkordb package raises ValueError."""
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith('FALKORDB_')}
+        clean_env.update({'FALKORDB_HOST': 'h'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+
+            self._reset_singleton()
+            manager = FalkorDBRemoteManager()
+
+            with patch.dict('sys.modules', {'falkordb': None}):
+                with patch('builtins.__import__', side_effect=ImportError("no falkordb")):
+                    with pytest.raises(ValueError, match="FalkorDB client missing"):
+                        manager.get_driver()
+
+
+class TestFactoryFalkorDBRemote:
+    """Test that get_database_manager() correctly routes to FalkorDBRemoteManager."""
+
+    def setup_method(self):
+        from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+        FalkorDBRemoteManager._instance = None
+        FalkorDBRemoteManager._driver = None
+        FalkorDBRemoteManager._graph = None
+
+    def teardown_method(self):
+        from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+        FalkorDBRemoteManager._instance = None
+        FalkorDBRemoteManager._driver = None
+        FalkorDBRemoteManager._graph = None
+
+    def test_explicit_falkordb_remote(self):
+        """Test DATABASE_TYPE=falkordb-remote returns FalkorDBRemoteManager."""
+        env = {
+            'DATABASE_TYPE': 'falkordb-remote',
+            'FALKORDB_HOST': 'myhost',
+        }
+        # Clear conflicting vars
+        clean_env = {k: v for k, v in os.environ.items()
+                     if k not in ('DATABASE_TYPE', 'DEFAULT_DATABASE', 'CGC_RUNTIME_DB_TYPE')
+                     and not k.startswith('FALKORDB_')}
+        clean_env.update(env)
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core import get_database_manager
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+            manager = get_database_manager()
+            assert isinstance(manager, FalkorDBRemoteManager)
+
+    def test_explicit_falkordb_remote_missing_host(self):
+        """Test DATABASE_TYPE=falkordb-remote without FALKORDB_HOST raises."""
+        clean_env = {k: v for k, v in os.environ.items()
+                     if k not in ('DATABASE_TYPE', 'DEFAULT_DATABASE', 'CGC_RUNTIME_DB_TYPE')
+                     and not k.startswith('FALKORDB_')}
+        clean_env.update({'DATABASE_TYPE': 'falkordb-remote'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core import get_database_manager
+            with pytest.raises(ValueError, match="FALKORDB_HOST is not set"):
+                get_database_manager()
+
+    def test_auto_detect_remote_via_host(self):
+        """Test that setting FALKORDB_HOST (without DATABASE_TYPE) auto-detects remote."""
+        clean_env = {k: v for k, v in os.environ.items()
+                     if k not in ('DATABASE_TYPE', 'DEFAULT_DATABASE', 'CGC_RUNTIME_DB_TYPE')
+                     and not k.startswith('FALKORDB_')
+                     and not k.startswith('NEO4J_')}
+        clean_env.update({'FALKORDB_HOST': 'auto-detected.host'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core import get_database_manager
+            from codegraphcontext.core.database_falkordb_remote import FalkorDBRemoteManager
+            manager = get_database_manager()
+            assert isinstance(manager, FalkorDBRemoteManager)
+            assert manager.host == 'auto-detected.host'
+
+    def test_unknown_db_type_includes_falkordb_remote(self):
+        """Test that unknown DATABASE_TYPE error message mentions falkordb-remote."""
+        clean_env = {k: v for k, v in os.environ.items()
+                     if k not in ('DATABASE_TYPE', 'DEFAULT_DATABASE', 'CGC_RUNTIME_DB_TYPE')}
+        clean_env.update({'DATABASE_TYPE': 'badvalue'})
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from codegraphcontext.core import get_database_manager
+            with pytest.raises(ValueError, match="falkordb-remote"):
+                get_database_manager()


### PR DESCRIPTION
Add FalkorDBRemoteManager that connects to external FalkorDB instances via TCP, complementing the existing embedded FalkorDB Lite (Unix socket) and Neo4j backends. Configured via FALKORDB_HOST, FALKORDB_PORT, FALKORDB_PASSWORD, FALKORDB_USERNAME, FALKORDB_SSL, and FALKORDB_GRAPH_NAME env vars. Auto-detected when FALKORDB_HOST is set, or explicitly selected with DATABASE_TYPE=falkordb-remote.