### PR TITLE
fix: find_callers returns 0 without context + eliminate false edges + TS crash

### DIFF
--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -404,12 +404,12 @@ class CodeFinder:
                     results = result.data()
             else:
                 result = session.run(f"""
-                    MATCH (caller:Function)-[call:CALLS]->(target:Function {{name: $function_name}})
-                    WHERE 1=1 {repo_filter}
+                    MATCH (caller)-[call:CALLS]->(target:Function {{name: $function_name}})
+                    WHERE (caller:Function OR caller:Class OR caller:File) {repo_filter}
                     OPTIONAL MATCH (caller_file:File)-[:CONTAINS]->(caller)
                     RETURN DISTINCT
                         caller.name as caller_function,
-                        caller.path as caller_file_path,
+                        COALESCE(caller.path, caller_file.path) as caller_file_path,
                         caller.line_number as caller_line_number,
                         caller.docstring as caller_docstring,
                         caller.is_dependency as caller_is_dependency,
@@ -418,7 +418,7 @@ class CodeFinder:
                         call.full_call_name as full_call_name,
                         target.path as target_file_path
                 ORDER BY caller_is_dependency ASC, caller_file_path, caller_line_number
-                    LIMIT 20
+                    LIMIT 50
                 """, function_name=function_name, repo_path=repo_path)
                 results = result.data()
             

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -290,6 +290,11 @@ class GraphWriter:
                             }
                         )
                 else:
+                    # Ensure full_import_name is always present — some language parsers
+                    # (e.g. TypeScript, JavaScript) omit it, causing KuzuDB to throw
+                    # "Invalid struct field name: full_import_name" on UNWIND.
+                    if "full_import_name" not in imp:
+                        imp["full_import_name"] = imp.get("source") or imp.get("name", "")
                     other_imports.append(imp)
 
             if js_imports:

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -87,7 +87,10 @@ def resolve_function_call(
             if not resolved_path:
                 resolved_path = candidates[0]
         else:
-            resolved_path = caller_file_path
+            # Cannot resolve target — skip rather than create a false
+            # self-referencing CALLS edge.  Legitimate same-file calls are
+            # already caught earlier by the local_names check (lines 36, 74).
+            return None
 
     if skip_external and is_unresolved_external:
         return None


### PR DESCRIPTION
## Summary

Three bugs found during real-world usage indexing a 220-file Python codebase (2,500+ functions) with KuzuDB backend.

### Bug 1: `find_callers` returns 0 results without `context` parameter

**File:** `tools/code_finder.py:406-422`

The no-context branch of `who_calls_function` restricted callers to `Function` nodes only:
```cypher
MATCH (caller:Function)-[call:CALLS]->(target:Function {name: $function_name})
```

But the with-context branch (line 368) correctly allows all caller types:
```cypher
MATCH (caller)-[call:CALLS]->(target:Function {name: $function_name, path: $path})
WHERE (caller:Function OR caller:Class OR caller:File)
```

This caused `find_callers` to miss callers from class methods and module-level code when `context` was omitted.

**Fix:** Match all caller types + use `COALESCE(caller.path, caller_file.path)` (consistent with the with-context branch) + increase LIMIT from 20 to 50 for no-context queries.

**Before:** `find_callers("update_character_info")` → 0 results
**After:** `find_callers("update_character_info")` → 14 results across 5 files

### Bug 2: False self-referencing CALLS edges from resolution fallback

**File:** `tools/indexing/resolution/calls.py:89-90`

When call resolution fails entirely (function name not in `imports_map` and not in `local_names`), the fallback created a false self-referencing edge:
```python
else:
    resolved_path = caller_file_path  # Creates false edge to caller's own file
```

Legitimate same-file calls are already caught earlier by `local_names` checks at lines 36 and 74. This `else` branch only fires when the system has zero information about the target — assigning `caller_file_path` fabricates an edge with no evidence.

**Fix:** Return `None` instead of creating a false edge. `build_function_call_groups` (line 163) already handles `None` returns with `if not resolved: continue`.

### Bug 3: KuzuDB crash on TypeScript/JavaScript imports

**File:** `tools/indexing/persistence/writer.py:293`

TypeScript and JavaScript parsers don't include `full_import_name` in their import dicts, but the `other_imports` Cypher query references `row.full_import_name` in the UNWIND. KuzuDB throws "Invalid struct field name: full_import_name" and kills the entire indexing job.

**Fix:** Normalize `other_imports` to always include `full_import_name`, falling back to `source` or `name`.

## Testing

- Indexed a 220-file Python codebase (2,518 functions, 89 classes)
- Verified `find_callers` without context returns correct cross-file results
- Verified with-context queries still return identical results
- Verified TypeScript repos index without crashing (tested on a mixed Python/TS project)
- Two independent code review agents validated Fix 1 (confidence 95) and Fix 2 (confidence 97)

## Environment

- CodeGraphContext 0.4.2
- Database: KuzuDB
- Python 3.10, Ubuntu 22.04 WSL2