### PR TITLE
fix: pass repo_path through analyze_code_relationships + f-string fixes

### DIFF
--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -449,7 +449,7 @@ class CodeFinder:
     def find_class_hierarchy(self, class_name: str, path: Optional[str] = None, repo_path: Optional[str] = None) -> Dict[str, Any]:
         """Find class inheritance relationships using INHERITS relationships"""
         with self.driver.session() as session:
-            repo_filter = "WHERE 1=1 AND parent.path STARTS WITH $repo_path" if repo_path else ""
+            repo_filter = "AND parent.path STARTS WITH $repo_path" if repo_path else ""
             if path:
                 match_clause = "MATCH (child:Class {name: $class_name, path: $path})"
             else:
@@ -470,7 +470,7 @@ class CodeFinder:
             """
             parents_result = session.run(parents_query, class_name=class_name, path=path, repo_path=repo_path)
             
-            repo_filter_child = "WHERE 1=1 AND grandchild.path STARTS WITH $repo_path" if repo_path else ""
+            repo_filter_child = "AND grandchild.path STARTS WITH $repo_path" if repo_path else ""
             children_query = f"""
                 {match_clause}
                 MATCH (grandchild:Class)-[:INHERITS]->(child)

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -1,6 +1,6 @@
 # src/codegraphcontext/tools/code_finder.py
 import logging
-import re
+
 from typing import Any, Dict, List, Literal, Optional
 from pathlib import Path
 
@@ -348,7 +348,6 @@ class CodeFinder:
     def what_does_function_call(self, function_name: str, path: Optional[str] = None, repo_path: Optional[str] = None) -> List[Dict]:
         """Find what functions a specific function calls using CALLS relationships"""
         with self.driver.session() as session:
-            repo_filter = "AND called.path STARTS WITH $repo_path" if repo_path else ""
             if path:
                 # Convert path to absolute path
                 absolute_file_path = str(Path(path).resolve())
@@ -513,10 +512,10 @@ class CodeFinder:
     def find_function_overrides(self, function_name: str, repo_path: Optional[str] = None) -> List[Dict]:
         """Find all implementations of a function across different classes"""
         with self.driver.session() as session:
-            repo_filter = "WHERE 1=1 AND class.path STARTS WITH $repo_path" if repo_path else ""
+            repo_filter = "AND class.path STARTS WITH $repo_path" if repo_path else ""
             result = session.run(f"""
                 MATCH (class:Class)-[:CONTAINS]->(func:Function {{name: $function_name}})
-                WHERE 1=1 {{repo_filter}}
+                WHERE 1=1 {repo_filter}
                 OPTIONAL MATCH (file:File)-[:CONTAINS]->(class)
                 RETURN DISTINCT
                     class.name as class_name,

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -457,9 +457,9 @@ class CodeFinder:
                 match_clause = "MATCH (child:Class {name: $class_name})"
 
             parents_query = f"""
-                {{match_clause}}
+                {match_clause}
                 MATCH (child)-[:INHERITS]->(parent:Class)
-                WHERE 1=1 {{repo_filter}}
+                WHERE 1=1 {repo_filter}
                 OPTIONAL MATCH (parent_file:File)-[:CONTAINS]->(parent)
                 RETURN DISTINCT
                     parent.name as parent_class,
@@ -473,9 +473,9 @@ class CodeFinder:
             
             repo_filter_child = "WHERE 1=1 AND grandchild.path STARTS WITH $repo_path" if repo_path else ""
             children_query = f"""
-                {{match_clause}}
+                {match_clause}
                 MATCH (grandchild:Class)-[:INHERITS]->(child)
-                WHERE 1=1 {{repo_filter_child}}
+                WHERE 1=1 {repo_filter_child}
                 OPTIONAL MATCH (child_file:File)-[:CONTAINS]->(grandchild)
                 RETURN DISTINCT
                     grandchild.name as child_class,
@@ -821,69 +821,69 @@ class CodeFinder:
                 "instances": variable_instances.data()
             }
     
-    def analyze_code_relationships(self, query_type: str, target: str, context: Optional[str] = None) -> Dict[str, Any]:
+    def analyze_code_relationships(self, query_type: str, target: str, context: Optional[str] = None, repo_path: Optional[str] = None) -> Dict[str, Any]:
         """Main method to analyze different types of code relationships with fixed return types"""
         query_type = query_type.lower().strip()
         
         try:
             if query_type == "find_callers":
-                results = self.who_calls_function(target, context)
+                results = self.who_calls_function(target, context, repo_path=repo_path)
                 return {
                     "query_type": "find_callers", "target": target, "context": context, "results": results,
                     "summary": f"Found {len(results)} functions that call '{target}'"
                 }
             
             elif query_type == "find_callees":
-                results = self.what_does_function_call(target, context)
+                results = self.what_does_function_call(target, context, repo_path=repo_path)
                 return {
                     "query_type": "find_callees", "target": target, "context": context, "results": results,
                     "summary": f"Function '{target}' calls {len(results)} other functions"
                 }
                 
             elif query_type == "find_importers":
-                results = self.who_imports_module(target)
+                results = self.who_imports_module(target, repo_path=repo_path)
                 return {
                     "query_type": "find_importers", "target": target, "results": results,
                     "summary": f"Found {len(results)} files that import '{target}'"
                 }
                 
             elif query_type == "find_functions_by_argument":
-                results = self.find_functions_by_argument(target, context)
+                results = self.find_functions_by_argument(target, context, repo_path=repo_path)
                 return {
                     "query_type": "find_functions_by_argument", "target": target, "context": context, "results": results,
                     "summary": f"Found {len(results)} functions that take '{target}' as an argument"
                 }
             
             elif query_type == "find_functions_by_decorator":
-                results = self.find_functions_by_decorator(target, context)
+                results = self.find_functions_by_decorator(target, context, repo_path=repo_path)
                 return {
                     "query_type": "find_functions_by_decorator", "target": target, "context": context, "results": results,
                     "summary": f"Found {len(results)} functions decorated with '{target}'"
                 }
                 
             elif query_type in ["who_modifies", "modifies", "mutations", "changes", "variable_usage"]:
-                results = self.who_modifies_variable(target)
+                results = self.who_modifies_variable(target, repo_path=repo_path)
                 return {
                     "query_type": "who_modifies", "target": target, "results": results,
                     "summary": f"Found {len(results)} containers that hold variable '{target}'"
                 }
             
             elif query_type in ["class_hierarchy", "inheritance", "extends"]:
-                results = self.find_class_hierarchy(target, context)
+                results = self.find_class_hierarchy(target, context, repo_path=repo_path)
                 return {
                     "query_type": "class_hierarchy", "target": target, "results": results,
                     "summary": f"Class '{target}' has {len(results['parent_classes'])} parents, {len(results['child_classes'])} children, and {len(results['methods'])} methods"
                 }
             
             elif query_type in ["overrides", "implementations", "polymorphism"]:
-                results = self.find_function_overrides(target)
+                results = self.find_function_overrides(target, repo_path=repo_path)
                 return {
                     "query_type": "overrides", "target": target, "results": results,
                     "summary": f"Found {len(results)} implementations of function '{target}'"
                 }
             
             elif query_type in ["dead_code", "unused", "unreachable"]:
-                results = self.find_dead_code()
+                results = self.find_dead_code(repo_path=repo_path)
                 return {
                     "query_type": "dead_code", "results": results,
                     "summary": f"Found {len(results['potentially_unused_functions'])} potentially unused functions"
@@ -891,21 +891,21 @@ class CodeFinder:
             
             elif query_type == "find_complexity":
                 limit = int(context) if context and context.isdigit() else 10
-                results = self.find_most_complex_functions(limit)
+                results = self.find_most_complex_functions(limit, repo_path=repo_path)
                 return {
                     "query_type": "find_complexity", "limit": limit, "results": results,
                     "summary": f"Found the top {len(results)} most complex functions"
                 }
             
             elif query_type == "find_all_callers":
-                results = self.find_all_callers(target, context)
+                results = self.find_all_callers(target, context, repo_path=repo_path)
                 return {
                     "query_type": "find_all_callers", "target": target, "context": context, "results": results,
                     "summary": f"Found {len(results)} direct and indirect callers of '{target}'"
                 }
 
             elif query_type == "find_all_callees":
-                results = self.find_all_callees(target, context)
+                results = self.find_all_callees(target, context, repo_path=repo_path)
                 return {
                     "query_type": "find_all_callees", "target": target, "context": context, "results": results,
                     "summary": f"Found {len(results)} direct and indirect callees of '{target}'"
@@ -916,7 +916,7 @@ class CodeFinder:
                     start_func, end_func = target.split('->', 1)
                     # max_depth can be passed as context, default to 5 if not provided or invalid
                     max_depth = int(context) if context and context.isdigit() else 5
-                    results = self.find_function_call_chain(start_func.strip(), end_func.strip(), max_depth)
+                    results = self.find_function_call_chain(start_func.strip(), end_func.strip(), max_depth, repo_path=repo_path)
                     return {
                         "query_type": "call_chain", "target": target, "results": results,
                         "summary": f"Found {len(results)} call chains from '{start_func.strip()}' to '{end_func.strip()}' (max depth: {max_depth})"
@@ -928,14 +928,14 @@ class CodeFinder:
                     }
             
             elif query_type in ["module_deps", "module_dependencies", "module_usage"]:
-                results = self.find_module_dependencies(target)
+                results = self.find_module_dependencies(target, repo_path=repo_path)
                 return {
                     "query_type": "module_dependencies", "target": target, "results": results,
                     "summary": f"Module '{target}' is imported by {len(results['imported_by_files'])} files"
                 }
             
             elif query_type in ["variable_scope", "var_scope", "variable_usage_scope"]:
-                results = self.find_variable_usage_scope(target)
+                results = self.find_variable_usage_scope(target, repo_path=repo_path)
                 return {
                     "query_type": "variable_scope", "target": target, "results": results,
                     "summary": f"Variable '{target}' has {len(results['instances'])} instances across different scopes"


### PR DESCRIPTION
## Summary
- `analyze_code_relationships()` was missing `repo_path` parameter, causing `TypeError` whenever the MCP tool included `repo_path` in the call
- All 15 dispatched sub-calls now receive `repo_path=repo_path`
- Fixed f-string double-brace bugs in `find_class_hierarchy` and `find_function_overrides` where `{{repo_filter}}` produced literal text instead of interpolating the variable
- Removed unused `import re` and dead `repo_filter` variable in `what_does_function_call`

## Root cause
The MCP tool schema declares `repo_path` as a valid input, and the handler passes it through, but the `analyze_code_relationships` method signature didn't accept it — causing a silent `TypeError` caught by the generic exception handler.

## Test plan
- [ ] `analyze_code_relationships` with `query_type=find_callers` and `repo_path` set
- [ ] `class_hierarchy` query on a multi-repo indexed DB
- [ ] `find_function_overrides` with repo_path filtering