### PR TITLE
feat: Add index_repository MCP tool for git clone + index

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -137,11 +137,20 @@ class MCPServer:
     def unwatch_directory_tool(self, **args) -> Dict[str, Any]:
         return watcher_handlers.unwatch_directory(self.code_watcher, **args)
 
+    def index_repository_tool(self, **args) -> Dict[str, Any]:
+        return indexing_handlers.index_repository(
+            self.graph_builder,
+            self.job_manager,
+            self.loop,
+            self.list_indexed_repositories_tool,
+            **args
+        )
+
     def add_code_to_graph_tool(self, **args) -> Dict[str, Any]:
         return indexing_handlers.add_code_to_graph(
-            self.graph_builder, 
-            self.job_manager, 
-            self.loop, 
+            self.graph_builder,
+            self.job_manager,
+            self.loop,
             self.list_indexed_repositories_tool, # Pass the wrapper or bound method so it executes correctly
             **args
         )
@@ -179,6 +188,7 @@ class MCPServer:
         Routes a tool call from the AI assistant to the appropriate handler function. 
         """
         tool_map: Dict[str, Coroutine] = {
+            "index_repository": self.index_repository_tool,
             "add_package_to_graph": self.add_package_to_graph_tool,
             "find_dead_code": self.find_dead_code_tool,
             "find_code": self.find_code_tool,

--- a/src/codegraphcontext/tool_definitions.py
+++ b/src/codegraphcontext/tool_definitions.py
@@ -1,5 +1,18 @@
 
 TOOLS = {
+    "index_repository": {
+        "name": "index_repository",
+        "description": "Clone a git repository by HTTPS URL into the server and index it into the code graph. Supports private repositories when a GIT_TOKEN environment variable is configured. Returns a job ID for background processing.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "HTTPS git URL of the repository to clone and index (e.g., https://github.com/org/repo.git)."},
+                "branch": {"type": "string", "description": "Branch to clone.", "default": "main"},
+                "is_dependency": {"type": "boolean", "description": "Whether this repository is a dependency.", "default": False}
+            },
+            "required": ["url"]
+        }
+    },
     "add_code_to_graph": {
         "name": "add_code_to_graph",
         "description": "Performs a one-time scan of a local folder to add its code to the graph. Ideal for indexing libraries, dependencies, or projects not being actively modified. Returns a job ID for background processing.",

--- a/src/codegraphcontext/tools/handlers/indexing_handlers.py
+++ b/src/codegraphcontext/tools/handlers/indexing_handlers.py
@@ -1,9 +1,99 @@
 from typing import Any, Dict
 from pathlib import Path
+from urllib.parse import urlparse
 import asyncio
 import os
+import subprocess
 from ...utils.debug_log import debug_log
 from ..package_resolver import get_local_package_path
+
+def index_repository(graph_builder, job_manager, loop, list_repos_func, **args) -> Dict[str, Any]:
+    """
+    Clone a git repository by HTTPS URL and index it into the graph.
+    Injects GIT_TOKEN into the URL for authenticated cloning if available.
+    """
+    url = args.get("url")
+    branch = args.get("branch", "main")
+    is_dependency = args.get("is_dependency", False)
+
+    if not url:
+        return {"error": "The 'url' parameter is required."}
+
+    try:
+        # Derive repo name from URL (last path segment, strip .git)
+        parsed = urlparse(url)
+        repo_name = parsed.path.rstrip("/").split("/")[-1]
+        if repo_name.endswith(".git"):
+            repo_name = repo_name[:-4]
+
+        if not repo_name:
+            return {"error": f"Could not derive repository name from URL: {url}"}
+
+        clone_path = Path("/workspace") / repo_name
+        path_obj = clone_path.resolve()
+
+        # Check if already indexed
+        indexed_repos = list_repos_func().get("repositories", [])
+        for repo in indexed_repos:
+            if Path(repo["path"]).resolve() == path_obj:
+                return {
+                    "success": False,
+                    "message": f"Repository '{repo_name}' is already indexed at {path_obj}."
+                }
+
+        # Build clone URL with token if GIT_TOKEN is available
+        clone_url = url
+        git_token = os.environ.get("GIT_TOKEN")
+        if git_token and parsed.hostname:
+            clone_url = f"{parsed.scheme}://{git_token}@{parsed.hostname}"
+            if parsed.port:
+                clone_url += f":{parsed.port}"
+            clone_url += parsed.path
+
+        # Clone the repository
+        debug_log(f"Cloning {url} (branch: {branch}) into {clone_path}")
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", "--branch", branch, clone_url, str(clone_path)],
+            capture_output=True, text=True, timeout=300
+        )
+
+        if result.returncode != 0:
+            # Sanitize error output to avoid leaking tokens
+            stderr = result.stderr
+            if git_token:
+                stderr = stderr.replace(git_token, "***")
+            return {"error": f"git clone failed: {stderr.strip()}"}
+
+        # Index the cloned repository
+        total_files, estimated_time = graph_builder.estimate_processing_time(path_obj)
+        job_id = job_manager.create_job(str(path_obj), is_dependency)
+        job_manager.update_job(job_id, total_files=total_files, estimated_duration=estimated_time)
+
+        coro = graph_builder.build_graph_from_path_async(
+            path_obj, is_dependency, job_id
+        )
+        asyncio.run_coroutine_threadsafe(coro, loop)
+
+        debug_log(f"Started background job {job_id} for cloned repo: {repo_name} at {path_obj}")
+
+        return {
+            "success": True, "job_id": job_id,
+            "repository": repo_name,
+            "clone_path": str(path_obj),
+            "branch": branch,
+            "message": f"Cloned '{repo_name}' and started indexing",
+            "estimated_files": total_files,
+            "estimated_duration_seconds": round(estimated_time, 2),
+            "estimated_duration_human": f"{int(estimated_time // 60)}m {int(estimated_time % 60)}s" if estimated_time >= 60 else f"{int(estimated_time)}s",
+            "instructions": f"Use 'check_job_status' with job_id '{job_id}' to monitor progress"
+        }
+
+    except subprocess.TimeoutExpired:
+        return {"error": f"git clone timed out after 300 seconds for {url}"}
+    except Exception as e:
+        debug_log(f"Error in index_repository: {str(e)}")
+        return {"error": f"Failed to clone and index repository: {str(e)}"}
+
 
 def add_code_to_graph(graph_builder, job_manager, loop, list_repos_func, **args) -> Dict[str, Any]:
     """


### PR DESCRIPTION
New tool that clones a remote git repository by HTTPS URL into the container and indexes it into the graph. Supports authenticated cloning for private repos via the GIT_TOKEN environment variable.