### PR TITLE
Fix post-install link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ pip install codegraphcontext
 
 ### If 'cgc' command isn't found, run our one-line fix:
 ```
-curl -sSL [https://raw.githubusercontent.com/CodeGraphContext/CodeGraphContext/main/scripts/post_install_fix.sh](https://raw.githubusercontent.com/CodeGraphContext/CodeGraphContext/main/scripts/post_install_fix.sh) | bash
+curl -sSL https://raw.githubusercontent.com/CodeGraphContext/CodeGraphContext/main/scripts/post_install_fix.sh | bash
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,7 +203,7 @@ pip install codegraphcontext
 
 ### 如果找不到 'cgc' 命令，请运行我们的一键修复：
 ```
-curl -sSL [https://raw.githubusercontent.com/CodeGraphContext/CodeGraphContext/main/scripts/post_install_fix.sh](https://raw.githubusercontent.com/CodeGraphContext/CodeGraphContext/main/scripts/post_install_fix.sh) | bash
+curl -sSL https://raw.githubusercontent.com/CodeGraphContext/CodeGraphContext/main/scripts/post_install_fix.sh | bash
 ```
 
 ---


### PR DESCRIPTION
Fix URL of `post_install_fix.sh` in the quick start section.

(I've noticed that Korean translation is not affected and it uses different command for unix and windows)