### PR TITLE
fix(swift): make Swift parser produce real complexity, inheritance, and is_dependency data

### DIFF
--- a/src/codegraphcontext/tools/languages/swift.py
+++ b/src/codegraphcontext/tools/languages/swift.py
@@ -192,6 +192,40 @@ class SwiftTreeSitterParser:
         if not node: return ""
         return node.text.decode("utf-8")
 
+    def _calculate_complexity(self, node: Any) -> int:
+        """Cyclomatic complexity for a Swift function/init body.
+
+        Counts decision points: if/for/while/repeat-while/guard, each non-default
+        switch case, each catch block, boolean &&/||, and ternary `?:`.
+        """
+        decision_node_types = {
+            "if_statement",
+            "for_statement",
+            "while_statement",
+            "repeat_while_statement",
+            "guard_statement",
+            "catch_block",
+            "conjunction_expression",
+            "disjunction_expression",
+            "ternary_expression",
+        }
+        count = 1
+
+        def traverse(n: Any) -> None:
+            nonlocal count
+            t = n.type
+            if t in decision_node_types:
+                count += 1
+            elif t == "switch_entry":
+                is_default = any(c.type == "default_keyword" for c in n.children)
+                if not is_default:
+                    count += 1
+            for child in n.children:
+                traverse(child)
+
+        traverse(node)
+        return count
+
     def _parse_functions(self, captures: list, source_code: str, path: Path) -> list[Dict[str, Any]]:
         functions = []
         seen_nodes = set()
@@ -237,7 +271,8 @@ class SwiftTreeSitterParser:
                         "path": str(path),
                         "lang": self.language_name,
                         "context": context_name,
-                        "class_context": context_name if context_type and ("class" in context_type or "struct" in context_type) else None
+                        "class_context": context_name if context_type and ("class" in context_type or "struct" in context_type) else None,
+                        "cyclomatic_complexity": self._calculate_complexity(node),
                     }
                     
                     if self.index_source:

--- a/src/codegraphcontext/tools/languages/swift.py
+++ b/src/codegraphcontext/tools/languages/swift.py
@@ -313,12 +313,23 @@ class SwiftTreeSitterParser:
                     
                     source_text = self._get_node_text(node)
                     
-                    # Extract inheritance/protocol conformance
+                    # Extract inheritance/protocol conformance.
+                    # In tree-sitter-swift the bases appear as one or more
+                    # `inheritance_specifier` siblings under `class_declaration`,
+                    # each wrapping a `user_type` -> `type_identifier`. The
+                    # legacy `type_inheritance_clause` node type is not emitted
+                    # by the current grammar, so the previous logic produced
+                    # empty `bases` for every Swift type.
                     bases = []
                     for child in node.children:
-                        if child.type == "type_inheritance_clause":
+                        if child.type == "inheritance_specifier":
                             for subchild in child.children:
-                                if subchild.type == "type_identifier":
+                                if subchild.type == "user_type":
+                                    for inner in subchild.children:
+                                        if inner.type == "type_identifier":
+                                            bases.append(self._get_node_text(inner))
+                                            break
+                                elif subchild.type == "type_identifier":
                                     bases.append(self._get_node_text(subchild))
                     
                     type_data = {

--- a/src/codegraphcontext/tools/languages/swift.py
+++ b/src/codegraphcontext/tools/languages/swift.py
@@ -273,6 +273,7 @@ class SwiftTreeSitterParser:
                         "context": context_name,
                         "class_context": context_name if context_type and ("class" in context_type or "struct" in context_type) else None,
                         "cyclomatic_complexity": self._calculate_complexity(node),
+                        "is_dependency": False,
                     }
                     
                     if self.index_source:

--- a/tests/unit/languages/test_swift_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_swift_cyclomatic_complexity.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.tools.languages.swift import SwiftTreeSitterParser
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+@pytest.fixture(scope="module")
+def swift_parser(tmp_path_factory):
+    manager = get_tree_sitter_manager()
+    if not manager.is_language_available("swift"):
+        pytest.skip("Swift tree-sitter grammar is not available in this environment")
+
+    wrapper = MagicMock()
+    wrapper.language_name = "swift"
+    wrapper.language = manager.get_language_safe("swift")
+    wrapper.parser = manager.create_parser("swift")
+    return SwiftTreeSitterParser(wrapper)
+
+
+def test_swift_cyclomatic_complexity_increases_for_control_flow(swift_parser, tmp_path):
+    code = """
+import Foundation
+
+struct Helpers {
+    func simpleHelper() -> Int {
+        return 1
+    }
+
+    func complexFunction(x: Int, items: [Int]) -> Int {
+        var result = x
+        if x > 0 {
+            result += 1
+        } else {
+            result -= 1
+        }
+
+        for item in items {
+            if item % 2 == 0 && result > 0 {
+                result += item
+            }
+        }
+
+        switch result {
+        case 1:
+            result += 2
+        case 2, 3:
+            result += 3
+        default:
+            result = 0
+        }
+
+        guard result >= 0 else {
+            return -1
+        }
+
+        do {
+            try mightThrow()
+        } catch {
+            result = -2
+        }
+
+        return result > 0 ? result : 0
+    }
+
+    func mightThrow() throws {}
+}
+"""
+    f = tmp_path / "complexity_sample.swift"
+    f.write_text(code)
+
+    result = swift_parser.parse(f)
+
+    by_name = {fn["name"]: fn for fn in result["functions"]}
+    assert "simpleHelper" in by_name
+    assert "complexFunction" in by_name
+
+    assert by_name["simpleHelper"]["cyclomatic_complexity"] == 1
+    assert by_name["complexFunction"]["cyclomatic_complexity"] > 8

--- a/tests/unit/parsers/test_swift_parser.py
+++ b/tests/unit/parsers/test_swift_parser.py
@@ -63,3 +63,47 @@ class GenericController {
     assert any(item["name"] == "GenericController" for item in result["classes"])
     assert len(result["imports"]) == 1
     assert any(item["name"] == "sampleCount" for item in result["variables"])
+
+
+def test_parse_swift_inheritance_and_protocol_conformance(swift_parser, temp_test_dir):
+    code = """
+import Foundation
+
+protocol Drawable {}
+protocol Identifiable {}
+
+class BaseShape {}
+
+class Circle: BaseShape, Drawable, Identifiable {
+    func draw() {}
+}
+
+struct Point: Identifiable {
+    let x: Int
+    let y: Int
+}
+
+enum Direction: String, Drawable {
+    case north
+    case south
+}
+"""
+    f = temp_test_dir / "inheritance_sample.swift"
+    f.write_text(code)
+
+    result = swift_parser.parse(f)
+
+    classes_by_name = {item["name"]: item for item in result["classes"]}
+    structs_by_name = {item["name"]: item for item in result["structs"]}
+    enums_by_name = {item["name"]: item for item in result["enums"]}
+
+    assert "Circle" in classes_by_name
+    assert set(classes_by_name["Circle"]["bases"]) == {"BaseShape", "Drawable", "Identifiable"}
+
+    assert "Point" in structs_by_name
+    assert structs_by_name["Point"]["bases"] == ["Identifiable"]
+
+    assert "Direction" in enums_by_name
+    assert set(enums_by_name["Direction"]["bases"]) == {"String", "Drawable"}
+
+    assert classes_by_name["BaseShape"]["bases"] == []

--- a/tests/unit/parsers/test_swift_parser.py
+++ b/tests/unit/parsers/test_swift_parser.py
@@ -63,6 +63,7 @@ class GenericController {
     assert any(item["name"] == "GenericController" for item in result["classes"])
     assert len(result["imports"]) == 1
     assert any(item["name"] == "sampleCount" for item in result["variables"])
+    assert all(fn.get("is_dependency") is False for fn in result["functions"])
 
 
 def test_parse_swift_inheritance_and_protocol_conformance(swift_parser, temp_test_dir):


### PR DESCRIPTION
## Summary

Fix three Swift-parser bugs that together prevent CodeGraphContext from producing useful Swift analysis:

1. **Cyclomatic complexity is always 1.** The Swift parser never implemented `_calculate_complexity`, so every Swift Function received the writer's default value, making `find_most_complex_functions` and complexity-based queries useless for Swift.
2. **Inheritance / protocol conformance is empty.** `_parse_classes` looked for `type_inheritance_clause` nodes, but the current `tree-sitter-swift` grammar emits `inheritance_specifier` instead. Every Swift class, struct, enum, and protocol was persisted with `bases = []`.
3. **`is_dependency` is `null` on Swift Function nodes.** `find_most_complex_functions` filters `WHERE f.is_dependency = false`, and Cypher evaluates `null = false` to `null`, so every Swift function was excluded from complexity-ranking results even after fix (1).

Verified end-to-end on a ~5k-Swift-file iOS app:
- Cyclomatic complexity now ranges 1–47 with realistic distribution.
- 92% of indexed Swift types have non-empty `bases` (was 0%).
- `find_most_complex_functions` returns Swift functions; top result is a real cc=47 function.

Each fix is in its own commit so they can be reviewed (or reverted) independently.

## Test plan

- [x] \`pytest tests/unit/parsers/test_swift_parser.py\` — extended with inheritance + \`is_dependency\` assertions
- [x] \`pytest tests/unit/languages/test_swift_cyclomatic_complexity.py\` — new file, mirrors the existing Go cyclomatic-complexity test
- [x] \`pytest tests/unit\` — 167 passed, 2 skipped, no regressions
- [x] Manual verification against a real Swift codebase

Made with [Cursor](https://cursor.com)