### PR TITLE
fix: add detection find dead code

### DIFF
--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -521,9 +521,12 @@ class CodeFinder:
             result = session.run("""
                 MATCH (func:Function)
                 WHERE func.is_dependency = false
-                  AND NOT func.name IN ['main', '__init__', '__main__', 'setup', 'run', '__new__', '__del__']
+                  AND NOT func.name IN ['main', 'setup', 'run']
+                  AND NOT (func.name STARTS WITH '__' AND func.name ENDS WITH '__')
                   AND NOT func.name STARTS WITH '_test'
                   AND NOT func.name STARTS WITH 'test_'
+                  AND NOT func.name CONTAINS 'main'
+                  AND NOT func.name =~ '(?i).*(application|entry|entrypoint).*'
                   AND ALL(decorator_name IN $exclude_decorated_with WHERE NOT decorator_name IN func.decorators)
                 WITH func
                 OPTIONAL MATCH (caller:Function)-[:CALLS]->(func)


### PR DESCRIPTION
## Description

Fixed the `find_dead_code` method in [src/codegraphcontext/tools/code_finder.py](src/codegraphcontext/tools/code_finder.py) to correctly exclude special methods (like `__repr__`) and entry point functions (like `run_application`) from being flagged as dead code.

The Cypher query was updated to use pattern-based exclusions instead of explicit lists:
- All special methods (dunder methods matching `__*__` pattern) are now excluded using a start/end pattern check
- Entry point functions containing 'main' or matching common patterns like 'application', 'entry', 'entrypoint' are excluded using pattern matching
- Removed redundant explicit exclusions that are now covered by the pattern checks

This prevents false positives where special methods called by the Python interpreter and entry point functions called via `if __name__ == "__main__":` blocks were incorrectly identified as unused.

Closes #57.

## Checklist if Applicable

- [x] The tests passed – pytest tests/unit/ tests/integration/ -v (13 passed in 3.29s)
- [ ] Linting passed – not applicable
- [ ] Documentation has been added
- [ ] CHANGELOG.md has been updated