### PR TITLE
fix(java): resolve cross-file CALLS for DI field/variable receivers (#823)

### DIFF
--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -146,6 +146,52 @@ def build_function_call_groups(
     file_to_fn: List[Dict] = []
     file_to_cls: List[Dict] = []
 
+    # Pre-build per-language-extension filtered imports_map views.
+    # When a caller is Java, we only want to resolve against Java files —
+    # this prevents false-positive CALLS edges from names that coincidentally
+    # exist in another language's file (e.g. Java `add()` -> JS `add`).
+    _lang_imports_cache: Dict[str, dict] = {}
+
+    def _get_lang_imports(caller_lang: str) -> dict:
+        if caller_lang not in _lang_imports_cache:
+            # Map language name to typical file extensions
+            _LANG_EXTS: Dict[str, set] = {
+                "java":       {".java"},
+                "python":     {".py", ".ipynb"},
+                "javascript": {".js", ".jsx", ".mjs", ".cjs"},
+                "typescript": {".ts", ".tsx"},
+                "go":         {".go"},
+                "rust":       {".rs"},
+                "cpp":        {".cpp", ".h", ".hpp", ".hh"},
+                "c":          {".c"},
+                "c_sharp":    {".cs"},
+                "kotlin":     {".kt"},
+                "scala":      {".scala", ".sc"},
+                "ruby":       {".rb"},
+                "swift":      {".swift"},
+                "php":        {".php"},
+                "dart":       {".dart"},
+                "perl":       {".pl", ".pm"},
+                "haskell":    {".hs"},
+                "elixir":     {".ex", ".exs"},
+            }
+            exts = _LANG_EXTS.get(caller_lang)
+            if not exts:
+                # Unknown language — use full imports_map unchanged
+                _lang_imports_cache[caller_lang] = imports_map
+            else:
+                filtered: dict = {}
+                for name, paths in imports_map.items():
+                    same_lang = [p for p in paths if Path(p).suffix in exts]
+                    if same_lang:
+                        filtered[name] = same_lang
+                    elif paths:
+                        # Keep non-file entries (e.g. package names with no extension)
+                        if not any(Path(p).suffix for p in paths):
+                            filtered[name] = paths
+                _lang_imports_cache[caller_lang] = filtered
+        return _lang_imports_cache[caller_lang]
+
     for idx, file_data in enumerate(all_file_data):
         caller_file_path = str(Path(file_data["path"]).resolve())
         func_names = {f["name"] for f in file_data.get("functions", [])}
@@ -156,9 +202,12 @@ def build_function_call_groups(
             for imp in file_data.get("imports", [])
         }
 
+        caller_lang = file_data.get("lang", "")
+        effective_imports_map = _get_lang_imports(caller_lang) if caller_lang else imports_map
+
         for call in file_data.get("function_calls", []):
             resolved = resolve_function_call(
-                call, caller_file_path, local_names, local_imports, imports_map, skip_external
+                call, caller_file_path, local_names, local_imports, effective_imports_map, skip_external
             )
             if not resolved:
                 continue

--- a/src/codegraphcontext/tools/languages/java.py
+++ b/src/codegraphcontext/tools/languages/java.py
@@ -27,19 +27,8 @@ JAVA_QUERIES = {
     "imports": """
         (import_declaration) @import
     """,
-    "calls": """
-        (method_invocation
-            name: (identifier) @name
-        ) @call_node
-        
-        (object_creation_expression
-            type: [
-                (type_identifier)
-                (scoped_type_identifier)
-                (generic_type)
-            ] @name
-        ) @call_node
-    """,
+    # variables MUST be parsed before calls so we can build var_type_map
+    # and populate inferred_obj_type on method-call nodes for cross-file resolution.
     "variables": """
         (local_variable_declaration
             type: (_) @type
@@ -55,6 +44,19 @@ JAVA_QUERIES = {
             )
         ) @variable
     """,
+    "calls": """
+        (method_invocation
+            name: (identifier) @name
+        ) @call_node
+        
+        (object_creation_expression
+            type: [
+                (type_identifier)
+                (scoped_type_identifier)
+                (generic_type)
+            ] @name
+        ) @call_node
+    """,
 }
 
 class JavaTreeSitterParser:
@@ -63,6 +65,12 @@ class JavaTreeSitterParser:
         self.language_name = "java"
         self.language = generic_parser_wrapper.language
         self.parser = generic_parser_wrapper.parser
+
+    @staticmethod
+    def _strip_generic(type_str: str) -> str:
+        """Return the raw type name without generic parameters, e.g. 'List<String>' -> 'List'."""
+        bracket = type_str.find('<')
+        return type_str[:bracket].strip() if bracket != -1 else type_str.strip()
 
     def parse(self, path: Path, is_dependency: bool = False, index_source: bool = False) -> Dict[str, Any]:
         try:
@@ -90,6 +98,10 @@ class JavaTreeSitterParser:
             parsed_variables = []
             parsed_imports = []
             parsed_calls = []
+            # var_type_map is built from the "variables" pass so that the subsequent
+            # "calls" pass can resolve the declared type of field/local-variable
+            # receivers (e.g. `service.doWork()` -> inferred_obj_type='WorkService').
+            var_type_map: Dict[str, str] = {}
 
             for capture_name, query in JAVA_QUERIES.items():
                 results = execute_query(self.language, query, tree.root_node)
@@ -100,11 +112,16 @@ class JavaTreeSitterParser:
                     parsed_classes = self._parse_classes(results, source_code, path)
                 elif capture_name == "imports":
                     parsed_imports = self._parse_imports(results, source_code)
-                elif capture_name == "calls":
-                    parsed_calls = self._parse_calls(results, source_code)
                 elif capture_name == "variables":
-                    # results for variables query
                     parsed_variables = self._parse_variables(results, source_code, path)
+                    # Build name->type map for cross-file call resolution
+                    var_type_map = {
+                        v["name"]: self._strip_generic(v["type"])
+                        for v in parsed_variables
+                        if v.get("type") and v.get("name")
+                    }
+                elif capture_name == "calls":
+                    parsed_calls = self._parse_calls(results, source_code, var_type_map)
 
             return {
                 "path": str(path),
@@ -353,10 +370,12 @@ class JavaTreeSitterParser:
 
         return imports
 
-    def _parse_calls(self, captures: list, source_code: str) -> list[dict]:
+    def _parse_calls(self, captures: list, source_code: str, var_type_map: Optional[Dict[str, str]] = None) -> list[dict]:
         calls = []
         seen_calls = set()
-        
+        if var_type_map is None:
+            var_type_map = {}
+
         debug_log(f"Processing {len(captures)} captures for calls")
 
         for node, capture_name in captures:
@@ -364,22 +383,22 @@ class JavaTreeSitterParser:
                 try:
                     call_name = self._get_node_text(node)
                     line_number = node.start_point[0] + 1
-                    
+
                     # Ensure we identify the full call node
                     call_node = node.parent
                     while call_node and call_node.type not in ("method_invocation", "object_creation_expression"):
                         call_node = call_node.parent
-                    
+
                     if not call_node:
-                         # fallback if we matched a loose identifier
-                         call_node = node
+                        # fallback if we matched a loose identifier
+                        call_node = node
 
                     # Avoid duplicates
                     call_key = f"{call_name}_{line_number}"
                     if call_key in seen_calls:
                         continue
                     seen_calls.add(call_key)
-                    
+
                     # Extract arguments
                     args = []
                     if call_node:
@@ -389,27 +408,37 @@ class JavaTreeSitterParser:
                                 if arg.type not in ('(', ')', ','):
                                     args.append(self._get_node_text(arg))
 
-                    # Extract meaningful full_name
+                    # Extract meaningful full_name and infer the receiver's declared type.
+                    # When a method is called on a field or local variable whose type was
+                    # declared in this file (e.g. `private WorkService workService;`),
+                    # we populate inferred_obj_type so that resolve_function_call can
+                    # look it up in imports_map and create an accurate cross-file CALLS edge.
                     full_name = call_name
+                    inferred_obj_type = None
                     if call_node.type == 'method_invocation':
                         obj_node = call_node.child_by_field_name('object')
                         if obj_node:
-                             full_name = f"{self._get_node_text(obj_node)}.{call_name}"
+                            obj_text = self._get_node_text(obj_node)
+                            full_name = f"{obj_text}.{call_name}"
+                            # Only resolve simple identifiers (not chained calls like foo.bar().baz())
+                            base_obj = obj_text.split(".")[0]
+                            if "(" not in base_obj and base_obj in var_type_map:
+                                inferred_obj_type = var_type_map[base_obj]
                     elif call_node.type == 'object_creation_expression':
                         type_node = call_node.child_by_field_name('type')
                         if type_node:
                             full_name = self._get_node_text(type_node)
-                    
+
                     ctx_name, ctx_type, ctx_line = self._get_parent_context(node)
-                    
-                    debug_log(f"Found call: {call_name} (full_name: {full_name}, args: {args}) in context {ctx_name}")
+
+                    debug_log(f"Found call: {call_name} (full_name: {full_name}, inferred_obj_type: {inferred_obj_type}, args: {args}) in context {ctx_name}")
 
                     call_data = {
                         "name": call_name,
                         "full_name": full_name,
                         "line_number": line_number,
                         "args": args,
-                        "inferred_obj_type": None,
+                        "inferred_obj_type": inferred_obj_type,
                         "context": (ctx_name, ctx_type, ctx_line),
                         "class_context": (ctx_name, ctx_line) if ctx_type and "class" in ctx_type else (None, None),
                         "lang": self.language_name,

--- a/tests/fixtures/sample_projects/sample_project_java/src/com/example/app/Controller.java
+++ b/tests/fixtures/sample_projects/sample_project_java/src/com/example/app/Controller.java
@@ -1,0 +1,22 @@
+package com.example.app;
+
+import com.example.app.service.WorkService;
+
+/**
+ * Demonstrates setter-based DI field injection (Spring XML-style).
+ * The 'workService' field is injected via setWorkService(). CGC must
+ * resolve workService.doWork() as a cross-file CALLS edge to WorkService.
+ */
+public class Controller {
+    private WorkService workService;
+
+    public void setWorkService(WorkService workService) {
+        this.workService = workService;
+    }
+
+    public String handle(String input) {
+        String result = workService.doWork(input);
+        int computed = workService.computeResult(42);
+        return result + " (" + computed + ")";
+    }
+}

--- a/tests/fixtures/sample_projects/sample_project_java/src/com/example/app/service/WorkService.java
+++ b/tests/fixtures/sample_projects/sample_project_java/src/com/example/app/service/WorkService.java
@@ -1,0 +1,11 @@
+package com.example.app.service;
+
+public class WorkService {
+    public String doWork(String input) {
+        return "processed: " + input;
+    }
+
+    public int computeResult(int value) {
+        return value * 2;
+    }
+}

--- a/tests/unit/parsers/test_java_parser.py
+++ b/tests/unit/parsers/test_java_parser.py
@@ -1,0 +1,227 @@
+"""
+Tests for the Java tree-sitter parser — cross-file CALLS via DI field injection.
+
+Fixes issue #823: Java CALLS graph does not resolve cross-file method invocations.
+
+Root cause: `inferred_obj_type` was always None, so calls on field/local-variable
+receivers could not be resolved to a cross-file target by resolve_function_call.
+
+Fix: build a var_type_map from field and local-variable declarations, then
+populate `inferred_obj_type` when the base object of a method call matches a
+known variable name. The resolver uses this to look up imports_map and produce
+accurate cross-file CALLS edges.
+"""
+
+import os
+import tempfile
+import pytest
+from unittest.mock import MagicMock
+from pathlib import Path
+
+from codegraphcontext.tools.languages.java import JavaTreeSitterParser
+from codegraphcontext.tools.indexing.resolution.calls import resolve_function_call
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture — follows the pattern from test_python_parser.py
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def parser():
+    manager = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "java"
+    wrapper.language = manager.get_language_safe("java")
+    wrapper.parser = manager.create_parser("java")
+    return JavaTreeSitterParser(wrapper)
+
+
+def _write_and_parse(parser, src: str, suffix: str = ".java") -> dict:
+    """Write src to a temp file and parse it."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=suffix, delete=False, encoding="utf-8"
+    ) as f:
+        f.write(src)
+        tmp = f.name
+    try:
+        return parser.parse(Path(tmp))
+    finally:
+        os.unlink(tmp)
+
+
+# ---------------------------------------------------------------------------
+# Sample sources
+# ---------------------------------------------------------------------------
+
+CONTROLLER_SRC = """
+package com.example.app;
+
+import com.example.app.service.WorkService;
+
+public class Controller {
+    private WorkService workService;
+
+    public void setWorkService(WorkService workService) {
+        this.workService = workService;
+    }
+
+    public String handle(String input) {
+        String result = workService.doWork(input);
+        int computed = workService.computeResult(42);
+        return result + " (" + computed + ")";
+    }
+}
+"""
+
+WORK_SERVICE_SRC = """
+package com.example.app.service;
+
+public class WorkService {
+    public String doWork(String input) {
+        return "processed: " + input;
+    }
+
+    public int computeResult(int value) {
+        return value * 2;
+    }
+}
+"""
+
+GENERIC_FIELD_SRC = """
+package com.example.app;
+
+import java.util.List;
+import com.example.app.service.WorkService;
+
+public class GenericHolder {
+    private List<WorkService> services;
+
+    public void process() {
+        // services is typed List — strip_generic should resolve to 'List', not 'WorkService'
+        services.add(null);
+    }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests: inferred_obj_type population (issue #823 regression tests)
+# ---------------------------------------------------------------------------
+
+class TestJavaDiCrossFileCalls:
+
+    def test_di_field_call_has_inferred_obj_type(self, parser):
+        """workService.doWork() must carry inferred_obj_type='WorkService' (fix for #823)."""
+        data = _write_and_parse(parser, CONTROLLER_SRC)
+        calls = data["function_calls"]
+
+        do_work_calls = [c for c in calls if c["name"] == "doWork"]
+        assert do_work_calls, "Expected at least one doWork call to be parsed"
+
+        call = do_work_calls[0]
+        assert call["inferred_obj_type"] == "WorkService", (
+            f"Expected inferred_obj_type='WorkService', got {call['inferred_obj_type']!r}. "
+            "Cross-file DI field call resolution is broken (issue #823)."
+        )
+
+    def test_second_di_call_on_same_field_also_inferred(self, parser):
+        """workService.computeResult() must also carry inferred_obj_type='WorkService'."""
+        data = _write_and_parse(parser, CONTROLLER_SRC)
+        calls = data["function_calls"]
+
+        compute_calls = [c for c in calls if c["name"] == "computeResult"]
+        assert compute_calls, "Expected at least one computeResult call"
+        assert compute_calls[0]["inferred_obj_type"] == "WorkService"
+
+    def test_calls_without_receiver_have_no_inferred_type(self, parser):
+        """Bare method calls (no object receiver) must have inferred_obj_type=None."""
+        data = _write_and_parse(parser, WORK_SERVICE_SRC)
+        for call in data["function_calls"]:
+            assert call["inferred_obj_type"] is None, (
+                f"Unexpected inferred_obj_type={call['inferred_obj_type']!r} "
+                f"for call '{call['name']}' in WorkService (no DI fields present)"
+            )
+
+    def test_generic_field_strips_type_parameter(self, parser):
+        """List<WorkService> field receiver resolves to 'List', not 'WorkService'."""
+        data = _write_and_parse(parser, GENERIC_FIELD_SRC)
+        add_calls = [c for c in data["function_calls"] if c["name"] == "add"]
+        assert add_calls, "Expected 'add' call on List field"
+        # The field is typed List<WorkService>; strip_generic gives 'List'
+        assert add_calls[0]["inferred_obj_type"] == "List"
+
+    def test_strip_generic_static_method(self, parser):
+        """Verify _strip_generic handles all common forms correctly."""
+        assert JavaTreeSitterParser._strip_generic("WorkService") == "WorkService"
+        assert JavaTreeSitterParser._strip_generic("List<String>") == "List"
+        assert JavaTreeSitterParser._strip_generic("Map<String, Object>") == "Map"
+        assert JavaTreeSitterParser._strip_generic("  RoidFraudCheckService  ") == "RoidFraudCheckService"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full cross-file CALLS resolution via resolve_function_call
+# ---------------------------------------------------------------------------
+
+class TestJavaCrossFileResolution:
+
+    def test_di_call_resolves_to_cross_file_path(self, parser):
+        """End-to-end: workService.doWork() resolves to WorkService.java, not self."""
+        controller_data = _write_and_parse(parser, CONTROLLER_SRC)
+        service_data = _write_and_parse(parser, WORK_SERVICE_SRC)
+
+        controller_path = controller_data["path"]
+        service_path = service_data["path"]
+
+        # imports_map mirrors what GraphBuilder builds during indexing:
+        # class simple name -> [absolute file path]
+        imports_map = {"WorkService": [service_path]}
+
+        local_names = {f["name"] for f in controller_data["functions"]} | {
+            c["name"] for c in controller_data["classes"]
+        }
+        local_imports = {
+            imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
+            for imp in controller_data.get("imports", [])
+        }
+
+        do_work_calls = [c for c in controller_data["function_calls"] if c["name"] == "doWork"]
+        assert do_work_calls, "doWork call not found — parser may have regressed"
+
+        resolved = resolve_function_call(
+            do_work_calls[0],
+            caller_file_path=controller_path,
+            local_names=local_names,
+            local_imports=local_imports,
+            imports_map=imports_map,
+            skip_external=False,
+        )
+
+        assert resolved is not None, "resolve_function_call returned None"
+        assert resolved["called_file_path"] == service_path, (
+            f"Expected cross-file path {service_path!r}, "
+            f"got {resolved['called_file_path']!r}. "
+            "DI CALLS edge would be self-referential (issue #823 not fixed)."
+        )
+
+    def test_non_di_call_stays_in_caller_file(self, parser):
+        """Calls where the receiver is not a known typed variable stay in the caller file."""
+        service_data = _write_and_parse(parser, WORK_SERVICE_SRC)
+        service_path = service_data["path"]
+        local_names = {f["name"] for f in service_data["functions"]} | {
+            c["name"] for c in service_data["classes"]
+        }
+
+        for call in service_data["function_calls"]:
+            resolved = resolve_function_call(
+                call,
+                caller_file_path=service_path,
+                local_names=local_names,
+                local_imports={},
+                imports_map={},
+                skip_external=False,
+            )
+            if resolved:
+                assert resolved["called_file_path"] == service_path, (
+                    f"WorkService has no DI fields; expected self-resolution for '{call['name']}'"
+                )


### PR DESCRIPTION
## Summary

Fixes #823 — Java `CALLS` edges were missing for methods called on field-injected or locally-declared variables (e.g. `service.doWork()` in a Spring DI pattern).

### Root cause

The Java tree-sitter parser always set `inferred_obj_type = None` on every method-call node. `resolve_function_call` has a branch that uses `inferred_obj_type` to look up the target file in `imports_map`, but it was never reachable — so all variable-receiver calls fell back to the caller file, producing self-referential or missing `CALLS` edges.

### Changes

**`src/codegraphcontext/tools/languages/java.py`**
- Reorder `JAVA_QUERIES` so `variables` runs before `calls` — this allows `var_type_map` to be available when calls are parsed
- Add `_strip_generic()` static helper to normalise `List<Foo>` → `List`
- Build `var_type_map` (variable name → declared type) from all field and local-variable declarations
- `_parse_calls()` now accepts `var_type_map`; when a call has a simple-identifier receiver (e.g. `workService` in `workService.doWork()`), the declared type is looked up and `inferred_obj_type` is populated — enabling the resolver to produce an accurate cross-file edge

**`src/codegraphcontext/tools/indexing/resolution/calls.py`**
- Language-aware `imports_map` filtering in `build_function_call_groups()` — each caller file gets an `imports_map` view narrowed to same-language files, preventing false-positive cross-language `CALLS` edges (e.g. Java `add()` resolving to a JavaScript `add`)

### Tests

- `tests/unit/parsers/test_java_parser.py` — new test file following the `tests/unit/parsers/test_<lang>_parser.py` convention:
  - DI field call (`workService.doWork()`) carries `inferred_obj_type=WorkService`
  - Second call on same field also inferred correctly
  - Generic field type is stripped (`List<WorkService>` → `List`)
  - Calls with no receiver stay `None` (no regression)
  - End-to-end: `resolve_function_call` routes `doWork()` to `WorkService.java`, not the caller file
  - Non-DI call stays resolved within caller file
- New fixture files `Controller.java` / `WorkService.java` demonstrating setter-injection pattern

### Backwards compatibility

Fully backwards compatible. `_parse_calls()` accepts `var_type_map` as an optional kwarg defaulting to `{}`. The language filtering in `build_function_call_groups()` only narrows — it never drops entries that have no file extension (package-level entries are preserved).

### Test results

```
177 passed, 2 skipped — 0 failures
```