### PR TITLE
docs: fix markdown list formatting and rendering issues

### DIFF
--- a/docs/ON_DEMAND_BUNDLES.md
+++ b/docs/ON_DEMAND_BUNDLES.md
@@ -168,8 +168,11 @@ GET /api/bundle-status?repo=owner/repo
 **Cause:** Repository exceeds 1GB size limit
 
 **Solution:**
+
 - This is a safety limit to prevent long-running workflows
+
 - Consider increasing the limit in `/website/api/trigger-bundle.ts` if needed
+
 - Or add the repository to the weekly pre-indexed list instead
 
 ### Issue: "Bundle generation failed"

--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -22,8 +22,11 @@ graph LR
 
 ### 1. Ingestion Layer
 This layer is responsible for translating raw source code into semantic graph entities.
+
 *   **Parsers**: Uses Tree-sitter for high-fidelity AST extraction and SCIP for precise symbol resolution across files.
+
 *   **Graph Builder**: Orchestrates the parsing process, resolves imports, and establishes relationships (edges) between nodes.
+
 *   **Background Jobs**: Long-running indexing tasks are managed via an internal job queue to ensure the UI remains responsive.
 
 ### 2. Persistence Layer

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -6,6 +6,7 @@ The `cgc` command-line interface provides a suite of tools for indexing, queryin
 
 ### `index`
 Index a repository or directory.
+
 *   **Usage**: `cgc index [PATH]`
 *   **Options**:
     *   `--dependency`: Mark the indexed code as a dependency.
@@ -14,10 +15,12 @@ Index a repository or directory.
 
 ### `watch`
 Monitor a directory for changes and update the graph in real-time.
+
 *   **Usage**: `cgc watch [PATH]`
 
 ### `stats`
 Display statistics about the current indexed repository.
+
 *   **Usage**: `cgc stats [--all]`
 
 ---
@@ -26,6 +29,7 @@ Display statistics about the current indexed repository.
 
 ### `query`
 Execute relationship-based queries.
+
 *   **Usage**: `cgc query [TYPE] [TARGET]`
 *   **Types**:
     *   `callers`: Find functions that call the target.
@@ -35,12 +39,14 @@ Execute relationship-based queries.
 
 ### `find`
 Search for code symbols (functions, classes, etc.) by name or content.
+
 *   **Usage**: `cgc find [QUERY]`
 *   **Options**:
     *   `--fuzzy`: Use fuzzy matching for the search query.
 
 ### `visualize`
 Generate a visual graph of the codebase or a specific query.
+
 *   **Usage**: `cgc visualize [--query Q]`
 
 ---
@@ -49,14 +55,17 @@ Generate a visual graph of the codebase or a specific query.
 
 ### `bundle create`
 Export the current index to a `.cgc` bundle file.
+
 *   **Usage**: `cgc bundle create --name NAME`
 
 ### `bundle load`
 Load a local bundle or download one from the registry.
+
 *   **Usage**: `cgc bundle load [PATH|NAME]`
 
 ### `bundle search`
 Search the CGC bundle registry.
+
 *   **Usage**: `cgc bundle search [QUERY]`
 
 ---
@@ -65,21 +74,25 @@ Search the CGC bundle registry.
 
 ### `config`
 Manage global configuration settings.
+
 *   **Subcommands**:
     *   `set-db [kuzudb|falkordb|neo4j]`: Set the default database backend.
     *   `list`: Show all current configuration values.
 
 ### `doctor`
 Run diagnostics to verify installation and backend connectivity.
+
 *   **Usage**: `cgc doctor`
 
 ### `mcp`
 Start the Model Context Protocol (MCP) server. This command is typically invoked by AI assistants, not directly by users.
+
 *   **Usage**: `cgc mcp`
 
 ---
 
 ## Global Options
+
 *   `--database`: Override the default database for a single command.
 *   `--verbose`: Enable detailed logging for debugging.
 *   `--version`: Display the version of CodeGraphContext.

--- a/docs/docs/reference/mcp.md
+++ b/docs/docs/reference/mcp.md
@@ -6,6 +6,7 @@ When CodeGraphContext is running as an MCP server, it exposes a set of tools tha
 
 ### `find_code`
 Find relevant code snippets related to a keyword or phrase.
+
 *   **Parameters**: `query` (string), `fuzzy_search` (boolean), `repo_path` (optional).
 
 ### `list_indexed_repositories`


### PR DESCRIPTION
### Description
This PR fixes a widespread formatting bug in the documentation where bulleted lists were incorrectly rendering as plain text paragraphs rather than actual list items. 

The `python-markdown` parser used by MkDocs strictly requires a blank line preceding any list. Several markdown files were missing these blank lines directly above lists (e.g., under the `Usage`, `Options`, and `Parameters` sections), which caused the formatting to break on the deployed site.

### Changes Made
* Added the required preceding blank lines before lists across all affected `.md` files in the `docs` directory.
* Fixed list rendering specifically in `reference/cli.md`, `reference/mcp.md`, `concepts/architecture.md`, and bundle-related documentation files.
* Verified that all command usages and options will now correctly render as bullet points.
