### PR TITLE
fix: Add missing requests dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "nbconvert>=7.16.6",
     "pathspec>=0.12.1",
     "falkordb>=0.1.0",
+    "requests>=2.28.0",
     "falkordblite>=0.1.0; sys_platform != 'win32' and python_version >= '3.12'",
     "fastapi>=0.100.0",
     "uvicorn>=0.22.0"


### PR DESCRIPTION
## Summary
- `bundle_registry.py` and `registry_commands.py` import `requests` but it was never declared in `pyproject.toml`
- This causes `load_bundle` and `search_registry_bundles` MCP tools to fail with `ModuleNotFoundError: No module named 'requests'` when installed in a clean environment (e.g. Docker container)
- Adds `requests>=2.28.0` to the dependencies list

## Test plan
- [ ] `pip install -e .` in a clean venv and verify `import requests` works
- [ ] Run `search_registry_bundles` tool and confirm it no longer errors with missing module
- [ ] Run `load_bundle` tool and confirm registry download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)