### PR TITLE
fix(cpp): fix NameError in _find_enums crashing enum parsing

### DIFF
--- a/src/codegraphcontext/tools/languages/cpp.py
+++ b/src/codegraphcontext/tools/languages/cpp.py
@@ -270,6 +270,7 @@ class CppTreeSitterParser:
         query_str = CPP_QUERIES['enums']
         for node, capture_name in execute_query(self.language, query_str, root_node):
             if capture_name == 'name':
+                name = self._get_node_text(node)
                 enum_node = node.parent
                 enum_data = {
                     "name": name,

--- a/tests/unit/parsers/test_cpp_enums.py
+++ b/tests/unit/parsers/test_cpp_enums.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.tools.languages.cpp import CppTreeSitterParser
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+@pytest.fixture(scope="module")
+def cpp_parser():
+    manager = get_tree_sitter_manager()
+    if not manager.is_language_available("cpp"):
+        pytest.skip("C++ tree-sitter grammar is not available in this environment")
+
+    wrapper = MagicMock()
+    wrapper.language_name = "cpp"
+    wrapper.language = manager.get_language_safe("cpp")
+    wrapper.parser = manager.create_parser("cpp")
+    return CppTreeSitterParser(wrapper)
+
+
+def test_enum_parsing(cpp_parser, temp_test_dir):
+    code = """
+enum Color { RED, GREEN, BLUE };
+
+enum class Status { OK = 0, ERROR = 1 };
+"""
+    f = temp_test_dir / "enums.cpp"
+    f.write_text(code)
+    result = cpp_parser.parse(f)
+
+    enum_names = [e["name"] for e in result.get("enums", [])]
+    assert "Color" in enum_names
+    assert "Status" in enum_names
+
+
+def test_file_with_enums_and_classes(cpp_parser, temp_test_dir):
+    """Ensure files containing both enums and classes parse without errors."""
+    code = """
+enum DataType { INT = 0, VARCHAR = 1 };
+
+class Foo {
+public:
+    void bar() {}
+};
+"""
+    f = temp_test_dir / "mixed.cpp"
+    f.write_text(code)
+    result = cpp_parser.parse(f)
+
+    assert any(c["name"] == "Foo" for c in result["classes"])
+    assert any(e["name"] == "DataType" for e in result.get("enums", []))


### PR DESCRIPTION
## Summary

- Fix a `NameError` in `CppTreeSitterParser._find_enums()` where `name` was referenced before assignment
- This caused **any C++ file containing an enum to silently fail parsing**, dropping all its classes, functions, and other nodes from the graph
- The graph builder catches parse exceptions silently, so this bug was invisible — files were just missing from the index

## Root Cause

In `src/codegraphcontext/tools/languages/cpp.py`, line 275:

```python
enum_data = {
    "name": name,  # NameError: 'name' is not defined
```

The fix adds `name = self._get_node_text(node)` before use — matching the pattern used in `_find_structs`, `_find_unions`, and other sibling methods.

## Impact

On a real C++ codebase (300 files), this single fix increased indexed nodes significantly because most important C++ headers contain enums. Files like `queueelement.h` (with status/error enums) were completely missing from the graph.

## Tests

Added `tests/unit/parsers/test_cpp_enums.py` with 2 tests:
- `test_enum_parsing` — verifies enum names are extracted
- `test_file_with_enums_and_classes` — verifies files with both enums and classes parse completely

🤖 Generated with [Claude Code](https://claude.com/claude-code)