### PR TITLE
fix: restrict /api/file endpoint to repository directory (CWE-22 path traversal)

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -344,7 +344,7 @@ def cypher_helper_visual(query: str):
 
 import uvicorn
 import urllib.parse
-from ..viz.server import run_server, set_db_manager
+from ..viz.server import run_server, set_db_manager, set_allowed_base_dir
 
 def visualize_helper(repo_path: Optional[str] = None, port: int = 8000):
     """"Generates an interactive visualization using the Playground UI."""
@@ -356,6 +356,12 @@ def visualize_helper(repo_path: Optional[str] = None, port: int = 8000):
     
     # Set the DB manager for the server
     set_db_manager(db_manager)
+
+    # Restrict /api/file reads to the repository being visualized (or cwd)
+    if repo_path:
+        set_allowed_base_dir(str(Path(repo_path).resolve()))
+    else:
+        set_allowed_base_dir(str(Path.cwd()))
     
     # Determine the static directory (built React app)
     # This points to src/codegraphcontext/viz/dist where we build the website

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -26,10 +26,35 @@ app.add_middleware(
 db_manager: Optional[DatabaseManager] = None
 # Path to static directory
 _static_dir: Optional[str] = None
+# Allowed base directory for /api/file reads (security: path traversal prevention)
+_allowed_base_dir: Optional[str] = None
 
 def set_db_manager(manager: DatabaseManager):
     global db_manager
     db_manager = manager
+
+def set_allowed_base_dir(base_dir: Optional[str]):
+    """Set the allowed base directory for file reads via /api/file.
+
+    Only files whose resolved path falls within this directory (after
+    symlink resolution) will be served. If *base_dir* is ``None``, all
+    file-read requests will be rejected with 403.
+    """
+    global _allowed_base_dir
+    _allowed_base_dir = str(Path(base_dir).resolve()) if base_dir else None
+
+def _is_path_within_base(file_path: Path, base_dir: str) -> bool:
+    """Return True if *file_path* resolves to a location inside *base_dir*.
+
+    Uses ``Path.resolve()`` to canonicalise both paths (resolving symlinks
+    and ``..`` components) so that traversal and symlink-escape attacks are
+    blocked.
+    """
+    try:
+        resolved = file_path.resolve()
+        return resolved.is_relative_to(Path(base_dir).resolve())
+    except (OSError, ValueError):
+        return False
 
 @app.get("/api/graph")
 async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str] = None):
@@ -235,12 +260,19 @@ async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str]
 
 @app.get("/api/file")
 async def get_file(path: str):
+    if not _allowed_base_dir:
+        raise HTTPException(status_code=403, detail="File serving is not configured")
+
     file_path = Path(path)
-    if not file_path.exists():
+    if not _is_path_within_base(file_path, _allowed_base_dir):
+        raise HTTPException(status_code=403, detail="Access denied: path is outside the allowed directory")
+
+    resolved_path = file_path.resolve()
+    if not resolved_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
     
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(resolved_path, "r", encoding="utf-8") as f:
             return {"content": f.read()}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_cwe22_path_traversal.py
+++ b/tests/test_cwe22_path_traversal.py
@@ -1,0 +1,97 @@
+"""
+PoC test for CWE-22: Arbitrary file read via viz server /api/file endpoint.
+
+The /api/file endpoint previously accepted a ``path`` query parameter and
+read any file from the filesystem without path validation.  This test suite
+confirms that:
+
+1. Files within the configured base directory are served normally.
+2. Absolute paths outside the base directory are rejected with 403.
+3. ``..`` traversal sequences that escape the base directory are blocked.
+4. Symlinks pointing outside the base directory are blocked.
+5. When no base directory is configured, all reads are rejected.
+6. Relative paths (which could resolve anywhere) are rejected.
+"""
+import os
+import pytest
+
+from codegraphcontext.viz.server import app
+
+
+@pytest.fixture
+def base_dir(tmp_path):
+    """Create a temporary base directory with sample files."""
+    (tmp_path / "allowed.txt").write_text("allowed content")
+
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    (subdir / "nested.txt").write_text("nested content")
+
+    return tmp_path
+
+
+@pytest.fixture
+def client(base_dir):
+    """Return a TestClient whose /api/file is restricted to *base_dir*."""
+    from fastapi.testclient import TestClient
+    from codegraphcontext.viz import server as srv
+
+    srv._allowed_base_dir = str(base_dir)
+    yield TestClient(app)
+    srv._allowed_base_dir = None          # clean up
+
+
+class TestPathTraversal:
+    """Verify the /api/file endpoint blocks path-traversal attacks."""
+
+    def test_read_allowed_file(self, client, base_dir):
+        """Reading a file inside the allowed base dir works."""
+        resp = client.get("/api/file", params={"path": str(base_dir / "allowed.txt")})
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "allowed content"
+
+    def test_read_nested_allowed_file(self, client, base_dir):
+        """Reading a nested file inside the allowed base dir works."""
+        resp = client.get("/api/file", params={"path": str(base_dir / "sub" / "nested.txt")})
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "nested content"
+
+    def test_absolute_path_outside_base(self, client):
+        """Absolute path pointing outside the base dir → 403."""
+        resp = client.get("/api/file", params={"path": "/etc/passwd"})
+        assert resp.status_code == 403
+
+    def test_traversal_via_dotdot(self, client, base_dir):
+        """Path with ``..`` components escaping the base dir → 403."""
+        traversal = str(base_dir / "sub" / ".." / ".." / "etc" / "passwd")
+        resp = client.get("/api/file", params={"path": traversal})
+        assert resp.status_code == 403
+
+    def test_symlink_escape(self, client, base_dir):
+        """Symlink inside base_dir targeting an external file → 403."""
+        link = base_dir / "escape_link"
+        try:
+            os.symlink("/etc/passwd", str(link))
+        except (OSError, NotImplementedError):
+            pytest.skip("Cannot create symlinks on this platform")
+
+        resp = client.get("/api/file", params={"path": str(link)})
+        assert resp.status_code == 403
+
+    def test_no_base_dir_configured(self):
+        """When no base directory is set, all reads → 403."""
+        from fastapi.testclient import TestClient
+        from codegraphcontext.viz import server as srv
+
+        old = srv._allowed_base_dir
+        try:
+            srv._allowed_base_dir = None
+            resp = TestClient(app).get("/api/file", params={"path": "/etc/passwd"})
+            assert resp.status_code == 403
+        finally:
+            srv._allowed_base_dir = old
+
+    def test_relative_path(self, client):
+        """Relative paths (resolve to unpredictable locations) → 403."""
+        resp = client.get("/api/file", params={"path": "../../etc/passwd"})
+        assert resp.status_code == 403


### PR DESCRIPTION
## Vulnerability Summary

**CWE-22: Improper Limitation of a Pathname to a Restricted Directory (Path Traversal)**
**Severity: High**

### Data Flow

1. The `/api/file` endpoint in `src/codegraphcontext/viz/server.py` accepts a `path` query parameter directly from the HTTP request.
2. This parameter is passed to `Path(path)` and then `open(file_path, "r")` with **zero validation or sanitization**.
3. An attacker can supply any absolute path (e.g. `/etc/passwd`, `~/.ssh/id_rsa`, `~/.aws/credentials`) or relative path with `..` traversal to read arbitrary files on the filesystem.

### Exploitability

Although the server binds to `127.0.0.1:8000` (localhost only), CORS is configured with `allow_origins=["*"]`, which means **any website the developer visits can make cross-origin requests** to the endpoint and read responses. This effectively allows browser-based exfiltration:

```javascript
// Malicious JS on any website while developer runs cgc visualize
const resp = await fetch("http://localhost:8000/api/file?path=/etc/passwd");
const data = await resp.json(); // contains file contents
```

Or directly:
```bash
curl "http://localhost:8000/api/file?path=/etc/passwd"
curl "http://localhost:8000/api/file?path=/home/user/.ssh/id_rsa"
curl "http://localhost:8000/api/file?path=/home/user/.aws/credentials"
```

---

## Fix Description

This PR restricts the `/api/file` endpoint to only serve files within the repository directory being visualized. The changes are minimal and targeted:

### `src/codegraphcontext/viz/server.py`
- Added `_allowed_base_dir` module-level variable and `set_allowed_base_dir()` setter.
- Added `_is_path_within_base()` helper that uses `Path.resolve()` to canonicalize both the requested path and the base directory (resolving symlinks and `..` components), then checks `is_relative_to()`.
- The `/api/file` handler now:
  - Returns 403 if no base directory is configured.
  - Returns 403 if the resolved path falls outside the allowed base directory.
  - Opens the `resolved` path (not the raw user input) for reading.

### `src/codegraphcontext/cli/cli_helpers.py`
- Calls `set_allowed_base_dir()` in `visualize_helper()` with the resolved repo path (or `cwd` as fallback) before starting the server.

### Rationale
- `Path.resolve()` handles `..`, `.`, and symlinks, preventing traversal and symlink-escape attacks.
- `is_relative_to()` is the standard Python 3.9+ method for safe path containment checks.
- The allowed directory is the repository being visualized, which is exactly the intended scope of this endpoint.

---

## Test Results

Added `tests/test_cwe22_path_traversal.py` with 7 test cases:

| Test | Description | Result |
|------|-------------|--------|
| `test_read_allowed_file` | File inside base dir → 200 | ✅ Pass |
| `test_read_nested_allowed_file` | Nested file inside base dir → 200 | ✅ Pass |
| `test_absolute_path_outside_base` | `/etc/passwd` → 403 | ✅ Pass |
| `test_traversal_via_dotdot` | `sub/../../etc/passwd` → 403 | ✅ Pass |
| `test_symlink_escape` | Symlink to `/etc/passwd` inside base dir → 403 | ✅ Pass |
| `test_no_base_dir_configured` | No base dir set → 403 | ✅ Pass |
| `test_relative_path` | `../../etc/passwd` → 403 | ✅ Pass |

---

## Disprove Analysis

We systematically attempted to invalidate this finding:

### Authentication Check
No authentication exists on the `/api/file` endpoint. No `login_required`, `@auth`, `Bearer`, `api_key`, or any authentication middleware was found.

### Network Check
The server binds to `127.0.0.1:8000`, so it is not directly reachable from the network. However, CORS `allow_origins=["*"]` means any website can make cross-origin requests to the localhost endpoint and read responses, effectively negating localhost-only binding as a security control.

### Deployment Check
- The visualizer is a developer tool started manually via `cgc visualize`
- Dockerfile exposes port 8080 for CLI use; docker-compose has no port mapping for the viz server
- This limits exposure to when a developer actively uses the tool

### Caller Trace
`/api/file` is only exposed as an HTTP endpoint — no internal Python callers. The `path` parameter comes directly from the HTTP request with zero validation.

### Input Validation Check
No input validation, sanitization, escaping, or allowlisting exists in the original `server.py`.

### Prior Reports
Two open security-related issues (#664, #753) exist but none cover this specific path traversal.

### Fix Adequacy — Parallel Path Analysis
- The SPA fallback handler uses Starlette URL normalization, making traversal difficult (different code path).
- The `/api/graph` endpoint has Cypher injection risk (`session.run(cypher_query)` with raw user input) — this is a **separate vulnerability** of a different class.
- **No parallel code path provides equivalent arbitrary file-read access.** The fix is not cosmetic.

### Verdict: **CONFIRMED_VALID** (High Confidence)

The vulnerability is a textbook CWE-22 path traversal with zero input validation on a file-read endpoint. The CORS wildcard makes it exploitable via browser-based attacks despite localhost binding. The fix correctly restricts reads to the repository directory using `Path.resolve()` + `is_relative_to()`.

---

## Additional Recommendations

These are separate from this PR but worth noting:
1. **Tighten CORS** to localhost origins only instead of `allow_origins=["*"]`
2. **Address Cypher injection** in `/api/graph` (separate finding, different CWE)
3. **Add `is_relative_to` check** to the SPA fallback handler as defense-in-depth