### PR TITLE
fix: Sanitize graph props and strip /workspace/ paths for remote MCP use

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -36,6 +36,40 @@ from .tools.handlers import (
 DEFAULT_EDIT_DISTANCE = 2
 DEFAULT_FUZZY_SEARCH = False
 
+WORKSPACE_PREFIX = "/workspace/"
+
+
+def _is_path_key(key: str) -> bool:
+    """Check if a dict key represents a file path field.
+
+    Matches keys like 'path', 'clone_path', 'caller_file_path', and also
+    Cypher-aliased keys like 'f.path', 'n.caller_file_path'.
+    """
+    # Strip Cypher alias prefix (e.g. "f.path" -> "path")
+    bare = key.rsplit(".", 1)[-1] if "." in key else key
+    return bare == "path" or bare.endswith("_path")
+
+
+def _strip_path_value(value):
+    """Strip /workspace/ prefix from a single string value."""
+    if isinstance(value, str) and value.startswith(WORKSPACE_PREFIX):
+        return value[len(WORKSPACE_PREFIX):]
+    return value
+
+
+def _strip_workspace_prefix(obj):
+    """Recursively strip /workspace/ prefix from path values in results."""
+    if isinstance(obj, dict):
+        return {
+            k: _strip_path_value(v) if _is_path_key(k) else _strip_workspace_prefix(v)
+            for k, v in obj.items()
+        }
+    elif isinstance(obj, list):
+        return [_strip_workspace_prefix(item) for item in obj]
+    return obj
+
+
+
 class MCPServer:
     """
     The main MCP Server class.
@@ -254,7 +288,8 @@ class MCPServer:
                     tool_name = params.get('name')
                     args = params.get('arguments', {})
                     result = await self.handle_tool_call(tool_name, args)
-                    
+                    result = _strip_workspace_prefix(result)
+
                     if "error" in result:
                         response = {
                             "jsonrpc": "2.0", "id": request_id,

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -526,7 +526,7 @@ class GraphBuilder:
                         {set_clause_str}
                         MERGE (f)-[r:IMPORTS]->(m)
                         SET r += $rel_props
-                    """, **params)
+                    """, **_sanitize_props(params))
 
 
             # Handle CONTAINS relationship between class to their children like variables

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -526,7 +526,7 @@ class GraphBuilder:
                         {set_clause_str}
                         MERGE (f)-[r:IMPORTS]->(m)
                         SET r += $rel_props
-                    """, **_sanitize_props(params))
+                    """, **self._sanitize_props(params))
 
 
             # Handle CONTAINS relationship between class to their children like variables
@@ -710,7 +710,7 @@ class GraphBuilder:
                 
                 # KùzuDB workaround: Try Function->Function first, then other combinations
                 # This avoids polymorphic MERGE which KùzuDB doesn't support
-                call_params = {
+                call_params = self._sanitize_props({
                     'caller_name': caller_name,
                     'caller_file_path': caller_file_path,
                     'caller_line_number': caller_line_number,
@@ -719,8 +719,9 @@ class GraphBuilder:
                     'line_number': call['line_number'],
                     'args': call.get('args', []),
                     'full_call_name': call.get('full_name', called_name)
-                }
-                 # Try Function caller -> Function callee
+                })
+
+                # Try Function caller -> Function callee
                 if not self._safe_run_create(session, """
                     OPTIONAL MATCH (caller:Function {name: $caller_name, path: $caller_file_path})
                     OPTIONAL MATCH (called:Function {name: $called_name, path: $called_file_path})
@@ -799,14 +800,15 @@ class GraphBuilder:
                                 """, call_params)
             else:
                 # File-level calls: Try Function first, then Class
-                call_params = {
+                call_params = self._sanitize_props({
                     'caller_file_path': caller_file_path,
                     'called_name': called_name,
                     'called_file_path': resolved_path,
                     'line_number': call['line_number'],
                     'args': call.get('args', []),
                     'full_call_name': call.get('full_name', called_name)
-                }
+                })
+
 
                 if not self._safe_run_create(session, """
                     OPTIONAL MATCH (caller:File {path: $caller_file_path})

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -517,8 +517,12 @@ class GraphBuilder:
                     # Ensure full_import_name is available in params for SET clause
                     params = imp.copy()
                     params['path'] = file_path_str
-                    params['rel_props'] = rel_props
                     params['module_name'] = imp.get('name') # Use 'name' from imp as module name
+
+                    # Sanitize scalar params but keep rel_props as a dict
+                    # (FalkorDB SET r += $rel_props requires a map, not a string)
+                    sanitized = self._sanitize_props(params)
+                    sanitized['rel_props'] = rel_props
 
                     session.run(f"""
                         MATCH (f:File {{path: $path}})
@@ -526,7 +530,7 @@ class GraphBuilder:
                         {set_clause_str}
                         MERGE (f)-[r:IMPORTS]->(m)
                         SET r += $rel_props
-                    """, **self._sanitize_props(params))
+                    """, **sanitized)
 
 
             # Handle CONTAINS relationship between class to their children like variables


### PR DESCRIPTION
## Summary

- **Strip `/workspace/` prefix from tool result paths** — When CGC runs as a remote MCP server (via mcp-proxy SSE in K8s), `index_repository` clones repos into `/workspace/<repo>` inside the container. All tool results now automatically strip this prefix so LLMs see repo-relative paths (e.g. `myrepo/src/app.py`). Handles both direct path keys and Cypher-aliased keys like `f.path`.

- **Sanitize non-primitive FalkorDB properties** — Language parsers produce tuples (`context` in call nodes) and lists-of-dicts (`detailed_args` in C functions) which FalkorDB rejects. These are now serialized to JSON strings before `SET n += $props`. Fixes "Property values can only be of primitive types" error that caused C/C++ repo indexing to fail after a few files.

- **Update LLM system prompt for remote architecture** — Rewrite the `prompts.py` system prompt to reflect that the MCP server runs as a remote container service, not locally. Add a "Remote Server Architecture" section explaining that `index_repository` clones into the server container, `add_code_to_graph`/`watch_directory` operate on the server's filesystem, and returned paths are relative. Add all 12 previously missing tools to the Tool Manifest table (e.g. `index_repository`, `list_indexed_repositories`, `delete_repository`, `find_dead_code`, `load_bundle`, `search_registry_bundles`, `visualize_graph_query`, etc.).

## Files Changed

- `src/codegraphcontext/server.py` — Added `_strip_workspace_prefix` recursive helper, applied in `call_tool` handler
- `src/codegraphcontext/tools/graph_builder.py` — Added `_sanitize_props` helper, applied before `session.run`
- `src/codegraphcontext/prompts.py` — Rewrote Role/Goal section for remote architecture, added all missing tools to Tool Manifest

## Test plan

- [x] `./tests/run_tests.sh fast` — all 32 tests pass
- [x] Deployed to K8s cluster as v0.2.8, verified via SSE:
  - `list_indexed_repositories` returns `"path": "gokart-c"` (not `/workspace/gokart-c`)
  - `find_code` returns repo-relative paths
  - `execute_cypher_query` with `MATCH (f:File) RETURN f.path` returns stripped paths
  - `index_repository` on a 1620-file C repo indexes with zero errors (previously failed at 3 files)
- [x] Verified updated prompt is served via MCP `instructions` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)