### PR TITLE
fix: address security findings (Zip Slip, importlib, pytest dep)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "tree-sitter>=0.21.0",
     "tree-sitter-language-pack>=0.6.0",
     "pyyaml",
-    "pytest",
     "nbformat",
     "nbconvert>=7.16.6",
     "pathspec>=0.12.1",

--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -161,9 +161,13 @@ class CGCBundle:
             with tempfile.TemporaryDirectory() as temp_dir:
                 temp_path = Path(temp_dir)
                 
-                # Step 1: Extract ZIP
+                # Step 1: Extract ZIP (with Zip Slip protection)
                 info_logger("Extracting bundle...")
                 with zipfile.ZipFile(bundle_path, 'r') as zip_ref:
+                    for entry in zip_ref.namelist():
+                        resolved = (temp_path / entry).resolve()
+                        if not str(resolved).startswith(str(temp_path.resolve())):
+                            return False, f"Zip Slip detected: entry '{entry}' escapes target directory"
                     zip_ref.extractall(temp_path)
                 
                 # Step 2: Validate bundle

--- a/src/codegraphcontext/tools/package_resolver.py
+++ b/src/codegraphcontext/tools/package_resolver.py
@@ -1,5 +1,5 @@
 # src/codegraphcontext/tools/package_resolver.py
-import importlib
+import importlib.util
 import stdlibs
 from pathlib import Path
 import subprocess
@@ -10,25 +10,27 @@ from ..utils.debug_log import debug_log
 def _get_python_package_path(package_name: str) -> Optional[str]:
     """
     Finds the local installation path of a Python package.
+    Uses importlib.util.find_spec() to locate the module without executing its code.
     """
     try:
         debug_log(f"Getting local path for Python package: {package_name}")
-        module = importlib.import_module(package_name)
-        if hasattr(module, '__file__') and module.__file__:
-            module_file = Path(module.__file__)
+        spec = importlib.util.find_spec(package_name)
+        if spec is None:
+            return None
+        if spec.origin and spec.origin != "frozen":
+            module_file = Path(spec.origin)
             if module_file.name == '__init__.py':
                 return str(module_file.parent)
             elif package_name in stdlibs.module_names:
                 return str(module_file)
             else:
                 return str(module_file.parent)
-        elif hasattr(module, '__path__'):
-            if isinstance(module.__path__, list) and module.__path__:
-                return str(Path(module.__path__[0]))
-            else:
-                return str(Path(str(module.__path__)))
+        elif spec.submodule_search_locations:
+            locations = list(spec.submodule_search_locations)
+            if locations:
+                return str(Path(locations[0]))
         return None
-    except ImportError:
+    except (ModuleNotFoundError, ValueError):
         return None
     except Exception as e:
         debug_log(f"Error getting local path for {package_name}: {e}")


### PR DESCRIPTION
## Summary

Addresses three security findings from a third-party review:

- **Replace `importlib.import_module()` with `importlib.util.find_spec()`** in `package_resolver.py` — locates Python packages without executing module-level code, eliminating a privilege escalation vector where a malicious installed package could achieve arbitrary code execution by being named in an `add_package_to_graph` call
- **Add Zip Slip validation to `cgc_bundle.py`** — validates that all zip entries resolve within the target directory before `extractall()`, preventing path-traversal attacks via malicious `.cgc` bundle files
- **Remove `pytest` from production dependencies** in `pyproject.toml` — it was already listed in `[project.optional-dependencies] dev` where it belongs; having it in production deps unnecessarily increases the attack surface

## Test plan

- [ ] Verify `add_package_to_graph` still correctly resolves Python package paths (e.g., `requests`, `numpy`)
- [ ] Verify `cgc load` / `load_bundle` MCP tool still works with valid `.cgc` bundles
- [ ] Verify that a bundle with `../` path entries is rejected
- [ ] Verify `pip install .` succeeds without `pytest` in production deps
- [ ] Run existing test suite: `pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)