### PR TITLE
Feature/neo4j database name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@
 NEO4J_URI=bolt://neo4j:7687
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=codegraph123
+# Optional database name for Neo4j (if using Neo4j 4.0+ with multiple databases)
+# NEO4J_DATABASE=neo4j
 
 # For production, use a strong password:
 # NEO4J_PASSWORD=your_secure_password_here

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ docs/DOCUMENTATION_AUDIT_2026-01-29.md
 vscode-extension
 GRANT_KNOWLEDGE_GRAPH.md
 cgc_btc/
+
+# Claude
+.claude/*
+CLAUDE.md

--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -16,7 +16,7 @@ CONFIG_DIR = Path.home() / ".codegraphcontext"
 CONFIG_FILE = CONFIG_DIR / ".env"
 
 # Database credential keys (stored in same .env file but not managed as config)
-DATABASE_CREDENTIAL_KEYS = {"NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD"}
+DATABASE_CREDENTIAL_KEYS = {"NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD", "NEO4J_DATABASE"}
 
 # Default configuration values
 DEFAULT_CONFIG = {

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -288,7 +288,11 @@ def _load_credentials():
             os.environ.get("NEO4J_PASSWORD")
         ])
         if has_neo4j_creds:
-            console.print("[cyan]Using database: Neo4j[/cyan]")
+            neo4j_db = os.environ.get("NEO4J_DATABASE")
+            if neo4j_db:
+                console.print(f"[cyan]Using database: Neo4j (database: {neo4j_db})[/cyan]")
+            else:
+                console.print("[cyan]Using database: Neo4j[/cyan]")
         else:
             console.print("[yellow]⚠ DEFAULT_DATABASE=neo4j but credentials not found. Falling back to FalkorDB.[/yellow]")
     else:
@@ -700,7 +704,7 @@ def doctor():
             
             if uri and username and password:
                 console.print(f"   [cyan]Testing Neo4j connection to {uri}...[/cyan]")
-                is_connected, error_msg = DatabaseManager.test_connection(uri, username, password)
+                is_connected, error_msg = DatabaseManager.test_connection(uri, username, password, database=os.environ.get("NEO4J_DATABASE"))
                 if is_connected:
                     console.print(f"   [green]✓[/green] Neo4j connection successful")
                 else:

--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -377,7 +377,7 @@ def configure_mcp_client():
                     if line and not line.startswith("#") and "=" in line:
                         key, value = line.split("=", 1)
                         key = key.strip()
-                        if key in ["NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD"]:
+                        if key in ["NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD", "NEO4J_DATABASE"]:
                             env_vars[key] = value.strip()
         except Exception:
             pass

--- a/src/codegraphcontext/core/database.py
+++ b/src/codegraphcontext/core/database.py
@@ -10,6 +10,24 @@ from neo4j import GraphDatabase, Driver
 
 from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logger, warning_logger
 
+class Neo4jDriverWrapper:
+    """
+    A simple wrapper around the Neo4j Driver to inject a database name into session() calls.
+    """
+    def __init__(self, driver: Driver, database: str = None):
+        self._driver = driver
+        self._database = database
+
+    def session(self, **kwargs):
+        """Proxy method to get a session from the underlying driver."""
+        if self._database and 'database' not in kwargs:
+            kwargs["database"] = self._database
+        return self._driver.session(**kwargs)
+    
+    def close(self):
+        """Proxy method to close the underlying driver."""
+        self._driver.close()
+
 class DatabaseManager:
     """
     Manages the Neo4j database driver as a singleton to ensure only one
@@ -42,6 +60,7 @@ class DatabaseManager:
         self.neo4j_uri = os.getenv('NEO4J_URI')
         self.neo4j_username = os.getenv('NEO4J_USERNAME', 'neo4j')
         self.neo4j_password = os.getenv('NEO4J_PASSWORD')
+        self.neo4j_database = os.getenv('NEO4J_DATABASE') # Optional, if not set, will use default database configured in Neo4j
         self._initialized = True
 
     def get_driver(self) -> Driver:
@@ -53,7 +72,7 @@ class DatabaseManager:
             ValueError: If Neo4j credentials are not set in environment variables.
 
         Returns:
-            The active Neo4j Driver instance.
+            The a wrapper for Neo4j Driver instance.
         """
         if self._driver is None:
             with self._lock:
@@ -100,7 +119,7 @@ class DatabaseManager:
                             self._driver.close()
                         self._driver = None
                         raise
-        return self._driver
+        return Neo4jDriverWrapper(self._driver, database=self.neo4j_database)
 
     def close_driver(self):
         """Closes the Neo4j driver connection if it exists."""
@@ -116,7 +135,10 @@ class DatabaseManager:
         if self._driver is None:
             return False
         try:
-            with self._driver.session() as session:
+            session_kwargs = {}
+            if self.neo4j_database:
+                session_kwargs['database'] = self.neo4j_database
+            with self._driver.session(**session_kwargs) as session:
                 session.run("RETURN 1").consume()
             return True
         except Exception:
@@ -163,7 +185,7 @@ class DatabaseManager:
         return True, None
 
     @staticmethod
-    def test_connection(uri: str, username: str, password: str) -> Tuple[bool, Optional[str]]:
+    def test_connection(uri: str, username: str, password: str, database: str=None) -> Tuple[bool, Optional[str]]:
         """
         Tests the Neo4j database connection.
         
@@ -206,7 +228,10 @@ class DatabaseManager:
             # Now test Neo4j authentication
             driver = GraphDatabase.driver(uri, auth=(username, password))
             
-            with driver.session() as session:
+            session_kwargs = {}
+            if database:
+                session_kwargs['database'] = database # Pass database to session if provided
+            with driver.session(**session_kwargs) as session:
                 result = session.run("RETURN 'Connection successful' as status")
                 result.single()
             

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -1,4 +1,5 @@
 
+import os
 import pytest
 from typer.testing import CliRunner
 from unittest.mock import patch, MagicMock
@@ -45,4 +46,93 @@ class TestCLICommands:
         # assert "No such command" in result.stdout
 
 
+class TestNeo4jDatabaseNameCLI:
+    """Integration tests for NEO4J_DATABASE display in CLI commands."""
+
+    @patch('codegraphcontext.cli.main.config_manager')
+    @patch('codegraphcontext.core.database.DatabaseManager.test_connection')
+    def test_doctor_passes_database_to_test_connection(self, mock_test_conn, mock_config_mgr):
+        """Test that the doctor command passes NEO4J_DATABASE to test_connection."""
+        mock_config_mgr.load_config.return_value = {"DEFAULT_DATABASE": "neo4j"}
+        mock_config_mgr.CONFIG_FILE = MagicMock()
+        mock_config_mgr.CONFIG_FILE.exists.return_value = True
+        mock_config_mgr.validate_config_value.return_value = (True, None)
+        mock_test_conn.return_value = (True, None)
+
+        env = {
+            "NEO4J_URI": "bolt://localhost:7687",
+            "NEO4J_USERNAME": "neo4j",
+            "NEO4J_PASSWORD": "password",
+            "NEO4J_DATABASE": "mydb",
+            "DEFAULT_DATABASE": "neo4j",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch('codegraphcontext.cli.main._load_credentials'):
+                result = runner.invoke(app, ["doctor"])
+
+        mock_test_conn.assert_called_once_with(
+            "bolt://localhost:7687", "neo4j", "password", database="mydb"
+        )
+
+    @patch('codegraphcontext.cli.main.find_dotenv', return_value=None)
+    @patch('codegraphcontext.cli.main.config_manager')
+    def test_load_credentials_displays_database_name(self, mock_config_mgr, mock_find_dotenv):
+        """Test _load_credentials prints database name when NEO4J_DATABASE is set."""
+        mock_config_mgr.ensure_config_dir.return_value = None
+
+        env = {
+            "NEO4J_URI": "bolt://localhost:7687",
+            "NEO4J_USERNAME": "neo4j",
+            "NEO4J_PASSWORD": "password",
+            "NEO4J_DATABASE": "mydb",
+            "DEFAULT_DATABASE": "neo4j",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch('codegraphcontext.cli.main.Path') as mock_path:
+                # Prevent file system access in _load_credentials
+                mock_path.home.return_value.__truediv__ = MagicMock(return_value=MagicMock(exists=MagicMock(return_value=False)))
+                mock_path.cwd.return_value.__truediv__ = MagicMock(return_value=MagicMock(exists=MagicMock(return_value=False)))
+
+                from codegraphcontext.cli.main import _load_credentials
+                from io import StringIO
+                from rich.console import Console
+
+                output = StringIO()
+                with patch('codegraphcontext.cli.main.console', Console(file=output, force_terminal=False)):
+                    _load_credentials()
+
+                printed = output.getvalue()
+                assert "Using database: Neo4j (database: mydb)" in printed
+
+    @patch('codegraphcontext.cli.main.find_dotenv', return_value=None)
+    @patch('codegraphcontext.cli.main.config_manager')
+    def test_load_credentials_no_database_name(self, mock_config_mgr, mock_find_dotenv):
+        """Test _load_credentials prints Neo4j without database when NEO4J_DATABASE is not set."""
+        mock_config_mgr.ensure_config_dir.return_value = None
+
+        env = {
+            "NEO4J_URI": "bolt://localhost:7687",
+            "NEO4J_USERNAME": "neo4j",
+            "NEO4J_PASSWORD": "password",
+            "DEFAULT_DATABASE": "neo4j",
+        }
+        # Remove NEO4J_DATABASE if it exists
+        clean_env = {k: v for k, v in os.environ.items() if k != "NEO4J_DATABASE"}
+        clean_env.update(env)
+        with patch.dict(os.environ, clean_env, clear=True):
+            with patch('codegraphcontext.cli.main.Path') as mock_path:
+                mock_path.home.return_value.__truediv__ = MagicMock(return_value=MagicMock(exists=MagicMock(return_value=False)))
+                mock_path.cwd.return_value.__truediv__ = MagicMock(return_value=MagicMock(exists=MagicMock(return_value=False)))
+
+                from codegraphcontext.cli.main import _load_credentials
+                from io import StringIO
+                from rich.console import Console
+
+                output = StringIO()
+                with patch('codegraphcontext.cli.main.console', Console(file=output, force_terminal=False)):
+                    _load_credentials()
+
+                printed = output.getvalue()
+                assert "Using database: Neo4j" in printed
+                assert "(database:" not in printed
 

--- a/tests/unit/core/test_database.py
+++ b/tests/unit/core/test_database.py
@@ -1,8 +1,8 @@
 
 import os
 import pytest
-from unittest.mock import MagicMock, patch
-from codegraphcontext.core.database import DatabaseManager
+from unittest.mock import MagicMock, patch, call
+from codegraphcontext.core.database import DatabaseManager, Neo4jDriverWrapper
 
 class TestDatabaseManager:
     """
@@ -52,9 +52,186 @@ class TestDatabaseManager:
         with patch.dict(os.environ, {"NEO4J_URI": "bolt://localhost:7687", "NEO4J_USERNAME": "u", "NEO4J_PASSWORD": "p"}):
             db_manager = DatabaseManager()
             db_manager._driver = mock_driver
-            
+
             mock_driver.session.side_effect = Exception("Connection refused")
-            
+
             assert db_manager.is_connected() is False
 
+    def test_initialization_with_database(self, mock_driver):
+        """Test that DatabaseManager reads NEO4J_DATABASE from env."""
+        with patch.dict(os.environ, {
+            "NEO4J_URI": "bolt://localhost:7687",
+            "NEO4J_USERNAME": "neo4j",
+            "NEO4J_PASSWORD": "password",
+            "NEO4J_DATABASE": "mydb"
+        }):
+            if DatabaseManager._instance:
+                DatabaseManager._instance = None
+            db_manager = DatabaseManager()
+            assert db_manager.neo4j_database == "mydb"
 
+    def test_initialization_without_database(self, mock_driver):
+        """Test that neo4j_database is None when NEO4J_DATABASE is not set."""
+        env = {"NEO4J_URI": "bolt://localhost:7687", "NEO4J_USERNAME": "neo4j", "NEO4J_PASSWORD": "password"}
+        with patch.dict(os.environ, env, clear=True):
+            if DatabaseManager._instance:
+                DatabaseManager._instance = None
+            db_manager = DatabaseManager()
+            assert db_manager.neo4j_database is None
+
+    def test_get_driver_returns_wrapper_with_database(self, mock_driver):
+        """Test get_driver() returns a Neo4jDriverWrapper with the configured database."""
+        with patch.dict(os.environ, {
+            "NEO4J_URI": "bolt://localhost:7687",
+            "NEO4J_USERNAME": "neo4j",
+            "NEO4J_PASSWORD": "password",
+            "NEO4J_DATABASE": "mydb"
+        }):
+            if DatabaseManager._instance:
+                DatabaseManager._instance = None
+            db_manager = DatabaseManager()
+            db_manager._driver = mock_driver
+
+            # Mock the connection test inside get_driver
+            session_mock = MagicMock()
+            mock_driver.session.return_value.__enter__.return_value = session_mock
+
+            wrapper = db_manager.get_driver()
+            assert isinstance(wrapper, Neo4jDriverWrapper)
+            assert wrapper._database == "mydb"
+
+    def test_get_driver_returns_wrapper_without_database(self, mock_driver):
+        """Test get_driver() returns a Neo4jDriverWrapper with None database when not configured."""
+        env = {"NEO4J_URI": "bolt://localhost:7687", "NEO4J_USERNAME": "neo4j", "NEO4J_PASSWORD": "password"}
+        with patch.dict(os.environ, env, clear=True):
+            if DatabaseManager._instance:
+                DatabaseManager._instance = None
+            db_manager = DatabaseManager()
+            db_manager._driver = mock_driver
+
+            session_mock = MagicMock()
+            mock_driver.session.return_value.__enter__.return_value = session_mock
+
+            wrapper = db_manager.get_driver()
+            assert isinstance(wrapper, Neo4jDriverWrapper)
+            assert wrapper._database is None
+
+    def test_is_connected_passes_database_to_session(self, mock_driver):
+        """Test is_connected() includes database in session kwargs when neo4j_database is set."""
+        with patch.dict(os.environ, {
+            "NEO4J_URI": "bolt://localhost:7687",
+            "NEO4J_USERNAME": "u",
+            "NEO4J_PASSWORD": "p",
+            "NEO4J_DATABASE": "mydb"
+        }):
+            if DatabaseManager._instance:
+                DatabaseManager._instance = None
+            db_manager = DatabaseManager()
+            db_manager._driver = mock_driver
+
+            session_mock = MagicMock()
+            mock_driver.session.return_value.__enter__.return_value = session_mock
+
+            db_manager.is_connected()
+            mock_driver.session.assert_called_with(database="mydb")
+
+    def test_is_connected_no_database_in_session(self, mock_driver):
+        """Test is_connected() does NOT include database in session kwargs when neo4j_database is None."""
+        env = {"NEO4J_URI": "bolt://localhost:7687", "NEO4J_USERNAME": "u", "NEO4J_PASSWORD": "p"}
+        with patch.dict(os.environ, env, clear=True):
+            if DatabaseManager._instance:
+                DatabaseManager._instance = None
+            db_manager = DatabaseManager()
+            db_manager._driver = mock_driver
+
+            session_mock = MagicMock()
+            mock_driver.session.return_value.__enter__.return_value = session_mock
+
+            db_manager.is_connected()
+            mock_driver.session.assert_called_with()
+
+
+class TestNeo4jDriverWrapper:
+    """Unit tests for the Neo4jDriverWrapper class."""
+
+    def test_session_injects_database_when_set(self):
+        """Test session() adds database kwarg when wrapper has a database configured."""
+        mock_driver = MagicMock()
+        wrapper = Neo4jDriverWrapper(mock_driver, database="mydb")
+
+        wrapper.session()
+        mock_driver.session.assert_called_once_with(database="mydb")
+
+    def test_session_no_database_when_none(self):
+        """Test session() does NOT add database kwarg when database is None."""
+        mock_driver = MagicMock()
+        wrapper = Neo4jDriverWrapper(mock_driver, database=None)
+
+        wrapper.session()
+        mock_driver.session.assert_called_once_with()
+
+    def test_session_does_not_override_existing_database(self):
+        """Test session() respects caller-provided database kwarg."""
+        mock_driver = MagicMock()
+        wrapper = Neo4jDriverWrapper(mock_driver, database="mydb")
+
+        wrapper.session(database="otherdb")
+        mock_driver.session.assert_called_once_with(database="otherdb")
+
+    def test_close_delegates_to_driver(self):
+        """Test close() calls close() on the underlying driver."""
+        mock_driver = MagicMock()
+        wrapper = Neo4jDriverWrapper(mock_driver, database="mydb")
+
+        wrapper.close()
+        mock_driver.close.assert_called_once()
+
+
+class TestTestConnection:
+    """Unit tests for DatabaseManager.test_connection() with database parameter."""
+
+    @patch('neo4j.GraphDatabase')
+    @patch('socket.socket')
+    def test_test_connection_with_database(self, mock_socket_cls, mock_gdb):
+        """Test test_connection() passes database to session when provided."""
+        # Mock socket connectivity check
+        mock_sock = MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.connect_ex.return_value = 0
+
+        # Mock driver and session
+        mock_driver = MagicMock()
+        mock_gdb.driver.return_value = mock_driver
+        mock_session = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+        is_connected, error = DatabaseManager.test_connection(
+            "bolt://localhost:7687", "neo4j", "password", database="mydb"
+        )
+
+        assert is_connected is True
+        assert error is None
+        mock_driver.session.assert_called_once_with(database="mydb")
+
+    @patch('neo4j.GraphDatabase')
+    @patch('socket.socket')
+    def test_test_connection_without_database(self, mock_socket_cls, mock_gdb):
+        """Test test_connection() does NOT pass database to session when None."""
+        mock_sock = MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.connect_ex.return_value = 0
+
+        mock_driver = MagicMock()
+        mock_gdb.driver.return_value = mock_driver
+        mock_session = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+        is_connected, error = DatabaseManager.test_connection(
+            "bolt://localhost:7687", "neo4j", "password"
+        )
+
+        assert is_connected is True
+        assert error is None
+        mock_driver.session.assert_called_once_with()


### PR DESCRIPTION
Add a new environment variable NEO4J_DATABASE to support multiple database names. If the variable is left unset, it uses the default database. Implemented by adding a wrapper class for the neo4j driver that optionally injects the database name into the session calls. 