### PR TITLE
fix(website): harden bundle trigger endpoint against abuse 

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -28,3 +28,16 @@ To create a production build of the website, run:
 ```bash
 npm run build
 ```
+
+## API Security Configuration
+
+The on-demand bundle trigger endpoint (`/api/trigger-bundle`) now includes abuse protections.
+
+Optional environment variables:
+
+- `BUNDLE_TRIGGER_API_KEY`: if set, requests must include header `x-bundle-trigger-key`.
+- `BUNDLE_TRIGGER_ALLOWED_ORIGINS`: comma-separated origin allow-list (for example: `https://codegraphcontext.io,https://www.codegraphcontext.io`).
+- `BUNDLE_TRIGGER_RATE_LIMIT_MAX`: max requests per IP inside rate-limit window (default: `10`).
+- `BUNDLE_TRIGGER_RATE_LIMIT_WINDOW_MS`: rate-limit window in ms (default: `900000`, i.e. 15 minutes).
+- `BUNDLE_TRIGGER_REPO_COOLDOWN_MS`: cooldown per repository after a trigger (default: `300000`, i.e. 5 minutes).
+- `BUNDLE_TRIGGER_ACTIVE_JOB_TTL_MS`: TTL for in-memory active-job dedupe records (default: `2700000`, i.e. 45 minutes).

--- a/website/api/lib/security.js
+++ b/website/api/lib/security.js
@@ -1,0 +1,177 @@
+const ipRateLimits = new Map();
+const repoCooldowns = new Map();
+const activeRepoJobs = new Map();
+
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_RATE_LIMIT_MAX = 10;
+const DEFAULT_REPO_COOLDOWN_MS = 5 * 60 * 1000;
+const DEFAULT_ACTIVE_JOB_TTL_MS = 45 * 60 * 1000;
+
+function parsePositiveInt(rawValue, fallback) {
+  const parsedValue = Number.parseInt(String(rawValue ?? ""), 10);
+  return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : fallback;
+}
+
+function getRateLimitConfig() {
+  return {
+    windowMs: parsePositiveInt(process.env.BUNDLE_TRIGGER_RATE_LIMIT_WINDOW_MS, DEFAULT_RATE_LIMIT_WINDOW_MS),
+    maxRequests: parsePositiveInt(process.env.BUNDLE_TRIGGER_RATE_LIMIT_MAX, DEFAULT_RATE_LIMIT_MAX),
+  };
+}
+
+function getRepoProtectionConfig() {
+  return {
+    cooldownMs: parsePositiveInt(process.env.BUNDLE_TRIGGER_REPO_COOLDOWN_MS, DEFAULT_REPO_COOLDOWN_MS),
+    activeJobTtlMs: parsePositiveInt(process.env.BUNDLE_TRIGGER_ACTIVE_JOB_TTL_MS, DEFAULT_ACTIVE_JOB_TTL_MS),
+  };
+}
+
+function getClientIp(req) {
+  const forwardedFor = req?.headers?.["x-forwarded-for"];
+  if (typeof forwardedFor === "string" && forwardedFor.length > 0) {
+    return forwardedFor.split(",")[0].trim();
+  }
+
+  const realIp = req?.headers?.["x-real-ip"];
+  if (typeof realIp === "string" && realIp.length > 0) {
+    return realIp.trim();
+  }
+
+  return req?.socket?.remoteAddress || "unknown";
+}
+
+function cleanupExpiredEntries(now = Date.now()) {
+  const { windowMs } = getRateLimitConfig();
+  const { cooldownMs, activeJobTtlMs } = getRepoProtectionConfig();
+
+  for (const [ip, entry] of ipRateLimits.entries()) {
+    if (now - entry.windowStart >= windowMs) {
+      ipRateLimits.delete(ip);
+    }
+  }
+
+  for (const [repo, nextAllowedAt] of repoCooldowns.entries()) {
+    if (now >= nextAllowedAt + cooldownMs) {
+      repoCooldowns.delete(repo);
+    }
+  }
+
+  for (const [repo, job] of activeRepoJobs.entries()) {
+    if (now - job.startedAt >= activeJobTtlMs) {
+      activeRepoJobs.delete(repo);
+    }
+  }
+}
+
+function checkRateLimit(ip, now = Date.now()) {
+  cleanupExpiredEntries(now);
+  const { windowMs, maxRequests } = getRateLimitConfig();
+
+  const existing = ipRateLimits.get(ip);
+  if (!existing) {
+    ipRateLimits.set(ip, { count: 1, windowStart: now });
+    return { allowed: true, remaining: maxRequests - 1, retryAfterSeconds: 0 };
+  }
+
+  if (now - existing.windowStart >= windowMs) {
+    ipRateLimits.set(ip, { count: 1, windowStart: now });
+    return { allowed: true, remaining: maxRequests - 1, retryAfterSeconds: 0 };
+  }
+
+  if (existing.count >= maxRequests) {
+    const retryAfterMs = windowMs - (now - existing.windowStart);
+    const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+    return { allowed: false, remaining: 0, retryAfterSeconds };
+  }
+
+  existing.count += 1;
+  ipRateLimits.set(ip, existing);
+  return { allowed: true, remaining: maxRequests - existing.count, retryAfterSeconds: 0 };
+}
+
+function checkRepoCooldown(repoKey, now = Date.now()) {
+  cleanupExpiredEntries(now);
+  const { cooldownMs } = getRepoProtectionConfig();
+
+  const nextAllowedAt = repoCooldowns.get(repoKey);
+  if (!nextAllowedAt || now >= nextAllowedAt) {
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  const retryAfterSeconds = Math.max(1, Math.ceil((nextAllowedAt - now) / 1000));
+  return { allowed: false, retryAfterSeconds, cooldownMs };
+}
+
+function setRepoCooldown(repoKey, now = Date.now()) {
+  const { cooldownMs } = getRepoProtectionConfig();
+  repoCooldowns.set(repoKey, now + cooldownMs);
+}
+
+function getActiveRepoJob(repoKey, now = Date.now()) {
+  cleanupExpiredEntries(now);
+  return activeRepoJobs.get(repoKey) || null;
+}
+
+function markRepoJobActive(repoKey, runId = null, runUrl = null, now = Date.now()) {
+  activeRepoJobs.set(repoKey, {
+    startedAt: now,
+    runId,
+    runUrl,
+  });
+}
+
+function clearRepoJob(repoKey) {
+  activeRepoJobs.delete(repoKey);
+}
+
+function normalizeRepoKey(owner, repo) {
+  return `${String(owner || "").toLowerCase()}/${String(repo || "").toLowerCase()}`;
+}
+
+function isAllowedOrigin(originHeader) {
+  const allowListRaw = process.env.BUNDLE_TRIGGER_ALLOWED_ORIGINS;
+  if (!allowListRaw || allowListRaw.trim().length === 0) {
+    return true;
+  }
+
+  if (!originHeader || typeof originHeader !== "string") {
+    return false;
+  }
+
+  const allowedOrigins = allowListRaw
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return allowedOrigins.includes(originHeader);
+}
+
+function isAuthorizedRequest(req) {
+  const expectedApiKey = process.env.BUNDLE_TRIGGER_API_KEY;
+  if (!expectedApiKey) {
+    return true;
+  }
+
+  const providedKey = req?.headers?.["x-bundle-trigger-key"];
+  return typeof providedKey === "string" && providedKey === expectedApiKey;
+}
+
+function __resetSecurityStateForTests() {
+  ipRateLimits.clear();
+  repoCooldowns.clear();
+  activeRepoJobs.clear();
+}
+
+export {
+  checkRateLimit,
+  checkRepoCooldown,
+  clearRepoJob,
+  getActiveRepoJob,
+  getClientIp,
+  isAllowedOrigin,
+  isAuthorizedRequest,
+  markRepoJobActive,
+  normalizeRepoKey,
+  setRepoCooldown,
+  __resetSecurityStateForTests,
+};

--- a/website/api/trigger-bundle.ts
+++ b/website/api/trigger-bundle.ts
@@ -1,10 +1,57 @@
 // api/trigger-bundle.ts
 // Triggers the on-demand bundle generation GitHub Actions workflow
 
+import {
+    checkRateLimit,
+    checkRepoCooldown,
+    getActiveRepoJob,
+    getClientIp,
+    isAllowedOrigin,
+    isAuthorizedRequest,
+    markRepoJobActive,
+    normalizeRepoKey,
+    setRepoCooldown,
+} from './lib/security.js';
+
 export default async function handler(req: any, res: any) {
     // Only allow POST requests
     if (req.method !== 'POST') {
         return res.status(405).json({ error: 'Method not allowed' });
+    }
+
+    // Basic request hardening
+    const origin = req.headers?.origin || req.headers?.referer;
+    if (!isAllowedOrigin(origin)) {
+        return res.status(403).json({
+            error: 'Forbidden origin'
+        });
+    }
+
+    if (!isAuthorizedRequest(req)) {
+        return res.status(401).json({
+            error: 'Unauthorized request'
+        });
+    }
+
+    const contentType = req.headers?.['content-type'] || '';
+    if (typeof contentType === 'string' && !contentType.includes('application/json')) {
+        return res.status(415).json({ error: 'Content-Type must be application/json' });
+    }
+
+    const clientIp = getClientIp(req);
+    const rateLimitResult = checkRateLimit(clientIp);
+    if (!rateLimitResult.allowed) {
+        res.setHeader('Retry-After', String(rateLimitResult.retryAfterSeconds));
+        return res.status(429).json({
+            error: 'Rate limit exceeded. Please retry later.',
+            retry_after_seconds: rateLimitResult.retryAfterSeconds
+        });
+    }
+
+    if (!process.env.GITHUB_TOKEN) {
+        return res.status(503).json({
+            error: 'Bundle generation service is not configured'
+        });
     }
 
     const rawRepoUrl = req.body.repoUrl;
@@ -28,6 +75,28 @@ export default async function handler(req: any, res: any) {
 
     const owner = match[2];
     const repo = match[3].replace('.git', '');
+    const normalizedRepo = normalizeRepoKey(owner, repo);
+
+    // Avoid duplicate or abusive triggers for the same repository
+    const existingActiveJob = getActiveRepoJob(normalizedRepo);
+    if (existingActiveJob) {
+        return res.status(202).json({
+            status: 'processing',
+            message: 'A bundle generation request is already in progress for this repository',
+            repository: normalizedRepo,
+            run_id: existingActiveJob.runId,
+            run_url: existingActiveJob.runUrl
+        });
+    }
+
+    const cooldownCheck = checkRepoCooldown(normalizedRepo);
+    if (!cooldownCheck.allowed) {
+        res.setHeader('Retry-After', String(cooldownCheck.retryAfterSeconds));
+        return res.status(429).json({
+            error: 'This repository was recently queued. Please wait before retrying.',
+            retry_after_seconds: cooldownCheck.retryAfterSeconds
+        });
+    }
 
     try {
         // Check if repository exists
@@ -105,6 +174,10 @@ export default async function handler(req: any, res: any) {
             throw new Error(`Failed to trigger workflow: ${workflowResponse.statusText}`);
         }
 
+        // Mark repository as active and apply cooldown to prevent rapid re-triggers
+        setRepoCooldown(normalizedRepo);
+        markRepoJobActive(normalizedRepo);
+
         // Get the latest workflow run ID (we just triggered it)
         // Wait a bit for GitHub to register the run
         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -127,6 +200,7 @@ export default async function handler(req: any, res: any) {
             if (runsData.workflow_runs && runsData.workflow_runs.length > 0) {
                 runId = runsData.workflow_runs[0].id;
                 runUrl = runsData.workflow_runs[0].html_url;
+                markRepoJobActive(normalizedRepo, runId, runUrl);
             }
         }
 


### PR DESCRIPTION
## Fix Summary (Issue #668)

This PR hardens the public bundle-generation endpoint to prevent abuse of GitHub Actions dispatch.

---

## What Was Fixed

Added request hardening to `trigger-bundle.ts`:

- Optional API key enforcement (`x-bundle-trigger-key`)
- Optional origin allowlist enforcement
- JSON `Content-Type` validation
- IP-based rate limiting (`429` + `Retry-After`)
- Per-repository cooldown (`429` + `Retry-After`)
- In-flight deduplication (returns `202 processing` instead of re-triggering)
- Safe failure when `GITHUB_TOKEN` is missing (`503`)

Added reusable security guard module in `security.js`:

- Client IP extraction
- Rate-limit window tracking
- Repo cooldown tracking
- Active-job tracking / deduplication
- Origin and API-key validation helpers

Updated docs in `README.md`:

- Added configuration for new security environment variables

---

## Why This Resolves the Issue

Previously, `/api/trigger-bundle` could be called without authentication or throttling, enabling workflow abuse and CI cost / queue exhaustion.

This change adds layered controls that block unauthorized, burst, and duplicate trigger attempts **before** dispatching workflows.

---

## Validation Performed

- Built frontend successfully with `npm run build`
- Verified no diagnostics in hardened files
- Confirmed branch pushed with fix: `fix/security-trigger-hardening`
- Commit: `4cbe2f7`

---

## Notes

- Current limiter / dedupe is in-memory (per instance)
- For distributed enforcement across multiple instances, a shared backend (e.g., Redis / Upstash) can be added in a follow-up