### PR TITLE
fix: address security vulnerabilities in viz server and bundle import

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -384,7 +384,11 @@ def visualize_helper(repo_path: Optional[str] = None, port: int = 8000):
     threading.Thread(target=open_browser, daemon=True).start()
     
     try:
-        run_server(host="127.0.0.1", port=port, static_dir=str(static_dir))
+        # Build list of allowed directories for file access
+        allowed_dirs = []
+        if repo_path:
+            allowed_dirs.append(str(Path(repo_path).resolve()))
+        run_server(host="127.0.0.1", port=port, static_dir=str(static_dir), allowed_dirs=allowed_dirs)
     except Exception as e:
         console.print(f"[bold red]An error occurred while running the server:[/bold red] {e}")
     finally:

--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -20,6 +20,8 @@ Bundle Structure:
 """
 
 import json
+import os
+import re
 import zipfile
 import tempfile
 from pathlib import Path
@@ -34,7 +36,23 @@ class CGCBundle:
     """Handles creation and loading of .cgc bundle files."""
     
     VERSION = "0.1.0"  # CGC bundle format version
-    
+    _CYPHER_IDENTIFIER_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+    @staticmethod
+    def _validate_cypher_identifier(value: str) -> bool:
+        """Validate that a value is safe to use as a Cypher label or relationship type."""
+        return bool(CGCBundle._CYPHER_IDENTIFIER_RE.match(value))
+
+    @staticmethod
+    def _safe_extract_zip(zip_ref: zipfile.ZipFile, dest: Path) -> None:
+        """Extract a ZIP archive, raising ValueError if any entry would escape dest."""
+        dest_resolved = str(dest.resolve()) + os.sep
+        for member in zip_ref.namelist():
+            member_path = (dest / member).resolve()
+            if not str(member_path).startswith(dest_resolved):
+                raise ValueError(f"Zip entry would escape extraction directory: {member}")
+        zip_ref.extractall(dest)
+
     def __init__(self, db_manager):
         """
         Initialize the CGC Bundle handler.
@@ -161,10 +179,10 @@ class CGCBundle:
             with tempfile.TemporaryDirectory() as temp_dir:
                 temp_path = Path(temp_dir)
                 
-                # Step 1: Extract ZIP
+                # Step 1: Extract ZIP (with path traversal protection)
                 info_logger("Extracting bundle...")
                 with zipfile.ZipFile(bundle_path, 'r') as zip_ref:
-                    zip_ref.extractall(temp_path)
+                    self._safe_extract_zip(zip_ref, temp_path)
                 
                 # Step 2: Validate bundle
                 info_logger("Validating bundle...")
@@ -711,7 +729,12 @@ cgc import <bundle-file>.cgc
         for labels, properties, old_id in batch:
             if not labels:
                 continue
-            
+
+            # Validate labels to prevent Cypher injection
+            if not all(self._validate_cypher_identifier(label) for label in labels):
+                warning_logger(f"Skipping node with invalid label(s): {labels}")
+                continue
+
             # Create node with labels
             label_str = ':'.join(labels)
             query = f"CREATE (n:{label_str}) SET n = $props RETURN {id_function}(n) as new_id"
@@ -765,7 +788,12 @@ cgc import <bundle-file>.cgc
             if not new_from or not new_to:
                 warning_logger(f"Skipping edge: node IDs not found in mapping")
                 continue
-            
+
+            # Validate relationship type to prevent Cypher injection
+            if not rel_type or not self._validate_cypher_identifier(rel_type):
+                warning_logger(f"Skipping edge with invalid relationship type: '{rel_type}'")
+                continue
+
             # Create relationship
             query = f"""
                 MATCH (a), (b)

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -14,10 +14,15 @@ from ..utils.debug_log import debug_log
 
 app = FastAPI()
 
-# Enable CORS for development
+# Enable CORS - restrict to local origins only
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[
+        "http://localhost:8000",
+        "http://127.0.0.1:8000",
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+    ],
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -26,6 +31,8 @@ app.add_middleware(
 db_manager: Optional[DatabaseManager] = None
 # Path to static directory
 _static_dir: Optional[str] = None
+# Allowed base directories for file access (set when server starts)
+_allowed_dirs: List[str] = []
 
 def set_db_manager(manager: DatabaseManager):
     global db_manager
@@ -135,10 +142,17 @@ async def get_graph(repo_path: Optional[str] = None):
 
 @app.get("/api/file")
 async def get_file(path: str):
-    file_path = Path(path)
+    file_path = Path(path).resolve()
+
+    # Validate that the resolved path is within an allowed directory
+    if not _allowed_dirs or not any(
+        str(file_path).startswith(allowed) for allowed in _allowed_dirs
+    ):
+        raise HTTPException(status_code=403, detail="Access denied: path outside allowed directories")
+
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
-    
+
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             return {"content": f.read()}
@@ -167,12 +181,14 @@ async def spa_fallback(request: Request, full_path: str):
     
     return HTMLResponse("Not Found", status_code=404)
 
-def run_server(host: str = "127.0.0.1", port: int = 8000, static_dir: Optional[str] = None):
-    global _static_dir
+def run_server(host: str = "127.0.0.1", port: int = 8000, static_dir: Optional[str] = None, allowed_dirs: Optional[List[str]] = None):
+    global _static_dir, _allowed_dirs
     _static_dir = static_dir
+    if allowed_dirs:
+        _allowed_dirs = [str(Path(d).resolve()) for d in allowed_dirs]
     if static_dir:
         # Mount API first
         # We don't mount "/" with StaticFiles because we use spa_fallback for all routes
         pass
-    
+
     uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
## Summary

- **Arbitrary file read via `/api/file`**: The endpoint accepted any filesystem path without restriction. Now validates that resolved paths are within allowed project directories, returning 403 otherwise.
- **Wildcard CORS policy**: Changed `allow_origins=["*"]` to localhost-only origins, preventing cross-origin exfiltration attacks from malicious websites.
- **Cypher injection in bundle import**: Node labels and relationship types from `.cgc` bundle JSONL files were interpolated directly into Cypher queries via f-strings. Added identifier validation (`^[A-Za-z_][A-Za-z0-9_]*$`) before interpolation.
- **Zip-slip in bundle extraction**: `extractall()` was called without validating member paths. Added path traversal check to ensure no ZIP entry escapes the extraction directory.

## Test plan

- [ ] Verify `/api/file` returns 403 for paths outside the project directory (e.g., `/etc/passwd`)
- [ ] Verify `/api/file` still serves files within the visualized project directory
- [ ] Verify CORS blocks requests from non-localhost origins
- [ ] Verify importing a valid `.cgc` bundle still works
- [ ] Verify importing a bundle with malicious labels (e.g., containing `}`) is rejected with a warning
- [ ] Verify importing a bundle with path-traversal ZIP entries raises `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)