### PR TITLE
feat: Phase 1-5 — Spring/Maven graph, confidence labels, ORM edges, embeddings, inheritance re-resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ todo.md
 .ignore
 extensions/vscode/out/
 extensions/vscode/*.vsix
+PHASE1_PHASE2_CHANGES.md
+NEXUS_BENCHMARK_BEFORE.md
+CGC_VALUE_PROPOSITION.md

--- a/CGC_PHASES_PR_DESCRIPTION.md
+++ b/CGC_PHASES_PR_DESCRIPTION.md
@@ -1,0 +1,117 @@
+# feat: Add embedding pipeline (Phase 4) and inheritance-aware re-resolution (Phase 5)
+
+## Summary
+
+This PR adds two new post-indexing resolution phases that significantly improve CALLS edge quality in Java codebases, and fixes a critical import bug that prevented Phases 4 and 5 from ever running.
+
+---
+
+## Critical Bug Fix
+
+**`pipeline.py`**: Four-dot relative import (`from ....cli.config_manager`) went above the top-level package boundary, crashing every `cgc index` run with `"attempted relative import beyond top-level package"` before Phase 4 could execute. Fixed to `from ...cli.config_manager`.
+
+---
+
+## New Files
+
+### `src/codegraphcontext/tools/indexing/embeddings.py` (266 lines)
+Generates semantic embeddings for all `Function` nodes and writes them back to Neo4j.
+
+- Uses `fastembed` with `BAAI/bge-small-en-v1.5` (384-dim ONNX, Python 3.13 compatible, no torch dependency)
+- Falls back gracefully to `sentence-transformers` if fastembed is unavailable
+- Paths filtered using `STARTS WITH` (not `CONTAINS`) for cross-repo safety
+- Handles anonymous functions with a `"(anonymous)"` fallback to prevent blank embeddings from crashing the model
+- Streams in batches of 256, writes back to Neo4j atomically per batch
+
+### `src/codegraphcontext/tools/indexing/vector_resolver.py` (137 lines)
+ANN vector similarity search used as tiebreaker in Phase 5.
+
+- Queries Neo4j vector index for top-K similar functions by name
+- Dynamic `effective_top_k = max(self.top_k, len(candidate_paths))` — previously hardcoded `top_k=5` silently missed correct candidates when >5 existed
+- Returns ranked candidate paths for caller to score
+
+### `src/codegraphcontext/tools/indexing/resolution/post_resolution.py` (205 lines)
+Phase 5: Re-resolves tier-7/8 CALLS edges (same-file fallbacks) using the `INHERITS` graph and optional vector similarity.
+
+**Algorithm:**
+1. Find all same-file CALLS edges involving classes that participate in inheritance
+2. Look up all known implementations of the called method name across the class hierarchy
+3. Score candidates: interface matches > concrete implementation matches
+4. If `VectorResolver` is available and scores are tied, use embedding similarity as tiebreaker
+5. MERGE improved edges at tier-10 (inheritance-resolved) or tier-11 (vector-resolved)
+
+**Implementation fixes vs naive approach:**
+- Step 2 uses a single `UNWIND` batch query for all unique method names (was N separate queries — critical for large repos like nucleus with 258K functions)
+- Null guard on `called_name`: external `Module` refs have null `called.name`, which was propagating into Cypher
+- `line_number` removed from MERGE key (null caused unpredictable duplicate edge creation); moved to `SET ... coalesce(...)` after MERGE
+- MATCH clause uses WHERE for null-safe caller line check
+
+---
+
+## Modified Files
+
+### `src/codegraphcontext/tools/indexing/pipeline.py`
+- Fixed `....cli` → `...cli` (4 dots → 3) — the root cause of Phase 4+5 never running
+- Added Phase 4 block (embedding generation, `ENABLE_VECTOR_RESOLVE` gated)
+- Added Phase 5 block (inheritance re-resolution, `ENABLE_INHERIT_RESOLVE` gated)
+- Both phases wrapped in `try/except` — failures log a warning but do NOT mark the job FAILED
+
+### `src/codegraphcontext/core/watcher.py`
+- Consolidated duplicate `_gcv` (config value getter) imports in Steps 8 and 9 into a single guarded block
+- Step 9 now instantiates `VectorResolver` when `ENABLE_VECTOR_RESOLVE=true` — previously it was always `None`, so tier-11 edges never fired for incremental file-change events
+- Both steps gated by `_vector_enabled` / `_inherit_enabled` booleans from a single config read
+
+### `src/codegraphcontext/tools/indexing/resolution/calls.py`
+- Java `package_name` extraction from `package` directive (fixes 0% → 93% package coverage)
+- Qualified name (`qualified_name`) construction for Function nodes
+- Improved cross-file resolution for DI field/variable receivers
+
+### `src/codegraphcontext/tools/indexing/persistence/writer.py`
+- Writes `package_name` and `qualified_name` to File/Function nodes respectively
+
+---
+
+## New Test Files
+
+- `tests/unit/tools/test_calls_resolution_tiers.py` (323 lines) — resolution tier ordering, tier-10/11 edge creation
+- `tests/unit/tools/test_embeddings_and_vector_resolver.py` (328 lines) — EmbeddingPipeline, VectorResolver, dynamic top_k
+- `tests/unit/parsers/test_java_package_qualified_names.py` (260 lines) — package_name and qualified_name extraction
+
+---
+
+## Configuration Flags
+
+Add to `~/.codegraphcontext/.env`:
+```
+ENABLE_INHERIT_RESOLVE=true   # Enable Phase 5 (inheritance re-resolution). Default: false
+ENABLE_VECTOR_RESOLVE=true    # Enable Phase 4 (embeddings) + tier-11 tiebreaker. Default: false
+```
+
+Phase 5 runs in all cases when `ENABLE_INHERIT_RESOLVE=true`. Vector similarity tiebreaker in Phase 5 only activates when both flags are true.
+
+---
+
+## Test Results
+
+```
+239 passed, 2 skipped, 0 failed
+```
+
+---
+
+## Benchmark Results (Nexus, 5,941 files / 52,719 functions)
+
+| Metric | Before | After |
+|---|---|---|
+| Total CALLS edges | 70,537 | 186,981 (+165%) |
+| Cross-file CALLS | 49% | 70% |
+| Tier-7 fallbacks | 34,371 (49%) | 31,690 (16%) |
+| `execute` same-file | 100% | 8% ✅ |
+| `execute` distinct targets | 43 (14%) | 99 (33%) |
+| Functions embedded | 0 | 52,719 (100%) |
+| Tier-10 edges (inherit) | 0 | 144 |
+| Tier-11 edges (vector) | 0 | 248 |
+| `package_name` set | 0% | 93% |
+| `qualified_name` set | 0% | 96% |
+
+The remaining 31,690 tier-7 fallbacks are Spring XML-wired beans — unsolvable via AST alone, require XML config parsing (proposed Phase 6).

--- a/CROSS_REPO_IMPL_PLAN.md
+++ b/CROSS_REPO_IMPL_PLAN.md
@@ -1,0 +1,656 @@
+# Cross-Repo Resolution — Implementation Plan
+
+> **Status:** Verified against `cgc-latest` source on 2026-04-27. Updated from
+> a draft authored by a smaller model: corrected the universality claim,
+> tightened the resolution Cypher to be repo-scoped, added a config gate
+> consistent with existing Phase 4/5, fixed the watcher integration point,
+> and added a generalization track for non-Java languages.
+
+---
+
+## Problem
+
+When nexus imports `com.ea.nucleus.billing.invoice.Invoice`, the graph stores
+a `Module` node with `full_import_name = "com.ea.nucleus.billing.invoice.Invoice"`.
+The actual class definition lives in the nucleus repo as a `Class` node with
+`qualified_name = "com.ea.nucleus.billing.invoice.Invoice"`. **No edge connects
+the two**, so cross-repo call/dependency queries are impossible today.
+
+## Goal
+
+Add a **config-driven, per-repo, language-agnostic-by-design** cross-repo
+linking phase that:
+
+1. Reads `<repo>/.codegraphcontext/cgc_repo_config.json` for declared targets.
+2. For each `cross_repo` target, resolves `Module → Class` across repos by
+   joining `Module.full_import_name` to the callee class's FQN.
+3. Writes idempotent `RESOLVES_TO` edges with provenance (`from_repo`,
+   `to_repo`, `linked_at`).
+4. Runs automatically as **Phase 6** of `cgc index`, on watcher file events,
+   and via a manual `cgc cross-link run` command.
+5. Is gated by `ENABLE_CROSS_REPO_LINK` env-var, mirroring the existing
+   Phase 4 (`ENABLE_VECTOR_RESOLVE`) and Phase 5 (`ENABLE_INHERIT_RESOLVE`)
+   flags.
+
+---
+
+## Value Unlocked
+
+The single edge `(Module)-[:RESOLVES_TO]->(Class)` is small but enables
+several capabilities that are currently impossible:
+
+| Capability | Today | After |
+|---|---|---|
+| **Impact analysis across repos** — "if I change `Invoice.java` in nucleus, what breaks in nexus?" | Manual grep across both repos | One Cypher query traversing `RESOLVES_TO` |
+| **True dependency map** — which nucleus packages does nexus actually consume (vs. which are merely declared in `pom.xml`)? | POM-only view, no usage signal | Per-class usage counts grouped by package |
+| **Caller graphs that cross repo boundaries** — find every nexus function that flows through a specific nucleus type | Only same-repo CALLS edges | Combine `IMPORTS → RESOLVES_TO` with `CALLS` |
+| **Dead code detection at the org level** — nucleus classes nobody imports | Can only find unused-within-nucleus | Find `Class` nodes with zero inbound `RESOLVES_TO` from any consumer repo |
+| **Migration / refactor planning** — moving a package from `com.ea.nucleus.x` to `com.ea.nucleus.y` | Unknown blast radius | Concrete file-level list of consumer changes needed |
+| **AI agent context** — Copilot answering "how is `Invoice` used in nexus" | Returns guesses or only nucleus self-uses | Returns precise nexus call sites |
+
+Plus second-order benefits:
+
+- The same `RESOLVES_TO` mechanism scales to **N>2 repos** (nexus, nucleus,
+  nova-utilities, …) — no code change, just an extra entry in the config file.
+- Provenance metadata (`from_repo`, `to_repo`, `linked_at`) makes it trivial
+  to detect stale links after a repo is renamed or deleted, and to audit
+  which links were created when.
+
+---
+
+## Is This Java-Specific?
+
+**The transport is universal; the join key is currently Java-only.**
+
+- `Module.full_import_name` is populated by **every language parser**
+  (java, python, csharp, cpp, kotlin, scala, ruby, perl, php, rust, swift,
+  dart, c, elixir, haskell). So the *importer* side of the join works for
+  every language out of the box.
+- `Class.qualified_name` is currently set **only** by the Java parser
+  ([`java.py:297`](src/codegraphcontext/tools/languages/java.py#L297)).
+  Other language parsers emit Class nodes with `name` and `path` but no FQN.
+
+This means **Phase 6 ships working for Java first**, and the same
+`run_cross_repo_link()` function generalizes to other languages by adding
+`qualified_name` population to their parsers (see "Generalization" below).
+The Phase 6 code itself does **not** need any language-specific branches.
+
+---
+
+## Config Format
+
+Each repo that depends on another declares it in its own
+`.codegraphcontext/cgc_repo_config.json`:
+
+```json
+{
+  "cross_repo": [
+    {
+      "to": "/Users/kbhaskarla/Documents/workspace/nucleus",
+      "description": "nucleus identity, billing and platform services"
+    },
+    {
+      "to": "/Users/kbhaskarla/Documents/workspace/nova-utilities",
+      "description": "shared platform utilities"
+    }
+  ]
+}
+```
+
+Only the `to` path is needed — the `from` repo is the one that owns the file.
+The description is optional but useful for `cgc cross-link list`.
+
+This file is **not** in `.gitignore` — it is intentional per-repo metadata
+that should be committed alongside the code, like `.nvmrc` or
+`pyrightconfig.json`.
+
+---
+
+## Schema Change
+
+No new node properties or constraints are needed. Add one composite index
+to `schema.py` for query performance:
+
+```cypher
+CREATE INDEX resolves_to_repos IF NOT EXISTS
+FOR ()-[r:RESOLVES_TO]-()
+ON (r.from_repo, r.to_repo)
+```
+
+`RESOLVES_TO` edge properties:
+
+| Property    | Type   | Description                                     |
+|-------------|--------|-------------------------------------------------|
+| `from_repo` | string | Absolute path of the importing (caller) repo    |
+| `to_repo`   | string | Absolute path of the exporting (callee) repo    |
+| `linked_at` | string | ISO-8601 timestamp; refreshed on every re-link  |
+
+> Neo4j 5+ syntax. The existing `schema.py` already uses the same
+> `CREATE INDEX … IF NOT EXISTS FOR ()-[r:…]-()` form for relationship
+> indexes, so no compatibility work is needed.
+
+---
+
+## Files to Create
+
+### 1. `src/codegraphcontext/core/repo_config.py` (NEW)
+
+Reads/writes `<repo>/.codegraphcontext/cgc_repo_config.json`.
+
+```python
+def load_repo_config(repo_path: Path) -> dict
+    """Returns parsed JSON or {} if file not found."""
+
+def get_cross_repo_targets(repo_path: Path) -> list[dict]
+    """Returns list of {'to': str, 'description': str} dicts."""
+
+def add_cross_repo_target(repo_path: Path, to_path: str, description: str = "") -> None
+    """Appends a new target, creating the config file if needed.
+    No-op (with warning) if the same `to` already exists."""
+
+def remove_cross_repo_target(repo_path: Path, to_path: str) -> bool
+    """Removes target by path. Returns True if found and removed."""
+```
+
+### 2. `src/codegraphcontext/tools/indexing/resolution/cross_repo_resolution.py` (NEW)
+
+Core resolution pass — mirrors `post_resolution.py` structure (info_logger
+prefix, batch sizing, single try/except guard at the call site).
+
+```python
+def run_cross_repo_link(
+    driver: Any,
+    from_repo_path: str,
+    to_repo_paths: list[str],
+) -> int:
+    """
+    Resolve Module nodes imported by `from_repo` to Class nodes in any of
+    `to_repo_paths` by matching full_import_name == qualified_name.
+
+    Returns count of RESOLVES_TO edges created or refreshed.
+    """
+```
+
+**Algorithm — two-step, repo-scoped to avoid noisy edges:**
+
+```cypher
+-- Step 1: collect candidate FQNs imported FROM the source repo only.
+-- (Module nodes are global; we must filter by the IMPORTS edge's File path.)
+MATCH (f:File)-[:IMPORTS]->(m:Module)
+WHERE f.path STARTS WITH $from_prefix
+  AND m.full_import_name IS NOT NULL
+RETURN DISTINCT m.full_import_name AS fqn
+```
+
+```cypher
+-- Step 2: for each target repo, MERGE edges in batches.
+-- The repo-prefix guard on BOTH sides is what prevents spurious links
+-- when multiple repos define classes with the same FQN.
+UNWIND $fqns AS fqn
+MATCH (m:Module {full_import_name: fqn})<-[:IMPORTS]-(f:File)
+WHERE f.path STARTS WITH $from_prefix
+MATCH (c:Class {qualified_name: fqn})
+WHERE c.path STARTS WITH $to_prefix
+MERGE (m)-[r:RESOLVES_TO]->(c)
+ON CREATE SET r.from_repo = $from_repo,
+              r.to_repo   = $to_repo,
+              r.linked_at = $now
+ON MATCH  SET r.linked_at = $now
+RETURN count(r) AS linked
+```
+
+Notes:
+
+- `from_prefix` and `to_prefix` are normalized with a trailing `/` (same
+  pattern as `post_resolution.py:54`) so that `/repos/nexus` does not
+  accidentally match `/repos/nexus_extra`.
+- FQN list is chunked at `_FQNS_BATCH = 500` to stay under Neo4j parameter
+  limits (mirrors `_NAMES_BATCH` in `post_resolution.py:88`).
+- `ON MATCH SET r.linked_at = $now` lets operators detect stale links by
+  comparing `linked_at` to the most recent indexing run.
+
+---
+
+## Files to Modify
+
+### 3. `src/codegraphcontext/tools/indexing/schema.py`
+
+Add the composite index alongside the existing `CREATE INDEX` block.
+
+### 4. `src/codegraphcontext/tools/indexing/pipeline.py`
+
+After the existing Phase 5 `if (_gcv("ENABLE_INHERIT_RESOLVE") …)` block
+(currently ending at line 115), add Phase 6 with the **same gating pattern**:
+
+```python
+# ── Phase 6: cross-repo linking (optional, config-gated) ──────────────────
+if (_gcv("ENABLE_CROSS_REPO_LINK") or "false").lower() == "true":
+    try:
+        from ...core.repo_config import get_cross_repo_targets
+        from .resolution.cross_repo_resolution import run_cross_repo_link
+        targets = get_cross_repo_targets(path)
+        if targets:
+            to_paths = [t["to"] for t in targets]
+            n_linked = run_cross_repo_link(writer.driver, str(path.resolve()), to_paths)
+            info_logger(f"[CROSS-REPO] Linked {n_linked} Module→Class edges across {len(to_paths)} target repo(s)")
+        else:
+            info_logger("[CROSS-REPO] No cross_repo targets declared; skipping.")
+    except Exception as _ce:
+        info_logger(f"[CROSS-REPO] Phase skipped: {_ce}")
+```
+
+### 5. `src/codegraphcontext/core/watcher.py`
+
+After the existing `if _inherit_enabled:` block (~line 218, **not** line 201),
+add a parallel `if _cross_repo_enabled:` block. Read the flag in the same
+upfront `_gcv` block where `_vector_enabled` and `_inherit_enabled` are read
+(~line 184), so all three phase flags are loaded once per file event.
+
+```python
+# Add to the up-front config read block (~line 183–187):
+_cross_repo_enabled = (_gcv("ENABLE_CROSS_REPO_LINK") or "false").lower() == "true"
+
+# After the _inherit_enabled block:
+if _cross_repo_enabled:
+    try:
+        from codegraphcontext.core.repo_config import get_cross_repo_targets
+        from codegraphcontext.tools.indexing.resolution.cross_repo_resolution import run_cross_repo_link
+        targets = get_cross_repo_targets(self.repo_path)
+        if targets:
+            to_paths = [t["to"] for t in targets]
+            n = run_cross_repo_link(self.graph_builder.driver, str(self.repo_path), to_paths)
+            info_logger(f"[CROSS-REPO] Incremental: {n} edges (re)linked")
+    except Exception as _e:
+        warning_logger(f"[CROSS-REPO] Incremental failed: {_e}")
+```
+
+### 6. `src/codegraphcontext/cli/main.py`
+
+Add a new `cross_link_app` Typer group, following the existing `mcp_app`,
+`neo4j_app`, `context_app` pattern:
+
+```
+cgc cross-link add    <from-repo> <to-repo> [--description "..."]
+cgc cross-link remove <from-repo> <to-repo>
+cgc cross-link list   <repo>
+cgc cross-link run    <repo>          # trigger Phase 6 manually, no re-index
+```
+
+Example session:
+
+```bash
+# Declare nexus depends on nucleus
+cgc cross-link add /workspace/nexus /workspace/nucleus \
+  --description "nucleus identity and billing services"
+
+# Run the linking pass now (without re-indexing)
+ENABLE_CROSS_REPO_LINK=true cgc cross-link run /workspace/nexus
+
+# See what's declared
+cgc cross-link list /workspace/nexus
+
+# Query in Neo4j after linking
+# MATCH (f:File)-[:IMPORTS]->(m:Module)-[:RESOLVES_TO]->(c:Class)
+# WHERE f.path CONTAINS '/nexus/' RETURN f.path, c.qualified_name LIMIT 20
+```
+
+> `cgc cross-link run` should bypass the env-var gate (the user has
+> explicitly requested the operation) but should still log a warning if the
+> gate is off, since `cgc index` and the watcher would otherwise skip it.
+
+---
+
+## Phase Ordering Summary
+
+| Phase | Name                     | File                            | Trigger           | Gate flag                  |
+|-------|--------------------------|---------------------------------|-------------------|----------------------------|
+| 1–3   | Parse + Write            | `pipeline.py`                   | `cgc index`       | always-on                  |
+| 4     | Embeddings               | `embeddings.py`                 | `cgc index`, watcher | `ENABLE_VECTOR_RESOLVE`    |
+| 5     | Inheritance Re-resolve   | `post_resolution.py`            | `cgc index`, watcher | `ENABLE_INHERIT_RESOLVE`   |
+| **6** | **Cross-Repo Linking**   | **`cross_repo_resolution.py`**  | **`cgc index`, watcher, `cgc cross-link run`** | **`ENABLE_CROSS_REPO_LINK`** |
+
+---
+
+## Query Examples (after implementation)
+
+```cypher
+-- All nexus files that use a nucleus class
+MATCH (f:File)-[:IMPORTS]->(m:Module)-[:RESOLVES_TO]->(c:Class)
+WHERE f.path CONTAINS '/nexus/'
+RETURN f.path, c.qualified_name, c.path
+
+-- Impact analysis: what breaks in nexus if Invoice changes?
+MATCH (c:Class {qualified_name: 'com.ea.nucleus.billing.invoice.Invoice'})
+      <-[:RESOLVES_TO]-(m:Module)<-[:IMPORTS]-(f:File)
+WHERE f.path CONTAINS '/nexus/'
+RETURN f.path
+
+-- Function-level: which nexus functions sit in files that import a nucleus type?
+MATCH (fn:Function)<-[:CONTAINS]-(f:File)-[:IMPORTS]->(m:Module)-[:RESOLVES_TO]->(c:Class)
+WHERE f.path CONTAINS '/nexus/'
+RETURN fn.name, fn.path, c.qualified_name
+
+-- Dependency heat map: which nucleus packages does nexus depend on the most?
+MATCH (f:File)-[:IMPORTS]->(m:Module)-[:RESOLVES_TO]->(c:Class)
+WHERE f.path CONTAINS '/nexus/' AND c.path CONTAINS '/nucleus/'
+WITH split(c.qualified_name, '.')[0..4] AS pkg
+RETURN pkg, count(*) AS usages ORDER BY usages DESC
+
+-- Stale-link audit: edges not refreshed in the last 24h
+MATCH ()-[r:RESOLVES_TO]->() WHERE r.linked_at < $cutoff_iso
+RETURN r.from_repo, r.to_repo, count(r) AS stale
+```
+
+---
+
+## Acceptance Criteria
+
+1. `cgc index /path/to/nexus` with `ENABLE_CROSS_REPO_LINK=true` and
+   `cgc_repo_config.json` declaring nucleus completes Phase 6 and logs
+   `[CROSS-REPO] Linked N Module→Class edges`.
+2. The query `MATCH (m:Module)-[:RESOLVES_TO]->(c:Class) RETURN count(*)`
+   returns N > 0 in Neo4j.
+3. Re-running `cgc index` does **not** create duplicate edges (MERGE
+   idempotency) and refreshes `linked_at` on existing edges.
+4. Touching a single `.java` file under `/nexus/` triggers the watcher's
+   incremental Phase 6 within the debounce window and refreshes only the
+   affected edges' `linked_at`.
+5. With `ENABLE_CROSS_REPO_LINK=false` (or unset), Phase 6 is a no-op and
+   logs nothing — same behavior as Phase 4/5 today.
+6. A repo with no `cgc_repo_config.json` (or with an empty `cross_repo`
+   array) skips Phase 6 with an informational log message and zero edges.
+
+---
+
+## Generalization to Other Languages
+
+The Phase 6 code is language-agnostic. To extend coverage beyond Java, only
+the parsers need to populate `qualified_name` on Class nodes. There is **no
+change to `cross_repo_resolution.py` or schema** for any of the steps below.
+
+| Language | FQN derivation | Effort |
+|---|---|---|
+| **Python** | `package_path_from_file(path) + "." + class_name`, where `package_path_from_file` walks up the directory tree until it leaves a directory containing `__init__.py`. | ~30 LOC in `python.py` |
+| **C#** | Concatenate enclosing `namespace_declaration` text with class `name`. The `csharp.py` parser already captures `(qualified_name) @name` for namespaces. | ~20 LOC in `csharp.py` |
+| **Kotlin** | Package declaration + class name (mirror of Java). | ~15 LOC in `kotlin.py` |
+| **Scala** | Package declaration + class/object name. | ~15 LOC in `scala.py` |
+| **Go** | Package path (from `go.mod` resolution) + identifier. Requires resolving module root first. | Moderate — needs `go.mod` lookup |
+| **TypeScript / JavaScript** | Imports are **path-based, not FQN-based** (`import { Foo } from "./bar"`). Cross-repo linking for TS/JS requires a different join: resolve relative paths to absolute file paths and match `File` nodes directly. **Track as a separate Phase 6b.** | Different design needed |
+
+Recommended rollout:
+
+1. Phase 6 (this plan) — ships Java-only working end-to-end.
+2. Follow-up MR — populate `qualified_name` for Python and C# parsers; no
+   Phase 6 changes needed, the same `RESOLVES_TO` edges start appearing
+   automatically once parsers re-index.
+3. Phase 6b (separate plan) — path-based resolution for TS/JS imports.
+
+---
+
+## Out of Scope
+
+- Wildcard / star import resolution (`com.ea.nucleus.*` → all classes in
+  package). Java-static imports of fields/methods. Both can be handled by
+  later passes that consult `Module.alias` and package-level lookups.
+- Cross-repo `CALLS` and `INHERITS` edges. With `RESOLVES_TO` in place,
+  these can be synthesized in a later phase by composing
+  `CALLS-target-name` + `RESOLVES_TO` + `Class CONTAINS Function`.
+- Path-based (TS/JS) cross-repo resolution — see Phase 6b above.
+- Auto-discovery of `to` repos from build files (`pom.xml` `<dependency>`,
+  `package.json` workspaces). The config file is intentionally explicit so
+  the operator controls which repos participate.
+# Cross-Repo Resolution — Implementation Plan
+
+## Problem
+
+When nexus imports `com.ea.nucleus.billing.invoice.Invoice`, the graph records
+a `Module` node with `full_import_name = "com.ea.nucleus.billing.invoice.Invoice"`.
+The actual class definition lives in the nucleus repo as a `Class` node with
+`qualified_name = "com.ea.nucleus.billing.invoice.Invoice"`. There is currently
+no edge connecting them, so cross-repo call/dependency queries are impossible.
+
+## Goal
+
+Add a config-driven, per-repo cross-repo linking phase that:
+1. Reads a `cgc_repo_config.json` file from `<repo>/.codegraphcontext/`
+2. For each declared `cross_repo` pair, resolves `Module → Class` across repos
+3. Writes `RESOLVES_TO` edges in Neo4j with provenance metadata
+4. Runs automatically after indexing and on watcher file-change events
+5. Is idempotent (safe to re-run; uses MERGE)
+
+---
+
+## Config Format
+
+Each repo that depends on another declares it in its own
+`.codegraphcontext/cgc_repo_config.json`:
+
+```json
+{
+  "cross_repo": [
+    {
+      "to": "/Users/kbhaskarla/Documents/workspace/nucleus",
+      "description": "nucleus identity, billing and platform services"
+    },
+    {
+      "to": "/Users/kbhaskarla/Documents/workspace/nova-utilities",
+      "description": "shared platform utilities"
+    }
+  ]
+}
+```
+
+> Only the `to` path is needed — the `from` repo is the one that owns the file.
+> The description is optional but useful for `cgc cross-link list`.
+
+This file is **not** in `.gitignore` — it's intentional per-repo metadata that
+should be committed alongside the code (like a `.nvmrc` or `pyrightconfig.json`).
+
+---
+
+## Schema Change
+
+Add one new relationship type to `schema.py`:
+
+```cypher
+-- No new constraint needed; Module already has UNIQUE on name.
+-- RESOLVES_TO edges are created via MERGE so duplicates never form.
+-- Add a composite index for query performance:
+
+CREATE INDEX resolves_to_repos IF NOT EXISTS
+FOR ()-[r:RESOLVES_TO]-()
+ON (r.from_repo, r.to_repo)
+```
+
+`RESOLVES_TO` edge properties:
+
+| Property    | Type   | Description                                     |
+|-------------|--------|-------------------------------------------------|
+| `from_repo` | string | Absolute path of the importing (caller) repo    |
+| `to_repo`   | string | Absolute path of the exporting (callee) repo    |
+| `linked_at` | string | ISO-8601 timestamp of when the edge was created |
+
+---
+
+## Files to Create
+
+### 1. `src/codegraphcontext/core/repo_config.py` (NEW)
+
+Reads/writes `<repo>/.codegraphcontext/cgc_repo_config.json`.
+
+```python
+def load_repo_config(repo_path: Path) -> dict
+    """Returns parsed JSON or {} if file not found."""
+
+def get_cross_repo_targets(repo_path: Path) -> list[dict]
+    """Returns list of {'to': str, 'description': str} dicts."""
+
+def add_cross_repo_target(repo_path: Path, to_path: str, description: str = "") -> None
+    """Appends a new target to cgc_repo_config.json, creating it if needed."""
+
+def remove_cross_repo_target(repo_path: Path, to_path: str) -> bool
+    """Removes target by path. Returns True if found and removed."""
+```
+
+### 2. `src/codegraphcontext/tools/indexing/resolution/cross_repo_resolution.py` (NEW)
+
+Core resolution pass — mirrors `post_resolution.py` structure.
+
+```python
+def run_cross_repo_link(
+    driver: Any,
+    from_repo_path: str,
+    to_repo_paths: list[str],
+) -> int:
+    """
+    Resolve Module nodes in from_repo to Class nodes in to_repos
+    by matching full_import_name == qualified_name.
+
+    Returns count of RESOLVES_TO edges created or already existing.
+
+    Algorithm:
+      1. MATCH (f:File)-[:IMPORTS]->(m:Module)
+             WHERE f.path STARTS WITH $from_prefix
+               AND m.full_import_name IS NOT NULL
+         RETURN DISTINCT m.name, m.full_import_name
+
+      2. For each to_repo:
+         MATCH (c:Class)
+             WHERE c.path STARTS WITH $to_prefix
+               AND c.qualified_name IN $fqns
+         RETURN c.qualified_name, elementId(c)
+
+      3. Batch MERGE:
+         UNWIND $pairs AS pair
+         MATCH (m:Module {full_import_name: pair.fqn})
+         MATCH (c:Class {qualified_name: pair.fqn})
+               WHERE c.path STARTS WITH pair.to_prefix
+         MERGE (m)-[r:RESOLVES_TO]->(c)
+         ON CREATE SET r.from_repo = pair.from_repo,
+                       r.to_repo   = pair.to_repo,
+                       r.linked_at = pair.linked_at
+         RETURN count(r) as linked
+    """
+```
+
+---
+
+## Files to Modify
+
+### 3. `src/codegraphcontext/tools/indexing/schema.py`
+
+Add after the existing `CREATE INDEX` statements:
+
+```python
+session.run(
+    "CREATE INDEX resolves_to_repos IF NOT EXISTS "
+    "FOR ()-[r:RESOLVES_TO]-() ON (r.from_repo, r.to_repo)"
+)
+```
+
+### 4. `src/codegraphcontext/tools/indexing/pipeline.py`
+
+After the existing `run_inheritance_reresolve` call block (currently Phase 5),
+add Phase 6 — cross-repo linking:
+
+```python
+# Phase 6: cross-repo resolution
+try:
+    from ...core.repo_config import get_cross_repo_targets
+    from .resolution.cross_repo_resolution import run_cross_repo_link
+    targets = get_cross_repo_targets(Path(repo_path_str))
+    if targets:
+        to_paths = [t["to"] for t in targets]
+        n_linked = run_cross_repo_link(writer.driver, repo_path_str, to_paths)
+        info_logger(f"[CROSS-REPO] Linked {n_linked} Module→Class edges")
+except Exception as _e:
+    warning_logger(f"[CROSS-REPO] Phase skipped: {_e}")
+```
+
+### 5. `src/codegraphcontext/core/watcher.py`
+
+After the existing Phase 5 block (around line 201), add a parallel block
+for Phase 6 using the same guard pattern (`try/except` with `warning_logger`).
+
+### 6. `src/codegraphcontext/cli/main.py`
+
+Add a new `cross_link_app` Typer command group under `cgc cross-link`:
+
+```
+cgc cross-link add    <from-repo> <to-repo> [--description "..."]
+cgc cross-link remove <from-repo> <to-repo>
+cgc cross-link list   <repo>
+cgc cross-link run    <repo>          # trigger resolution pass manually
+```
+
+Example CLI interactions:
+
+```bash
+# Declare nexus depends on nucleus
+cgc cross-link add /workspace/nexus /workspace/nucleus \
+  --description "nucleus identity and billing services"
+
+# Run the linking pass now (without re-indexing)
+cgc cross-link run /workspace/nexus
+
+# See what's declared
+cgc cross-link list /workspace/nexus
+
+# Query in Neo4j after linking
+# MATCH (f:File)-[:IMPORTS]->(m:Module)-[:RESOLVES_TO]->(c:Class)
+# WHERE f.path CONTAINS '/nexus/'
+# RETURN f.path, c.qualified_name, c.path
+# LIMIT 20
+```
+
+---
+
+## Phase Ordering Summary
+
+| Phase | Name                     | File                            | Trigger         |
+|-------|--------------------------|---------------------------------|-----------------|
+| 1–3   | Parse + Write            | `pipeline.py`                   | `cgc index`     |
+| 4     | Embeddings               | `embeddings.py`                 | `cgc index`     |
+| 5     | Inheritance Re-resolve   | `post_resolution.py`            | `cgc index`     |
+| **6** | **Cross-Repo Linking**   | **`cross_repo_resolution.py`**  | **`cgc index`, watcher, `cgc cross-link run`** |
+
+---
+
+## Query Examples (after implementation)
+
+```cypher
+-- All nexus files that use a nucleus class
+MATCH (f:File)-[:IMPORTS]->(m:Module)-[:RESOLVES_TO]->(c:Class)
+WHERE f.path CONTAINS '/nexus/'
+RETURN f.path, c.qualified_name, c.path
+
+-- Impact analysis: what breaks in nexus if Invoice changes?
+MATCH (m:Module {full_import_name: 'com.ea.nucleus.billing.invoice.Invoice'})
+      <-[:IMPORTS]-(f:File)
+WHERE f.path CONTAINS '/nexus/'
+RETURN f.path
+
+-- Function-level: which nexus functions call through a nucleus type?
+MATCH (fn:Function)-[:CALLS]->(callee),
+      (f:File)-[:CONTAINS]->(fn),
+      (f)-[:IMPORTS]->(m:Module)-[:RESOLVES_TO]->(c:Class)
+WHERE f.path CONTAINS '/nexus/'
+RETURN fn.name, fn.path, c.qualified_name
+
+-- Dependency map: all nucleus packages nexus depends on
+MATCH (f:File)-[:IMPORTS]->(m:Module)-[:RESOLVES_TO]->(c:Class)
+WHERE f.path CONTAINS '/nexus/'
+      AND c.path CONTAINS '/nucleus/'
+WITH split(c.qualified_name, '.')[0..4] as pkg
+RETURN pkg, count(*) as usages ORDER BY usages DESC
+```
+
+---
+
+## Out of Scope (not in this plan)
+
+- Wildcard import resolution (`com.ea.nucleus.*` → multiple classes) — future work
+- Cross-repo CALLS edges (function A in nexus calls function B in nucleus directly)
+- Cross-repo INHERITS edges
+- Non-Java repos (this plan is Java/Maven-specific; Python/TS can follow the same
+  pattern using `qualified_name` once those parsers emit it)

--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -55,6 +55,11 @@ DEFAULT_CONFIG = {
     # JSON object mapping tool names to integer result-count limits.
     # Example: {"find_code": 20, "analyze_code_relationships": 10, "find_dead_code": 30}
     "TOOL_RESULT_LIMITS": "{}",
+    # Post-indexing resolution phases (default off)
+    "ENABLE_INHERIT_RESOLVE": "false",
+    "ENABLE_VECTOR_RESOLVE": "false",
+    "CGC_EMBEDDING_MODEL": "local",
+    "CGC_EMBEDDING_BATCH_SIZE": "256",
 }
 
 # Configuration key descriptions
@@ -84,6 +89,37 @@ CONFIG_DESCRIPTIONS = {
     "SKIP_EXTERNAL_RESOLUTION": "Skip resolution attempts for external library method calls (recommended for enterprise large Java/Spring codebases)",
     "MAX_TOOL_RESPONSE_TOKENS": "Maximum tokens per MCP tool response (0 = unlimited). Truncates oversized payloads and appends a notice.",
     "TOOL_RESULT_LIMITS": "JSON object mapping tool names to max result counts, e.g. {\"find_code\": 20, \"analyze_code_relationships\": 10}. Missing keys use built-in defaults.",
+    # Post-indexing resolution phases
+    "ENABLE_INHERIT_RESOLVE": (
+        "[Phase 5] Re-resolve ambiguous same-file CALLS edges using the inheritance graph (INHERITS relationships). "
+        "When enabled, methods called on an interface or abstract class are re-pointed to the correct concrete "
+        "implementation based on the class hierarchy, reducing tier-7 fallback edges. "
+        "WHEN TO ENABLE: any Java/Kotlin/C# codebase that uses inheritance or interface-based DI (e.g. Spring, OSGi). "
+        "PREREQUISITES: run 'cgc index' first so INHERITS edges exist in the graph. No extra tools needed. "
+        "COST: adds ~1-5 min per 50K functions at the end of each 'cgc index' run. Safe to toggle on/off — only adds new edges, never removes existing ones."
+    ),
+    "ENABLE_VECTOR_RESOLVE": (
+        "[Phase 4 + Phase 5 tiebreaker] Generate semantic embeddings for all Function nodes and use vector "
+        "similarity as a tiebreaker when inheritance resolution alone cannot distinguish between multiple candidates. "
+        "Phase 4 writes a 384-dim embedding to every Function node; Phase 5 queries those embeddings during re-resolution. "
+        "WHEN TO ENABLE: large codebases (>10K functions) where inheritance alone leaves many ambiguous calls "
+        "(tier-7 fallbacks still high after ENABLE_INHERIT_RESOLVE). Also useful for cross-language repos. "
+        "PREREQUISITES: (1) fastembed must be installed — run 'pip install fastembed'. "
+        "(2) Neo4j must be the active database (vector index not supported on FalkorDB/KuzuDB). "
+        "(3) ENABLE_INHERIT_RESOLVE should also be true — vector is a tiebreaker for Phase 5, not a replacement. "
+        "COST: Phase 4 takes ~15 min per 50K functions on CPU (first run only; incremental updates are fast). "
+        "Embedding model (~40 MB) is downloaded automatically on first use from HuggingFace."
+    ),
+    "CGC_EMBEDDING_MODEL": (
+        "Embedding backend for ENABLE_VECTOR_RESOLVE. "
+        "'local' uses fastembed (BAAI/bge-small-en-v1.5, 384-dim, runs on CPU, no GPU or API key needed). "
+        "'openai' uses OpenAI text-embedding-3-small (requires OPENAI_API_KEY env var, costs money per token). "
+        "Default: local"
+    ),
+    "CGC_EMBEDDING_BATCH_SIZE": (
+        "Number of function texts to embed per batch when ENABLE_VECTOR_RESOLVE=true. "
+        "Larger values are faster but use more RAM. Default: 256. Reduce to 64 if you hit memory errors."
+    ),
 }
 
 # Valid values for each config key
@@ -101,6 +137,9 @@ CONFIG_VALIDATORS = {
     "INDEX_SOURCE": ["true", "false"],
     "SCIP_INDEXER": ["true", "false"],
     "SKIP_EXTERNAL_RESOLUTION": ["true", "false"],
+    "ENABLE_INHERIT_RESOLVE": ["true", "false"],
+    "ENABLE_VECTOR_RESOLVE": ["true", "false"],
+    "CGC_EMBEDDING_MODEL": ["local", "openai"],
 }
 DEFAULT_CGCIGNORE_PATTERNS = """\
 # Default .cgcignore patterns

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -1093,6 +1093,46 @@ def delete(
         
         delete_helper(path, context)
 
+
+@app.command()
+def report(
+    output: Optional[str] = typer.Option(None, "--output", "-o", help="Output file path. Defaults to CGC_REPORT.md in the current directory."),
+    java: bool = typer.Option(False, "--java", "-j", help="Include Spring/Maven Java sections."),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
+):
+    """
+    Generate a CGC_REPORT.md with god nodes, complexity, cross-module connections, and suggested queries.
+
+    Use --java to also include Spring endpoint tables, bean stereotype counts,
+    and Maven module dependency summaries.
+
+    Examples:
+        cgc report
+        cgc report --output /tmp/my_report.md
+        cgc report --java
+    """
+    _load_credentials()
+    output_path = Path(output) if output else Path.cwd() / "CGC_REPORT.md"
+    db_manager, _, _ = _initialize_services(context)
+    try:
+        from codegraphcontext.tools.report_generator import generate_report
+        report_text = generate_report(db_manager, output_path=output_path, include_java=java)
+        console.print(f"[green]✓[/green] Report written to [bold]{output_path}[/bold]")
+        # Print a short preview (first ~40 lines)
+        preview_lines = report_text.splitlines()[:40]
+        console.print("\n".join(preview_lines))
+        if len(report_text.splitlines()) > 40:
+            console.print(f"[dim]... ({len(report_text.splitlines())} lines total, see {output_path})[/dim]")
+    except Exception as exc:
+        console.print(f"[red]Report generation failed:[/red] {exc}")
+        raise typer.Exit(code=1)
+    finally:
+        try:
+            db_manager.close_driver()
+        except Exception:
+            pass
+
+
 @app.command()
 def visualize(
     repo: Optional[str] = typer.Option(None, "--repo", "-r", help="Path to the repository to visualize."),
@@ -2380,6 +2420,150 @@ def main(
         console.print("👉 Run [cyan]cgc help[/cyan] to see all available commands")
         console.print("👉 Run [cyan]cgc --version[/cyan] to check the version\n")
         console.print("👉 Running [green]codegraphcontext[/green] works the same as using [green]cgc[/green]")
+
+
+# ============================================================================
+# DATASOURCE COMMAND GROUP — Index external data sources (#843)
+# ============================================================================
+
+datasource_app = typer.Typer(help="Index external data sources (Redis, Cassandra, Aurora MySQL) into the code graph")
+app.add_typer(datasource_app, name="datasource")
+
+
+@datasource_app.command("mysql")
+def datasource_mysql(
+    ctx: typer.Context,
+    host: str = typer.Option(..., "--host", "-H", help="MySQL host / Aurora endpoint"),
+    port: int = typer.Option(3306, "--port", "-p", help="MySQL port"),
+    user: str = typer.Option(..., "--user", "-u", help="MySQL username"),
+    password: str = typer.Option(..., "--password", "-P", help="MySQL password", hide_input=True),
+    database: str = typer.Option(..., "--database", "-d", help="Database / schema name"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Logical datasource name (default: mysql-<database>)"),
+    env: str = typer.Option("production", "--env", "-e", help="Deployment environment label"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="CGC context to use"),
+):
+    """Ingest Aurora MySQL schema (tables + columns) and write to the code graph.
+
+    Requires: pip install PyMySQL
+    """
+    try:
+        from codegraphcontext.tools.datasources.mysql_ingester import ingest as mysql_ingest
+    except ImportError as e:
+        console.print(f"[red]Import error:[/red] {e}")
+        raise typer.Exit(1)
+
+    if context:
+        config_manager.set_config_value("CONTEXT", context)
+
+    console.print(f"[cyan]Connecting to Aurora MySQL at {host}:{port}/{database}...[/cyan]")
+    try:
+        result = mysql_ingest(host=host, port=port, user=user, password=password,
+                               database=database, name=name, env=env)
+    except Exception as exc:
+        console.print(f"[red]Failed to connect / ingest:[/red] {exc}")
+        raise typer.Exit(1)
+
+    _write_datasource_graph(result)
+    console.print(
+        f"[green]✓ MySQL datasource[/green] [bold]{result['datasource']['name']}[/bold] indexed: "
+        f"{len(result.get('tables', []))} tables, {len(result.get('columns', []))} columns"
+    )
+
+
+@datasource_app.command("cassandra")
+def datasource_cassandra(
+    ctx: typer.Context,
+    host: str = typer.Option(..., "--host", "-H", help="Cassandra contact point (comma-separated for multiple)"),
+    port: int = typer.Option(9042, "--port", "-p", help="Cassandra native transport port"),
+    keyspace: str = typer.Option(..., "--keyspace", "-k", help="Keyspace to ingest"),
+    username: Optional[str] = typer.Option(None, "--user", "-u", help="Cassandra username"),
+    password: Optional[str] = typer.Option(None, "--password", "-P", help="Cassandra password", hide_input=True),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Logical datasource name (default: cassandra-<keyspace>)"),
+    env: str = typer.Option("production", "--env", "-e", help="Deployment environment label"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="CGC context to use"),
+):
+    """Ingest Cassandra keyspace schema (tables + columns) and write to the code graph.
+
+    Requires: pip install cassandra-driver
+    """
+    try:
+        from codegraphcontext.tools.datasources.cassandra_ingester import ingest as cassandra_ingest
+    except ImportError as e:
+        console.print(f"[red]Import error:[/red] {e}")
+        raise typer.Exit(1)
+
+    if context:
+        config_manager.set_config_value("CONTEXT", context)
+
+    hosts = [h.strip() for h in host.split(",")]
+    console.print(f"[cyan]Connecting to Cassandra at {hosts}/{keyspace}...[/cyan]")
+    try:
+        result = cassandra_ingest(hosts=hosts, port=port, keyspace=keyspace,
+                                   username=username, password=password, name=name, env=env)
+    except Exception as exc:
+        console.print(f"[red]Failed to connect / ingest:[/red] {exc}")
+        raise typer.Exit(1)
+
+    _write_datasource_graph(result)
+    console.print(
+        f"[green]✓ Cassandra datasource[/green] [bold]{result['datasource']['name']}[/bold] indexed: "
+        f"{len(result.get('tables', []))} tables, {len(result.get('columns', []))} columns"
+    )
+
+
+@datasource_app.command("redis")
+def datasource_redis(
+    ctx: typer.Context,
+    host: str = typer.Option(..., "--host", "-H", help="Redis host"),
+    port: int = typer.Option(6379, "--port", "-p", help="Redis port"),
+    db: int = typer.Option(0, "--db", help="Redis database index"),
+    password: Optional[str] = typer.Option(None, "--password", "-P", help="Redis AUTH password", hide_input=True),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Logical datasource name"),
+    env: str = typer.Option("production", "--env", "-e", help="Deployment environment label"),
+    max_keys: int = typer.Option(10000, "--max-keys", help="Maximum keys to scan (avoid full scan in large clusters)"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="CGC context to use"),
+):
+    """Discover Redis key patterns and write to the code graph.
+
+    Scans up to --max-keys keys and groups them into patterns (e.g. user:*).
+
+    Requires: pip install redis
+    """
+    try:
+        from codegraphcontext.tools.datasources.redis_ingester import ingest as redis_ingest
+    except ImportError as e:
+        console.print(f"[red]Import error:[/red] {e}")
+        raise typer.Exit(1)
+
+    if context:
+        config_manager.set_config_value("CONTEXT", context)
+
+    console.print(f"[cyan]Connecting to Redis at {host}:{port}/{db}...[/cyan]")
+    try:
+        result = redis_ingest(host=host, port=port, db=db, password=password,
+                               name=name, env=env, max_keys=max_keys)
+    except Exception as exc:
+        console.print(f"[red]Failed to connect / ingest:[/red] {exc}")
+        raise typer.Exit(1)
+
+    _write_datasource_graph(result)
+    console.print(
+        f"[green]✓ Redis datasource[/green] [bold]{result['datasource']['name']}[/bold] indexed: "
+        f"{len(result.get('key_patterns', []))} key patterns"
+    )
+
+
+def _write_datasource_graph(ingested: dict) -> None:
+    """Shared helper: write ingested datasource dict to the active graph."""
+    from codegraphcontext.core.database import DatabaseManager
+    dm = DatabaseManager()
+    driver = dm.get_driver()
+    if driver is None:
+        console.print("[red]No active graph connection. Run[/red] cgc context switch <name> [red]first.[/red]")
+        raise typer.Exit(1)
+
+    from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+    GraphWriter(driver).write_datasource_graph(ingested)
 
 
 if __name__ == "__main__":

--- a/src/codegraphcontext/core/watcher.py
+++ b/src/codegraphcontext/core/watcher.py
@@ -248,6 +248,48 @@ class RepositoryEventHandler(FileSystemEventHandler):
         info_logger(f"[INCREMENTAL] Re-linking {len(subset_file_data)} files...")
         self.graph_builder.link_function_calls(subset_file_data, self.imports_map, file_class_lookup)
         self.graph_builder.link_inheritance(subset_file_data, self.imports_map)
+
+        # Step 8+9: Phase 4 (embeddings) and Phase 5 (inheritance re-resolution).
+        # Both are gated by env-var flags.  Each is wrapped in its own try/except
+        # so a failure in one never prevents the other from running.
+        try:
+            from codegraphcontext.cli.config_manager import get_config_value as _gcv
+            _vector_enabled = (_gcv("ENABLE_VECTOR_RESOLVE") or "false").lower() == "true"
+            _inherit_enabled = (_gcv("ENABLE_INHERIT_RESOLVE") or "false").lower() == "true"
+        except Exception as _cfg_e:
+            warning_logger(f"[PHASE4/5] Could not read config flags: {_cfg_e}")
+            _vector_enabled = False
+            _inherit_enabled = False
+
+        if _vector_enabled:
+            try:
+                from codegraphcontext.tools.indexing.embeddings import EmbeddingPipeline
+                embed_pipeline = EmbeddingPipeline(self.graph_builder.driver)
+                embed_pipeline.invalidate_for_file(changed_path_str)
+                embed_pipeline.run(str(self.repo_path))
+                info_logger(f"[EMBED] Incremental embedding complete for {changed_path_str}")
+            except Exception as _e:
+                warning_logger(f"[EMBED] Incremental embedding failed: {_e}")
+
+        if _inherit_enabled:
+            try:
+                from codegraphcontext.tools.indexing.resolution.post_resolution import run_inheritance_reresolve
+                # Build a VectorResolver when embeddings are also enabled so tier-11
+                # edges fire incrementally, not just during full indexing runs.
+                _vector_resolver = None
+                if _vector_enabled:
+                    try:
+                        from codegraphcontext.tools.indexing.vector_resolver import VectorResolver
+                        _vector_resolver = VectorResolver(self.graph_builder.driver)
+                    except Exception as _ve:
+                        warning_logger(f"[VECTOR] Resolver unavailable for watcher: {_ve}")
+                n_improved = run_inheritance_reresolve(
+                    self.graph_builder.driver, str(self.repo_path), _vector_resolver
+                )
+                info_logger(f"[INHERIT-RESOLVE] Incremental: {n_improved} edges improved")
+            except Exception as _e:
+                warning_logger(f"[INHERIT-RESOLVE] Incremental failed: {_e}")
+
         info_logger(f"[INCREMENTAL] Done. Graph refresh for {event_path_str} complete! ✅")
 
     # The following methods are called by the watchdog observer when a file event occurs.

--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -346,6 +346,32 @@ class MCPServer:
     def get_repository_stats_tool(self, **args) -> Dict[str, Any]:
         return management_handlers.get_repository_stats(self.code_finder, **args)
 
+    def generate_report_tool(self, **args) -> Dict[str, Any]:
+        from .tools.report_generator import generate_report
+        output_path_raw = args.get("output_path")
+        output_path = Path(output_path_raw) if output_path_raw else self.cwd / "CGC_REPORT.md"
+        try:
+            report = generate_report(
+                self.db_manager,
+                output_path=output_path,
+                include_java=bool(args.get("include_java", False)),
+                god_node_limit=int(args.get("god_node_limit", 15)),
+                complexity_limit=int(args.get("complexity_limit", 15)),
+                cross_module_limit=int(args.get("cross_module_limit", 20)),
+            )
+            return {"status": "ok", "output_path": str(output_path), "report": report}
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    def find_java_spring_endpoints_tool(self, **args) -> Dict[str, Any]:
+        return analysis_handlers.find_java_spring_endpoints(self.code_finder, **args)
+
+    def find_java_spring_beans_tool(self, **args) -> Dict[str, Any]:
+        return analysis_handlers.find_java_spring_beans(self.code_finder, **args)
+
+    def find_datasource_nodes_tool(self, **args) -> Dict[str, Any]:
+        return analysis_handlers.find_datasource_nodes(self.code_finder, **args)
+
     def discover_codegraph_contexts_tool(self, **args) -> Dict[str, Any]:
         scan_path = Path(args.get("path", str(self.cwd))).resolve()
         max_depth = int(args.get("max_depth", 1))
@@ -466,6 +492,10 @@ class MCPServer:
             "get_repository_stats": self.get_repository_stats_tool,
             "discover_codegraph_contexts": self.discover_codegraph_contexts_tool,
             "switch_context": self.switch_context_tool,
+            "generate_report": self.generate_report_tool,
+            "find_java_spring_endpoints": self.find_java_spring_endpoints_tool,
+            "find_java_spring_beans": self.find_java_spring_beans_tool,
+            "find_datasource_nodes": self.find_datasource_nodes_tool,
         }
         handler = tool_map.get(tool_name)
         if handler:

--- a/src/codegraphcontext/tool_definitions.py
+++ b/src/codegraphcontext/tool_definitions.py
@@ -216,5 +216,64 @@ TOOLS = {
             },
             "required": ["context_path"]
         }
+    },
+    "generate_report": {
+        "name": "generate_report",
+        "description": "Generate a CGC_REPORT.md summarising god nodes (highest fan-in), most complex functions, cross-module coupling, potential dead code, and suggested Cypher queries. Use include_java=true to also include Spring endpoint tables, bean stereotype counts, and Maven module dependency summaries.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "output_path": {"type": "string", "description": "Where to write the report. Defaults to CGC_REPORT.md in the server working directory."},
+                "include_java": {"type": "boolean", "description": "Include Spring/Maven Java-specific sections.", "default": False},
+                "god_node_limit": {"type": "integer", "description": "Max rows for god-nodes section.", "default": 15},
+                "complexity_limit": {"type": "integer", "description": "Max rows for complexity section.", "default": 15},
+                "cross_module_limit": {"type": "integer", "description": "Max rows for cross-module connections section.", "default": 20}
+            }
+        }
+    },
+    "find_java_spring_endpoints": {
+        "name": "find_java_spring_endpoints",
+        "description": "Find all Spring HTTP endpoint handler functions in the indexed Java codebase. Optionally filter by HTTP method (GET, POST, PUT, DELETE, PATCH) or URL path pattern.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "http_method": {"type": "string", "description": "Optional: HTTP method to filter by (GET, POST, PUT, DELETE, PATCH).", "enum": ["GET", "POST", "PUT", "DELETE", "PATCH"]},
+                "path_pattern": {"type": "string", "description": "Optional: URL path substring to filter by (e.g. '/api/users')."},
+                "repo_path": {"type": "string", "description": "Optional: Restrict search to a specific repository path."}
+            }
+        }
+    },
+    "find_java_spring_beans": {
+        "name": "find_java_spring_beans",
+        "description": "Find Spring bean classes by stereotype (CONTROLLER, REST_CONTROLLER, SERVICE, REPOSITORY, COMPONENT, CONFIGURATION). Returns class names, file paths, and injection counts.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "stereotype": {"type": "string", "description": "Optional: Filter by Spring stereotype.", "enum": ["CONTROLLER", "REST_CONTROLLER", "SERVICE", "REPOSITORY", "COMPONENT", "CONFIGURATION"]},
+                "repo_path": {"type": "string", "description": "Optional: Restrict search to a specific repository path."}
+            }
+        }
+    },
+    "find_datasource_nodes": {
+        "name": "find_datasource_nodes",
+        "description": "Query Datasource, DbTable, DbColumn, and RedisKeyPattern nodes in the code graph. Returns datasources and their tables/key-patterns, optionally filtered by kind or name.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "description": "Optional: Filter by datasource kind.",
+                    "enum": ["mysql", "cassandra", "redis"]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Optional: Filter by datasource name (substring match)."
+                },
+                "include_columns": {
+                    "type": "boolean",
+                    "description": "If true, include DbColumn / RedisKeyPattern details in the response. Default false."
+                }
+            }
+        }
     }
 }

--- a/src/codegraphcontext/tools/datasources/__init__.py
+++ b/src/codegraphcontext/tools/datasources/__init__.py
@@ -1,0 +1,1 @@
+# Datasource ingestion package (#843 scoped to Redis, Cassandra, Aurora MySQL)

--- a/src/codegraphcontext/tools/datasources/cassandra_ingester.py
+++ b/src/codegraphcontext/tools/datasources/cassandra_ingester.py
@@ -1,0 +1,99 @@
+"""Cassandra schema ingester (#843).
+
+Pulls keyspace + table + column metadata from system_schema and writes
+Datasource / DbTable / DbColumn nodes.
+
+Requires: pip install cassandra-driver
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def ingest(
+    hosts: List[str],
+    port: int,
+    keyspace: str,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    name: Optional[str] = None,
+    env: str = "production",
+) -> Dict[str, Any]:
+    """Fetch schema from Cassandra system_schema and return a datasource graph dict.
+
+    Returns:
+        {
+            datasource: {name, kind, host, env, keyspace},
+            tables:     [{name, fqn, datasource_name}],
+            columns:    [{name, type, nullable, table_fqn, datasource_name}],
+        }
+    """
+    try:
+        from cassandra.cluster import Cluster
+        from cassandra.auth import PlainTextAuthProvider
+    except ImportError:
+        raise ImportError(
+            "Cassandra driver not found. Install with: pip install cassandra-driver"
+        )
+
+    datasource_name = name or f"cassandra-{keyspace}"
+
+    auth_provider = None
+    if username and password:
+        auth_provider = PlainTextAuthProvider(username=username, password=password)
+
+    cluster = Cluster(hosts, port=port, auth_provider=auth_provider)
+    session = cluster.connect()
+
+    try:
+        tables: List[Dict[str, Any]] = []
+        columns: List[Dict[str, Any]] = []
+
+        # Tables from system_schema
+        rows = session.execute(
+            "SELECT table_name, comment FROM system_schema.tables WHERE keyspace_name = %s",
+            (keyspace,),
+        )
+        for row in rows:
+            fqn = f"{keyspace}.{row.table_name}"
+            tables.append({
+                "name": row.table_name,
+                "fqn": fqn,
+                "datasource_name": datasource_name,
+                "comment": getattr(row, "comment", ""),
+            })
+
+        # Columns from system_schema
+        rows = session.execute(
+            """SELECT table_name, column_name, type, kind
+               FROM system_schema.columns
+               WHERE keyspace_name = %s""",
+            (keyspace,),
+        )
+        for row in rows:
+            table_fqn = f"{keyspace}.{row.table_name}"
+            columns.append({
+                "name": row.column_name,
+                "type": row.type,
+                "nullable": True,  # Cassandra columns are always nullable except PK
+                "table_fqn": table_fqn,
+                "datasource_name": datasource_name,
+                "is_primary_key": row.kind in ("partition_key", "clustering"),
+            })
+
+    finally:
+        session.shutdown()
+        cluster.shutdown()
+
+    return {
+        "datasource": {
+            "name": datasource_name,
+            "kind": "cassandra",
+            "host": hosts[0],
+            "env": env,
+            "keyspace": keyspace,
+        },
+        "tables": tables,
+        "columns": columns,
+    }

--- a/src/codegraphcontext/tools/datasources/mysql_ingester.py
+++ b/src/codegraphcontext/tools/datasources/mysql_ingester.py
@@ -1,0 +1,120 @@
+"""Aurora MySQL schema ingester (#843).
+
+Pulls table + column metadata from information_schema and writes
+Datasource / DbTable / DbColumn nodes with HAS_COLUMN and STORED_IN edges.
+
+Requires: pip install PyMySQL  (or mysql-connector-python)
+Connection URI:  mysql://user:pass@host:3306/database
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def _connect(host: str, port: int, user: str, password: str, database: str) -> Any:
+    """Return a DB-API 2.0 connection. Tries PyMySQL then mysql-connector-python."""
+    try:
+        import pymysql
+        return pymysql.connect(
+            host=host, port=port, user=user, password=password, database=database,
+            cursorclass=pymysql.cursors.DictCursor, connect_timeout=10,
+        )
+    except ImportError:
+        pass
+    try:
+        import mysql.connector
+        return mysql.connector.connect(
+            host=host, port=port, user=user, password=password, database=database,
+            connection_timeout=10,
+        )
+    except ImportError:
+        raise ImportError(
+            "MySQL driver not found. Install with: pip install PyMySQL"
+        )
+
+
+def ingest(
+    host: str,
+    port: int,
+    user: str,
+    password: str,
+    database: str,
+    name: Optional[str] = None,
+    env: str = "production",
+) -> Dict[str, Any]:
+    """Fetch schema from Aurora MySQL and return a datasource graph dict.
+
+    Returns:
+        {
+            datasource: {name, kind, host, env, database},
+            tables:     [{name, fqn, datasource_name}],
+            columns:    [{name, type, nullable, table_fqn, datasource_name}],
+        }
+    """
+    datasource_name = name or f"mysql-{database}"
+    conn = _connect(host, port, user, password, database)
+
+    try:
+        tables: List[Dict[str, Any]] = []
+        columns: List[Dict[str, Any]] = []
+
+        with conn.cursor() as cur:
+            # Tables
+            cur.execute(
+                """
+                SELECT TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT
+                FROM information_schema.TABLES
+                WHERE TABLE_SCHEMA = %s
+                ORDER BY TABLE_NAME
+                """,
+                (database,),
+            )
+            for row in cur.fetchall():
+                fqn = f"{database}.{row['TABLE_NAME']}"
+                tables.append({
+                    "name": row["TABLE_NAME"],
+                    "fqn": fqn,
+                    "datasource_name": datasource_name,
+                    "table_type": row.get("TABLE_TYPE", "BASE TABLE"),
+                    "estimated_rows": row.get("TABLE_ROWS"),
+                    "comment": row.get("TABLE_COMMENT", ""),
+                })
+
+            # Columns
+            cur.execute(
+                """
+                SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE, IS_NULLABLE,
+                       COLUMN_DEFAULT, COLUMN_COMMENT, COLUMN_KEY
+                FROM information_schema.COLUMNS
+                WHERE TABLE_SCHEMA = %s
+                ORDER BY TABLE_NAME, ORDINAL_POSITION
+                """,
+                (database,),
+            )
+            for row in cur.fetchall():
+                table_fqn = f"{database}.{row['TABLE_NAME']}"
+                columns.append({
+                    "name": row["COLUMN_NAME"],
+                    "type": row["DATA_TYPE"],
+                    "nullable": row["IS_NULLABLE"] == "YES",
+                    "table_fqn": table_fqn,
+                    "datasource_name": datasource_name,
+                    "is_primary_key": row.get("COLUMN_KEY") == "PRI",
+                    "comment": row.get("COLUMN_COMMENT", ""),
+                })
+
+    finally:
+        conn.close()
+
+    return {
+        "datasource": {
+            "name": datasource_name,
+            "kind": "mysql",
+            "host": host,
+            "env": env,
+            "database": database,
+        },
+        "tables": tables,
+        "columns": columns,
+    }

--- a/src/codegraphcontext/tools/datasources/redis_ingester.py
+++ b/src/codegraphcontext/tools/datasources/redis_ingester.py
@@ -1,0 +1,122 @@
+"""Redis schema ingester (#843).
+
+Redis is schema-less, so "schema" here means key-pattern discovery.
+Scans keyspace for key patterns via SCAN + TYPE and groups them into
+RedisKeyPattern nodes (e.g. "user:*", "session:*").
+
+Requires: pip install redis
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+
+def _normalize_pattern(key: str) -> str:
+    """Replace numeric / UUID segments with * to group keys into patterns.
+
+    Examples:
+        user:12345        -> user:*
+        session:abc-def   -> session:*
+        cache:user:99     -> cache:user:*
+    """
+    # Replace numeric IDs
+    key = re.sub(r":\d+", ":*", key)
+    # Replace UUID-like segments
+    key = re.sub(
+        r":[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        ":*",
+        key,
+        flags=re.IGNORECASE,
+    )
+    # Replace long hex strings (>= 12 chars)
+    key = re.sub(r":[0-9a-f]{12,}", ":*", key, flags=re.IGNORECASE)
+    return key
+
+
+def ingest(
+    host: str,
+    port: int,
+    db: int = 0,
+    password: Optional[str] = None,
+    name: Optional[str] = None,
+    env: str = "production",
+    scan_count: int = 1000,
+    max_keys: int = 10000,
+) -> Dict[str, Any]:
+    """Discover Redis key patterns and return a datasource graph dict.
+
+    Args:
+        host, port, db, password: Connection parameters.
+        name:        Logical datasource name. Defaults to "redis-{host}:{port}/{db}".
+        env:         Deployment environment label.
+        scan_count:  SCAN COUNT hint per iteration.
+        max_keys:    Stop after scanning this many keys (avoid full keyspace scan in prod).
+
+    Returns:
+        {
+            datasource:   {name, kind, host, env, db},
+            key_patterns: [{pattern, key_type, example_key, count, datasource_name}],
+        }
+    """
+    try:
+        import redis as redis_lib
+    except ImportError:
+        raise ImportError(
+            "Redis driver not found. Install with: pip install redis"
+        )
+
+    datasource_name = name or f"redis-{host}:{port}/{db}"
+
+    r = redis_lib.Redis(
+        host=host, port=port, db=db,
+        password=password, socket_connect_timeout=10,
+        decode_responses=True,
+    )
+    r.ping()  # fail fast if unreachable
+
+    # SCAN for key samples
+    pattern_types: Dict[str, str] = {}      # pattern -> redis type
+    pattern_examples: Dict[str, str] = {}   # pattern -> one real key
+    pattern_counts: Counter = Counter()
+
+    cursor = 0
+    total_scanned = 0
+    while total_scanned < max_keys:
+        cursor, keys = r.scan(cursor=cursor, count=scan_count)
+        for key in keys:
+            pat = _normalize_pattern(key)
+            pattern_counts[pat] += 1
+            if pat not in pattern_types:
+                try:
+                    pattern_types[pat] = r.type(key)
+                    pattern_examples[pat] = key
+                except Exception:
+                    pattern_types[pat] = "unknown"
+                    pattern_examples[pat] = key
+        total_scanned += len(keys)
+        if cursor == 0:
+            break  # full scan complete
+
+    key_patterns: List[Dict[str, Any]] = []
+    for pattern, count in pattern_counts.most_common():
+        key_patterns.append({
+            "pattern": pattern,
+            "key_type": pattern_types.get(pattern, "unknown"),
+            "example_key": pattern_examples.get(pattern, ""),
+            "count": count,
+            "datasource_name": datasource_name,
+        })
+
+    return {
+        "datasource": {
+            "name": datasource_name,
+            "kind": "redis",
+            "host": host,
+            "env": env,
+            "db": db,
+        },
+        "key_patterns": key_patterns,
+    }

--- a/src/codegraphcontext/tools/handlers/analysis_handlers.py
+++ b/src/codegraphcontext/tools/handlers/analysis_handlers.py
@@ -149,3 +149,176 @@ def find_code(code_finder: CodeFinder, **args) -> Dict[str, Any]:
     except Exception as e:
         debug_log(f"Error finding code: {str(e)}")
         return {"error": f"Failed to find code: {str(e)}"}
+
+
+# ── Spring-aware handlers (#887 / #889) ───────────────────────────────────────
+
+def find_java_spring_endpoints(code_finder: CodeFinder, **args) -> Dict[str, Any]:
+    """Return all Spring HTTP endpoint functions, optionally filtered by method or path."""
+    http_method = args.get("http_method")
+    path_pattern = args.get("path_pattern")
+    repo_path = args.get("repo_path")
+
+    conditions = ["fn.http_method IS NOT NULL"]
+    params: Dict[str, Any] = {}
+
+    if http_method:
+        conditions.append("fn.http_method = $http_method")
+        params["http_method"] = http_method.upper()
+
+    if path_pattern:
+        conditions.append("fn.http_path CONTAINS $path_pattern")
+        params["path_pattern"] = path_pattern
+
+    if repo_path:
+        conditions.append("fn.path STARTS WITH $repo_path")
+        params["repo_path"] = repo_path
+
+    where_clause = " AND ".join(conditions)
+    query = f"""
+        MATCH (fn:Function)
+        WHERE {where_clause}
+        RETURN fn.http_method AS method, fn.http_path AS path,
+               fn.name AS handler, fn.path AS file, fn.line_number AS line_number
+        ORDER BY fn.http_path, fn.http_method
+        LIMIT 100
+    """
+
+    try:
+        with code_finder.driver.session() as session:
+            result = session.run(query, **params)
+            rows = [dict(r) for r in result]
+        return {"success": True, "endpoints": rows, "count": len(rows)}
+    except Exception as exc:
+        debug_log(f"Error finding Spring endpoints: {exc}")
+        return {"error": str(exc)}
+
+
+def find_java_spring_beans(code_finder: CodeFinder, **args) -> Dict[str, Any]:
+    """Return Spring bean classes, optionally filtered by stereotype."""
+    stereotype = args.get("stereotype")
+    repo_path = args.get("repo_path")
+
+    conditions = ["c.spring_stereotype IS NOT NULL"]
+    params: Dict[str, Any] = {}
+
+    if stereotype:
+        conditions.append("c.spring_stereotype = $stereotype")
+        params["stereotype"] = stereotype.upper()
+
+    if repo_path:
+        conditions.append("c.path STARTS WITH $repo_path")
+        params["repo_path"] = repo_path
+
+    where_clause = " AND ".join(conditions)
+    query = f"""
+        MATCH (c:Class)
+        WHERE {where_clause}
+        OPTIONAL MATCH ()-[:INJECTS]->(c)
+        WITH c, count(*) AS injection_count
+        RETURN c.name AS name, c.spring_stereotype AS stereotype,
+               c.path AS file, c.line_number AS line_number, injection_count
+        ORDER BY stereotype, name
+        LIMIT 100
+    """
+
+    try:
+        with code_finder.driver.session() as session:
+            result = session.run(query, **params)
+            rows = [dict(r) for r in result]
+        return {"success": True, "beans": rows, "count": len(rows)}
+    except Exception as exc:
+        debug_log(f"Error finding Spring beans: {exc}")
+        return {"error": str(exc)}
+
+
+def find_datasource_nodes(code_finder: CodeFinder, **args) -> Dict[str, Any]:
+    """Return Datasource nodes and their tables / key-patterns from the code graph (#843)."""
+    kind = args.get("kind")
+    name_filter = args.get("name")
+    include_columns = args.get("include_columns", False)
+
+    ds_conditions = []
+    params: Dict[str, Any] = {}
+
+    if kind:
+        ds_conditions.append("d.kind = $kind")
+        params["kind"] = kind
+
+    if name_filter:
+        ds_conditions.append("d.name CONTAINS $name_filter")
+        params["name_filter"] = name_filter
+
+    where_clause = ("WHERE " + " AND ".join(ds_conditions)) if ds_conditions else ""
+
+    # Base datasource + table query
+    table_query = f"""
+        MATCH (d:Datasource)
+        {where_clause}
+        OPTIONAL MATCH (tbl:DbTable)-[:STORED_IN]->(d)
+        RETURN d.name AS datasource, d.kind AS kind, d.host AS host, d.env AS env,
+               collect(tbl.fqn) AS tables
+        ORDER BY d.kind, d.name
+    """
+
+    # Redis key patterns
+    kp_query = f"""
+        MATCH (d:Datasource)
+        {where_clause}
+        WHERE d.kind = 'redis'
+        OPTIONAL MATCH (kp:RedisKeyPattern)-[:STORED_IN]->(d)
+        RETURN d.name AS datasource,
+               collect({{pattern: kp.pattern, key_type: kp.key_type, count: kp.count}}) AS key_patterns
+    """
+
+    try:
+        with code_finder.driver.session() as session:
+            ds_rows = [dict(r) for r in session.run(table_query, **params)]
+
+        redis_kp: Dict[str, Any] = {}
+        try:
+            with code_finder.driver.session() as session:
+                for r in session.run(kp_query, **params):
+                    redis_kp[r["datasource"]] = r["key_patterns"]
+        except Exception:
+            pass  # Redis key-pattern query is best-effort
+
+        # Optionally attach columns
+        columns_by_table: Dict[str, Any] = {}
+        if include_columns:
+            col_query = f"""
+                MATCH (d:Datasource) {where_clause}
+                MATCH (tbl:DbTable)-[:STORED_IN]->(d)
+                MATCH (tbl)-[:HAS_COLUMN]->(col:DbColumn)
+                RETURN tbl.fqn AS table_fqn, col.name AS col_name, col.type AS col_type,
+                       col.nullable AS nullable, col.is_primary_key AS is_pk
+                ORDER BY table_fqn, col_name
+            """
+            try:
+                with code_finder.driver.session() as session:
+                    for r in session.run(col_query, **params):
+                        fqn = r["table_fqn"]
+                        columns_by_table.setdefault(fqn, []).append({
+                            "name": r["col_name"],
+                            "type": r["col_type"],
+                            "nullable": r["nullable"],
+                            "is_primary_key": r["is_pk"],
+                        })
+            except Exception:
+                pass
+
+        # Merge into response
+        for row in ds_rows:
+            ds_name = row["datasource"]
+            if ds_name in redis_kp:
+                row["key_patterns"] = redis_kp[ds_name]
+            if include_columns:
+                for tbl_fqn in row.get("tables", []):
+                    if tbl_fqn in columns_by_table:
+                        row.setdefault("columns", {})[tbl_fqn] = columns_by_table[tbl_fqn]
+
+        return {"success": True, "datasources": ds_rows, "count": len(ds_rows)}
+    except Exception as exc:
+        debug_log(f"Error finding datasource nodes: {exc}")
+        return {"error": str(exc)}
+

--- a/src/codegraphcontext/tools/indexing/embeddings.py
+++ b/src/codegraphcontext/tools/indexing/embeddings.py
@@ -1,0 +1,266 @@
+"""Batch embedding generation for Function nodes stored in Neo4j.
+
+Usage (after indexing is complete):
+    from codegraphcontext.tools.indexing.embeddings import EmbeddingPipeline
+    pipeline = EmbeddingPipeline(driver)
+    pipeline.run(repo_path="/opt/repos/myapp")
+
+Embeddings are stored on each Function node as `embedding` (list[float]).
+A Neo4j vector index named "function_embeddings" is created on first run.
+
+Model selection (via env var CGC_EMBEDDING_MODEL):
+  - "openai"         → text-embedding-3-small via OpenAI API  (requires OPENAI_API_KEY)
+  - "local"          → sentence-transformers/all-MiniLM-L6-v2 if available, else fastembed BAAI/bge-small-en-v1.5
+  - "fastembed"      → fastembed BAAI/bge-small-en-v1.5 (ONNX, no torch required)
+  - any HF model ID  → loaded via sentence-transformers
+
+The embedding dimension is stored on the vector index (1536 for OpenAI, 384 for MiniLM).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from ...utils.debug_log import info_logger, warning_logger, error_logger
+
+# Embedding dimension constants
+_DIM_OPENAI = 1536
+_DIM_MINILM = 384
+_DIM_BGE_SMALL = 384
+
+_VECTOR_INDEX_NAME = "function_embeddings"
+
+
+def _build_text(fn: Dict[str, Any]) -> str:
+    """Construct the text to embed for a Function node.
+
+    We combine name, qualified_name, docstring, and parameter names
+    so that semantically similar functions are close in embedding space.
+    Never returns an empty string — falls back to "(anonymous)" so embedders
+    don't receive blank input.
+    """
+    parts: List[str] = []
+    qname = fn.get("qualified_name") or fn.get("name") or ""
+    if qname:
+        parts.append(qname)
+    if fn.get("docstring"):
+        parts.append(fn["docstring"])
+    params = fn.get("parameters") or fn.get("args") or []
+    if params:
+        parts.append("params: " + ", ".join(str(p) for p in params))
+    return " | ".join(parts) or "(anonymous)"
+
+
+class _OpenAIEmbedder:
+    def __init__(self, model: str = "text-embedding-3-small"):
+        try:
+            import openai
+        except ImportError:
+            raise ImportError("openai package required: pip install openai")
+        self.client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+        self.model = model
+        self.dim = _DIM_OPENAI
+
+    def embed_batch(self, texts: List[str]) -> List[List[float]]:
+        response = self.client.embeddings.create(input=texts, model=self.model)
+        return [item.embedding for item in response.data]
+
+
+class _LocalEmbedder:
+    def __init__(self, model_name: str = "sentence-transformers/all-MiniLM-L6-v2"):
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            raise ImportError(
+                "sentence-transformers package required: pip install sentence-transformers"
+            )
+        self.model = SentenceTransformer(model_name)
+        self.dim = self.model.get_sentence_embedding_dimension()
+
+    def embed_batch(self, texts: List[str]) -> List[List[float]]:
+        return self.model.encode(texts, show_progress_bar=False).tolist()
+
+
+class _FastEmbedder:
+    """ONNX-based embedder via fastembed — no torch required, works on Python 3.13."""
+
+    def __init__(self, model_name: str = "BAAI/bge-small-en-v1.5"):
+        try:
+            from fastembed import TextEmbedding
+        except ImportError:
+            raise ImportError(
+                "fastembed package required: pip install fastembed"
+            )
+        self._model = TextEmbedding(model_name=model_name)
+        self.dim = _DIM_BGE_SMALL
+
+    def embed_batch(self, texts: List[str]) -> List[List[float]]:
+        return [vec.tolist() for vec in self._model.embed(texts)]
+
+
+def _get_embedder(model_spec: Optional[str] = None):
+    """Return the appropriate embedder based on CGC_EMBEDDING_MODEL env var.
+
+    Falls back automatically: sentence-transformers → fastembed → error.
+    """
+    spec = model_spec or os.environ.get("CGC_EMBEDDING_MODEL", "local")
+    if spec == "openai":
+        return _OpenAIEmbedder()
+    if spec == "fastembed":
+        return _FastEmbedder()
+    # "local" or a specific HF model ID — try sentence-transformers, fall back to fastembed
+    if spec == "local":
+        try:
+            return _LocalEmbedder("sentence-transformers/all-MiniLM-L6-v2")
+        except ImportError:
+            info_logger(
+                "sentence-transformers not available; falling back to fastembed (ONNX)"
+            )
+            return _FastEmbedder()
+    # Explicit HF model ID — must use sentence-transformers
+    return _LocalEmbedder(spec)
+
+
+class EmbeddingPipeline:
+    """Reads Function nodes from Neo4j, generates embeddings, and writes them back."""
+
+    def __init__(self, driver: Any, batch_size: int = 256):
+        self.driver = driver
+        self.batch_size = batch_size
+
+    def _ensure_vector_index(self, dim: int) -> None:
+        """Create the Neo4j vector index if it doesn't already exist."""
+        with self.driver.session() as session:
+            try:
+                session.run(
+                    f"""
+                    CREATE VECTOR INDEX {_VECTOR_INDEX_NAME} IF NOT EXISTS
+                    FOR (f:Function) ON (f.embedding)
+                    OPTIONS {{indexConfig: {{
+                        `vector.dimensions`: {dim},
+                        `vector.similarity_function`: 'cosine'
+                    }}}}
+                    """
+                )
+                info_logger(f"[EMBED] Vector index '{_VECTOR_INDEX_NAME}' ready (dim={dim})")
+            except Exception as e:
+                warning_logger(f"[EMBED] Could not create vector index: {e}")
+
+    def _fetch_unembedded(self, repo_path: str) -> List[Tuple[str, str, Dict[str, Any]]]:
+        """Return (path, name, props) for Function nodes without an embedding.
+
+        Uses STARTS WITH (not CONTAINS) so a repo at /opt/repos/myapp never
+        accidentally matches /opt/repos/myapp_extra.
+        """
+        repo_path_prefix = repo_path.rstrip("/") + "/"
+        with self.driver.session() as session:
+            result = session.run(
+                """
+                MATCH (f:Function)
+                WHERE f.path STARTS WITH $repo_path_prefix
+                  AND f.embedding IS NULL
+                RETURN f.path AS path, f.name AS name, f.line_number AS line_number,
+                       f.qualified_name AS qualified_name,
+                       f.docstring AS docstring,
+                       f.parameters AS parameters
+                """,
+                repo_path_prefix=repo_path_prefix,
+            )
+            return [
+                (
+                    row["path"],
+                    row["name"],
+                    {
+                        "line_number": row["line_number"],
+                        "qualified_name": row.get("qualified_name"),
+                        "docstring": row.get("docstring"),
+                        "parameters": row.get("parameters") or [],
+                    },
+                )
+                for row in result
+            ]
+
+    def _write_embeddings(self, rows: List[Dict[str, Any]]) -> None:
+        with self.driver.session() as session:
+            session.run(
+                """
+                UNWIND $rows AS row
+                MATCH (f:Function {name: row.name, path: row.path})
+                WHERE row.line_number IS NULL OR f.line_number = row.line_number
+                SET f.embedding = row.embedding
+                """,
+                rows=rows,
+            )
+
+    def invalidate_for_file(self, file_path: str) -> int:
+        """Clear embeddings for all Function nodes in the given file.
+
+        Called by the watcher after a file is modified so stale embeddings
+        are re-generated on the next EmbeddingPipeline.run() call.
+        Returns the number of functions cleared.
+        """
+        with self.driver.session() as session:
+            result = session.run(
+                """
+                MATCH (f:Function {path: $path})
+                WHERE f.embedding IS NOT NULL
+                REMOVE f.embedding
+                RETURN count(f) AS cleared
+                """,
+                path=file_path,
+            )
+            row = result.single()
+            cleared = row["cleared"] if row else 0
+            info_logger(f"[EMBED] Invalidated {cleared} embeddings for {file_path}")
+            return cleared
+
+    def run(self, repo_path: str, model_spec: Optional[str] = None) -> None:
+        """Generate and persist embeddings for all un-embedded Function nodes in repo."""
+        embedder = _get_embedder(model_spec)
+        self._ensure_vector_index(embedder.dim)
+
+        info_logger(f"[EMBED] Fetching un-embedded functions for {repo_path} ...")
+        nodes = self._fetch_unembedded(repo_path)
+        info_logger(f"[EMBED] Found {len(nodes)} functions to embed")
+
+        if not nodes:
+            return
+
+        total = 0
+        batch_num = 0
+        t0 = time.time()
+        n_batches = (len(nodes) + self.batch_size - 1) // self.batch_size
+        for i in range(0, len(nodes), self.batch_size):
+            batch = nodes[i : i + self.batch_size]
+            texts = [_build_text({"name": name, **props}) for _path, name, props in batch]
+            try:
+                vectors = embedder.embed_batch(texts)
+            except Exception as e:
+                error_logger(f"[EMBED] Batch {batch_num+1}/{n_batches} failed: {e}")
+                batch_num += 1
+                continue
+
+            write_rows = [
+                {
+                    "path": path,
+                    "name": name,
+                    "line_number": props.get("line_number"),
+                    "embedding": vec,
+                }
+                for (path, name, props), vec in zip(batch, vectors)
+            ]
+            self._write_embeddings(write_rows)
+            total += len(write_rows)
+            batch_num += 1
+
+            # Log every 10 batches so output is readable without being noisy
+            if batch_num % 10 == 0 or batch_num == n_batches:
+                elapsed = time.time() - t0
+                pct = int(100 * total / len(nodes))
+                info_logger(
+                    f"[EMBED] batch {batch_num}/{n_batches} — {total}/{len(nodes)} ({pct}%) in {elapsed:.1f}s"
+                )
+
+        info_logger(f"[EMBED] Done: {total} embeddings written in {time.time() - t0:.1f}s")

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -87,12 +87,14 @@ class GraphWriter:
             session.run(
                 """
                 MERGE (f:File {path: $path})
-                SET f.name = $name, f.relative_path = $relative_path, f.is_dependency = $is_dependency
+                SET f.name = $name, f.relative_path = $relative_path, f.is_dependency = $is_dependency,
+                    f.package_name = $package_name
             """,
                 path=file_path_str,
                 name=file_name,
                 relative_path=relative_path,
                 is_dependency=is_dependency,
+                package_name=file_data.get("package_name"),
             )
 
             file_path_obj = Path(file_path_str)
@@ -449,37 +451,43 @@ class GraphWriter:
             UNWIND $batch AS row
             MATCH (caller:Function {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Function {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
         """
         q_fn_to_cls = """
             UNWIND $batch AS row
             MATCH (caller:Function {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Class {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
         """
         q_cls_to_fn = """
             UNWIND $batch AS row
             MATCH (caller:Class {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Function {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
         """
         q_cls_to_cls = """
             UNWIND $batch AS row
             MATCH (caller:Class {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Class {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
         """
         q_file_to_fn = """
             UNWIND $batch AS row
             MATCH (caller:File {path: row.caller_file_path})
             MATCH (called:Function {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
         """
         q_file_to_cls = """
             UNWIND $batch AS row
             MATCH (caller:File {path: row.caller_file_path})
             MATCH (called:Class {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
         """
         groups: List[Tuple[str, List[Dict], str]] = [
             ("fn→fn", fn_to_fn, q_fn_to_fn),

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -1043,6 +1043,50 @@ class GraphWriter:
                 written += len(op_edges[i : i + batch_size])
         info_logger(f"[MYBATIS] Written {written} READS/WRITES MyBatis edges")
 
+    def write_spring_data_repo_links(self, orm_batch: List[Dict[str, Any]]) -> None:
+        """Write READS/WRITES edges for Spring Data repository derived-query methods.
+
+        Each record must have kind='spring_data_method' and:
+            entity_class, method_name, method_path, operation, line_number
+
+        Uses a two-hop lookup: Function → (entity_class Class)-[:MAPS_TO]→ DbTable
+        so no table name is required at parse time.
+        """
+        records = [r for r in orm_batch if r.get("kind") == "spring_data_method"]
+        if not records:
+            return
+
+        edges = [
+            {
+                "method_name": r["method_name"],
+                "method_path": r["method_path"],
+                "entity_class": r["entity_class"],
+                "operation": r.get("operation", "READS"),
+                "line_number": r.get("line_number", 0),
+            }
+            for r in records
+        ]
+
+        batch_size = 500
+        written = 0
+        for op in ("READS", "WRITES"):
+            op_edges = [e for e in edges if e["operation"] == op]
+            if not op_edges:
+                continue
+            for i in range(0, len(op_edges), batch_size):
+                with self.driver.session() as session:
+                    session.run(
+                        f"""
+                        UNWIND $batch AS q
+                        MATCH (fn:Function {{name: q.method_name, path: q.method_path}})
+                        MATCH (entity:Class {{name: q.entity_class}})-[:MAPS_TO]->(tbl:DbTable)
+                        MERGE (fn)-[:{op} {{line_number: q.line_number, source: 'spring_data'}}]->(tbl)
+                        """,
+                        batch=op_edges[i : i + batch_size],
+                    )
+                written += len(op_edges[i : i + batch_size])
+        info_logger(f"[SPRING_DATA] Written {written} READS/WRITES derived-query edges")
+
     def delete_repository_from_graph(self, repo_path: str) -> bool:
         repo_path_str = repo_path
         path_prefix = repo_path_str + "/"

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -221,14 +221,14 @@ class GraphWriter:
                                 b[k] = bool(v) if v is not None else False
                             else:
                                 if v is None:
-                                    b[k] = ""
+                                    b.pop(k, None)
                                 elif isinstance(v, list):
                                     b[k] = _json.dumps(v)
                                 elif not isinstance(v, str):
                                     b[k] = str(v)
 
                     key_order = sorted(all_keys)
-                    batch[:] = [{k: b[k] for k in key_order} for b in batch]
+                    batch[:] = [{k: b[k] for k in key_order if k in b} for b in batch]
 
                 session.run(
                     f"""
@@ -452,42 +452,48 @@ class GraphWriter:
             MATCH (caller:Function {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Function {name: row.called_name, path: row.called_file_path})
             MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
+                c.confidence_label = row.confidence_label
         """
         q_fn_to_cls = """
             UNWIND $batch AS row
             MATCH (caller:Function {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Class {name: row.called_name, path: row.called_file_path})
             MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
+                c.confidence_label = row.confidence_label
         """
         q_cls_to_fn = """
             UNWIND $batch AS row
             MATCH (caller:Class {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Function {name: row.called_name, path: row.called_file_path})
             MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
+                c.confidence_label = row.confidence_label
         """
         q_cls_to_cls = """
             UNWIND $batch AS row
             MATCH (caller:Class {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Class {name: row.called_name, path: row.called_file_path})
             MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
+                c.confidence_label = row.confidence_label
         """
         q_file_to_fn = """
             UNWIND $batch AS row
             MATCH (caller:File {path: row.caller_file_path})
             MATCH (called:Function {name: row.called_name, path: row.called_file_path})
             MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
+                c.confidence_label = row.confidence_label
         """
         q_file_to_cls = """
             UNWIND $batch AS row
             MATCH (caller:File {path: row.caller_file_path})
             MATCH (called:Class {name: row.called_name, path: row.called_file_path})
             MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier
+            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
+                c.confidence_label = row.confidence_label
         """
         groups: List[Tuple[str, List[Dict], str]] = [
             ("fn→fn", fn_to_fn, q_fn_to_fn),
@@ -596,7 +602,8 @@ class GraphWriter:
                     UNWIND $batch AS row
                     MATCH (child:Class {name: row.child_name, path: row.path})
                     MATCH (parent:Class {name: row.parent_name, path: row.resolved_parent_file_path})
-                    MERGE (child)-[:INHERITS]->(parent)
+                    MERGE (child)-[r:INHERITS]->(parent)
+                    SET r.confidence_label = coalesce(row.confidence_label, 'EXTRACTED')
                 """,
                     batch=batch,
                 )
@@ -662,8 +669,382 @@ class GraphWriter:
                     path=p,
                 )
 
+    # ── Spring semantic edges (#887) ───────────────────────────────────────────
+
+    def write_spring_inject_links(self, inject_batch: List[Dict[str, Any]]) -> None:
+        """Create INJECTS edges: injector Class -> injected Class (via @Autowired / @Inject)."""
+        if not inject_batch:
+            return
+        info_logger(f"[SPRING] Writing {len(inject_batch)} INJECTS edges...")
+        batch_size = 500
+        with self.driver.session() as session:
+            for i in range(0, len(inject_batch), batch_size):
+                batch = inject_batch[i : i + batch_size]
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MATCH (injector:Class {name: row.injector_class, path: row.injector_path})
+                    MATCH (injected:Class {name: row.injected_class})
+                    MERGE (injector)-[r:INJECTS]->(injected)
+                    SET r.field_name = row.field_name,
+                        r.inject_line = row.inject_line,
+                        r.confidence_label = 'EXTRACTED'
+                    """,
+                    batch=batch,
+                )
+        info_logger(f"[SPRING] INJECTS edges written.")
+
+    def write_spring_endpoint_properties(self, endpoint_batch: List[Dict[str, Any]]) -> None:
+        """Set http_method / http_path / transactional properties on Function nodes."""
+        if not endpoint_batch:
+            return
+        info_logger(f"[SPRING] Updating {len(endpoint_batch)} endpoint function properties...")
+        batch_size = 500
+        with self.driver.session() as session:
+            for i in range(0, len(endpoint_batch), batch_size):
+                batch = endpoint_batch[i : i + batch_size]
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MATCH (fn:Function {name: row.func_name, path: row.path, line_number: row.line_number})
+                    SET fn.http_method = row.http_method,
+                        fn.http_path = row.http_path
+                    """,
+                    batch=batch,
+                )
+        info_logger("[SPRING] Endpoint properties updated.")
+
+    # ── Maven / Gradle build graph (#888) ─────────────────────────────────────
+
+    def write_maven_build_graph(self, build_data: Dict[str, Any], repo_path_str: str) -> None:
+        """Write MavenModule nodes, CHILD_MODULE, MODULE_DEPENDS_ON, USES_LIBRARY edges."""
+        if not build_data:
+            return
+        modules = build_data.get("modules", [])
+        external_libs = build_data.get("external_libs", [])
+        inter_module_deps = build_data.get("inter_module_deps", [])
+        child_relations = build_data.get("child_relations", [])
+
+        if not modules:
+            return
+
+        info_logger(f"[MAVEN] Writing {len(modules)} modules, "
+                    f"{len(inter_module_deps)} inter-module deps, "
+                    f"{len(external_libs)} external libs...")
+
+        batch_size = 200
+        with self.driver.session() as session:
+            # MavenModule nodes
+            for i in range(0, len(modules), batch_size):
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MERGE (m:MavenModule {group_id: row.group_id, artifact_id: row.artifact_id})
+                    SET m.version = row.version,
+                        m.packaging = row.packaging,
+                        m.pom_path = row.pom_path,
+                        m.repo_path = $repo_path
+                    """,
+                    batch=modules[i : i + batch_size],
+                    repo_path=repo_path_str,
+                )
+            # CHILD_MODULE edges
+            for i in range(0, len(child_relations), batch_size):
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MATCH (parent:MavenModule {artifact_id: row.parent_artifact_id})
+                    MATCH (child:MavenModule {artifact_id: row.child_artifact_id})
+                    MERGE (parent)-[:CHILD_MODULE]->(child)
+                    """,
+                    batch=child_relations[i : i + batch_size],
+                )
+            # MODULE_DEPENDS_ON edges (inter-module)
+            for i in range(0, len(inter_module_deps), batch_size):
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MATCH (src:MavenModule {artifact_id: row.src_artifact_id})
+                    MATCH (tgt:MavenModule {artifact_id: row.tgt_artifact_id})
+                    MERGE (src)-[r:MODULE_DEPENDS_ON]->(tgt)
+                    SET r.scope = row.scope
+                    """,
+                    batch=inter_module_deps[i : i + batch_size],
+                )
+            # ExternalLibrary nodes + USES_LIBRARY edges
+            for i in range(0, len(external_libs), batch_size):
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MERGE (lib:ExternalLibrary {group_id: row.group_id, artifact_id: row.artifact_id})
+                    SET lib.version = row.version
+                    WITH lib, row
+                    MATCH (src:MavenModule {artifact_id: row.src_artifact_id})
+                    MERGE (src)-[r:USES_LIBRARY]->(lib)
+                    SET r.scope = row.scope
+                    """,
+                    batch=external_libs[i : i + batch_size],
+                )
+
+        info_logger("[MAVEN] Build graph written.")
+
+    def write_gradle_build_graph(self, build_data: Dict[str, Any], repo_path_str: str) -> None:
+        """Write GradleModule nodes and MODULE_DEPENDS_ON / USES_LIBRARY edges."""
+        if not build_data:
+            return
+        modules = build_data.get("modules", [])
+        inter_module_deps = build_data.get("inter_module_deps", [])
+        external_libs = build_data.get("external_libs", [])
+
+        if not modules:
+            return
+
+        info_logger(f"[GRADLE] Writing {len(modules)} modules, "
+                    f"{len(inter_module_deps)} inter-module deps, "
+                    f"{len(external_libs)} external libs...")
+
+        batch_size = 200
+        with self.driver.session() as session:
+            for i in range(0, len(modules), batch_size):
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MERGE (m:GradleModule {name: row.name})
+                    SET m.build_file = row.build_file, m.repo_path = $repo_path
+                    """,
+                    batch=modules[i : i + batch_size],
+                    repo_path=repo_path_str,
+                )
+            for i in range(0, len(inter_module_deps), batch_size):
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MATCH (src:GradleModule {name: row.src_name})
+                    MATCH (tgt:GradleModule {name: row.tgt_name})
+                    MERGE (src)-[r:MODULE_DEPENDS_ON]->(tgt)
+                    SET r.configuration = row.configuration
+                    """,
+                    batch=inter_module_deps[i : i + batch_size],
+                )
+            for i in range(0, len(external_libs), batch_size):
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MERGE (lib:ExternalLibrary {group_id: row.group_id, artifact_id: row.artifact_id})
+                    SET lib.version = row.version
+                    WITH lib, row
+                    MATCH (src:GradleModule {name: row.src_name})
+                    MERGE (src)-[r:USES_LIBRARY]->(lib)
+                    SET r.configuration = row.configuration
+                    """,
+                    batch=external_libs[i : i + batch_size],
+                )
+
+        info_logger("[GRADLE] Build graph written.")
+
+    # ── Datasource architecture graph (#843 scoped) ──────────────────────────
+
+    def write_datasource_graph(self, ingested: Dict[str, Any]) -> None:
+        """Write Datasource / DbTable / DbColumn / RedisKeyPattern nodes and edges.
+
+        Accepts the dict returned by mysql_ingester.ingest(), cassandra_ingester.ingest(),
+        or redis_ingester.ingest().
+        """
+        ds = ingested.get("datasource", {})
+        if not ds:
+            return
+        ds_name = ds["name"]
+        ds_kind = ds.get("kind", "unknown")
+
+        with self.driver.session() as session:
+            session.run(
+                """
+                MERGE (d:Datasource {name: $name})
+                SET d.kind = $kind, d.host = $host, d.env = $env
+                """,
+                name=ds_name,
+                kind=ds_kind,
+                host=ds.get("host", ""),
+                env=ds.get("env", ""),
+            )
+        info_logger(f"[DATASOURCE] Written Datasource node: {ds_name} ({ds_kind})")
+
+        # ── MySQL / Cassandra tables + columns ────────────────────────────
+        tables = ingested.get("tables", [])
+        batch_size = 500
+
+        for i in range(0, len(tables), batch_size):
+            with self.driver.session() as session:
+                session.run(
+                    """
+                    UNWIND $batch AS t
+                    MERGE (tbl:DbTable {fqn: t.fqn})
+                    SET tbl.name = t.name,
+                        tbl.datasource_name = t.datasource_name,
+                        tbl.table_type = coalesce(t.table_type, ''),
+                        tbl.comment = coalesce(t.comment, '')
+                    WITH tbl, t
+                    MATCH (d:Datasource {name: t.datasource_name})
+                    MERGE (tbl)-[:STORED_IN]->(d)
+                    """,
+                    batch=tables[i : i + batch_size],
+                )
+        if tables:
+            info_logger(f"[DATASOURCE] Written {len(tables)} DbTable nodes for {ds_name}")
+
+        columns = ingested.get("columns", [])
+        for i in range(0, len(columns), batch_size):
+            with self.driver.session() as session:
+                session.run(
+                    """
+                    UNWIND $batch AS c
+                    MERGE (col:DbColumn {name: c.name, table_fqn: c.table_fqn})
+                    SET col.type = c.type,
+                        col.nullable = c.nullable,
+                        col.datasource_name = c.datasource_name,
+                        col.is_primary_key = coalesce(c.is_primary_key, false)
+                    WITH col, c
+                    MATCH (tbl:DbTable {fqn: c.table_fqn})
+                    MERGE (tbl)-[:HAS_COLUMN]->(col)
+                    """,
+                    batch=columns[i : i + batch_size],
+                )
+        if columns:
+            info_logger(f"[DATASOURCE] Written {len(columns)} DbColumn nodes for {ds_name}")
+
+        # ── Redis key patterns ────────────────────────────────────────────
+        key_patterns = ingested.get("key_patterns", [])
+        for i in range(0, len(key_patterns), batch_size):
+            with self.driver.session() as session:
+                session.run(
+                    """
+                    UNWIND $batch AS kp
+                    MERGE (k:RedisKeyPattern {pattern: kp.pattern, datasource_name: kp.datasource_name})
+                    SET k.key_type = kp.key_type,
+                        k.example_key = kp.example_key,
+                        k.count = kp.count
+                    WITH k, kp
+                    MATCH (d:Datasource {name: kp.datasource_name})
+                    MERGE (k)-[:STORED_IN]->(d)
+                    """,
+                    batch=key_patterns[i : i + batch_size],
+                )
+        if key_patterns:
+            info_logger(f"[DATASOURCE] Written {len(key_patterns)} RedisKeyPattern nodes for {ds_name}")
+
+    def write_orm_mapping_links(self, orm_batch: List[Dict[str, Any]]) -> None:
+        """Write MAPS_TO edges from Class → DbTable (JPA, Cassandra, Redis) for #843.
+
+        Each record in orm_batch must have:
+            kind: "class_table"
+            class_name, class_path, orm_table, datastore, line_number
+        """
+        class_table = [r for r in orm_batch if r.get("kind") == "class_table"]
+        if not class_table:
+            return
+
+        batch_size = 500
+        for i in range(0, len(class_table), batch_size):
+            with self.driver.session() as session:
+                session.run(
+                    """
+                    UNWIND $batch AS m
+                    MATCH (c:Class {name: m.class_name, path: m.class_path})
+                    MERGE (tbl:DbTable {name: m.orm_table})
+                    ON CREATE SET tbl.fqn = m.orm_table, tbl.datasource_name = m.datastore
+                    MERGE (c)-[:MAPS_TO {datastore: m.datastore, line_number: m.line_number}]->(tbl)
+                    """,
+                    batch=class_table[i : i + batch_size],
+                )
+        info_logger(f"[ORM] Written {len(class_table)} MAPS_TO edges")
+
+    def write_query_links(self, query_batch: List[Dict[str, Any]]) -> None:
+        """Write READS / WRITES edges from Function → DbTable for #843.
+
+        Each record must have:
+            kind: "method_query"
+            method_name, class_name, method_path, db_tables, operation, line_number
+        """
+        method_queries = [r for r in query_batch if r.get("kind") == "method_query" and r.get("db_tables")]
+        if not method_queries:
+            return
+
+        # Flatten: one edge per (method, table)
+        edges = []
+        for r in method_queries:
+            for tbl in r["db_tables"]:
+                edges.append({
+                    "method_name": r.get("method_name"),
+                    "class_name": r.get("class_name"),
+                    "method_path": r.get("method_path"),
+                    "table_name": tbl,
+                    "operation": r.get("operation", "READS"),
+                    "line_number": r.get("line_number", 0),
+                })
+
+        batch_size = 500
+        for op in ("READS", "WRITES"):
+            op_edges = [e for e in edges if e["operation"] == op]
+            for i in range(0, len(op_edges), batch_size):
+                with self.driver.session() as session:
+                    session.run(
+                        f"""
+                        UNWIND $batch AS q
+                        MATCH (fn:Function {{name: q.method_name, path: q.method_path}})
+                        MERGE (tbl:DbTable {{name: q.table_name}})
+                        ON CREATE SET tbl.fqn = q.table_name
+                        MERGE (fn)-[:{op} {{line_number: q.line_number}}]->(tbl)
+                        """,
+                        batch=op_edges[i : i + batch_size],
+                    )
+        info_logger(f"[ORM] Written {len(edges)} READS/WRITES query edges")
+
+    def write_mybatis_links(self, mybatis_batch: List[Dict[str, Any]]) -> None:
+        """Write READS / WRITES edges from Function → DbTable for MyBatis XML mappers.
+
+        Matches Function nodes by (name, class_context) instead of path because
+        the XML mapper files don't directly reference Java source paths.
+
+        Each record must have:
+            method_name, class_name, db_tables (list), operation ("READS"/"WRITES")
+        """
+        edges = []
+        for r in mybatis_batch:
+            for tbl in r.get("db_tables", []):
+                edges.append({
+                    "method_name": r["method_name"],
+                    "class_name": r["class_name"],
+                    "table_name": tbl,
+                    "operation": r.get("operation", "READS"),
+                })
+
+        if not edges:
+            return
+
+        batch_size = 500
+        written = 0
+        for op in ("READS", "WRITES"):
+            op_edges = [e for e in edges if e["operation"] == op]
+            if not op_edges:
+                continue
+            for i in range(0, len(op_edges), batch_size):
+                with self.driver.session() as session:
+                    session.run(
+                        f"""
+                        UNWIND $batch AS q
+                        MATCH (fn:Function {{name: q.method_name}})
+                        WHERE fn.class_context = q.class_name
+                        MERGE (tbl:DbTable {{name: q.table_name}})
+                        ON CREATE SET tbl.fqn = q.table_name
+                        MERGE (fn)-[:{op}]->(tbl)
+                        """,
+                        batch=op_edges[i : i + batch_size],
+                    )
+                written += len(op_edges[i : i + batch_size])
+        info_logger(f"[MYBATIS] Written {written} READS/WRITES MyBatis edges")
+
     def delete_repository_from_graph(self, repo_path: str) -> bool:
-        repo_path_str = str(Path(repo_path).resolve())
+        repo_path_str = repo_path
         path_prefix = repo_path_str + "/"
         with self.driver.session() as session:
             result = session.run(

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -142,6 +142,7 @@ async def run_tree_sitter_index_async(
         )
         writer.write_orm_mapping_links(orm_batch)
         writer.write_query_links(orm_batch)
+        writer.write_spring_data_repo_links(orm_batch)
 
     # ── MyBatis XML mapper READS / WRITES edges ───────────────────────────────
     if not is_dependency and path.is_dir():

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -85,6 +85,74 @@ async def run_tree_sitter_index_async(
     t2 = time.time()
     info_logger(f"Function calls created in {t2 - t1:.1f}s. Total post-processing: {t2 - t0:.1f}s")
 
+    # ── Spring injection edges (#887) ─────────────────────────────────────────
+    spring_inject_batch = []
+    for fd in all_file_data:
+        injections = fd.get("spring_injections")
+        if injections:
+            spring_inject_batch.extend(injections)
+    if spring_inject_batch:
+        info_logger(f"[SPRING] Writing {len(spring_inject_batch)} Spring injection edges...")
+        writer.write_spring_inject_links(spring_inject_batch)
+
+    # Also collect Spring endpoint properties from functions and write them
+    endpoint_batch = []
+    for fd in all_file_data:
+        for fn in fd.get("functions", []):
+            if fn.get("http_method"):
+                endpoint_batch.append({
+                    "func_name": fn["name"],
+                    "path": fn["path"],
+                    "line_number": fn["line_number"],
+                    "http_method": fn.get("http_method"),
+                    "http_path": fn.get("http_path"),
+                })
+    if endpoint_batch:
+        writer.write_spring_endpoint_properties(endpoint_batch)
+
+    # ── Maven / Gradle build graph (#888) ────────────────────────────────────
+    if not is_dependency and path.is_dir():
+        try:
+            from ...tools.languages.maven import parse_repo_maven
+            maven_data = parse_repo_maven(path.resolve())
+            if maven_data.get("modules"):
+                writer.write_maven_build_graph(maven_data, str(path.resolve()))
+        except Exception as _me:
+            info_logger(f"[MAVEN] Build graph failed (skipping): {_me}")
+
+        try:
+            from ...tools.languages.gradle import parse_repo_gradle
+            gradle_data = parse_repo_gradle(path.resolve())
+            if gradle_data.get("modules"):
+                writer.write_gradle_build_graph(gradle_data, str(path.resolve()))
+        except Exception as _ge:
+            info_logger(f"[GRADLE] Build graph failed (skipping): {_ge}")
+
+    # ── ORM / datasource code linkage (#843) ─────────────────────────────────
+    orm_batch = []
+    for fd in all_file_data:
+        orm_mappings = fd.get("orm_mappings")
+        if orm_mappings:
+            orm_batch.extend(orm_mappings)
+    if orm_batch:
+        class_table_count = sum(1 for r in orm_batch if r.get("kind") == "class_table")
+        query_count = sum(1 for r in orm_batch if r.get("kind") == "method_query")
+        info_logger(
+            f"[ORM] Writing {class_table_count} class→table mappings and {query_count} query links..."
+        )
+        writer.write_orm_mapping_links(orm_batch)
+        writer.write_query_links(orm_batch)
+
+    # ── MyBatis XML mapper READS / WRITES edges ───────────────────────────────
+    if not is_dependency and path.is_dir():
+        try:
+            from ...tools.languages.mybatis import find_and_parse_mybatis_mappers
+            mybatis_batch = find_and_parse_mybatis_mappers(path.resolve())
+            if mybatis_batch:
+                writer.write_mybatis_links(mybatis_batch)
+        except Exception as _me:
+            info_logger(f"[MYBATIS] Mapper parsing failed (skipping): {_me}")
+
     # ── Phase 4: embedding generation (optional, config-gated) ────────────────
     from ...cli.config_manager import get_config_value as _gcv
     if (_gcv("ENABLE_VECTOR_RESOLVE") or "false").lower() == "true":

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -85,5 +85,34 @@ async def run_tree_sitter_index_async(
     t2 = time.time()
     info_logger(f"Function calls created in {t2 - t1:.1f}s. Total post-processing: {t2 - t0:.1f}s")
 
+    # ── Phase 4: embedding generation (optional, config-gated) ────────────────
+    from ...cli.config_manager import get_config_value as _gcv
+    if (_gcv("ENABLE_VECTOR_RESOLVE") or "false").lower() == "true":
+        try:
+            from .embeddings import EmbeddingPipeline
+            repo_path_str = str(path.resolve())
+            info_logger("[EMBED] Starting embedding pipeline...")
+            EmbeddingPipeline(writer.driver).run(repo_path_str)
+            info_logger("[EMBED] Embedding pipeline complete.")
+        except Exception as _ee:
+            info_logger(f"[EMBED] Embedding pipeline failed (skipping): {_ee}")
+
+    # ── Phase 5: inheritance-aware re-resolution (optional, config-gated) ─────
+    if (_gcv("ENABLE_INHERIT_RESOLVE") or "false").lower() == "true":
+        try:
+            from .resolution.post_resolution import run_inheritance_reresolve
+            vector_resolver = None
+            if (_gcv("ENABLE_VECTOR_RESOLVE") or "false").lower() == "true":
+                try:
+                    from .vector_resolver import VectorResolver
+                    vector_resolver = VectorResolver(writer.driver)
+                except Exception as _ve:
+                    info_logger(f"[VECTOR] Resolver unavailable: {_ve}")
+            repo_path_str = str(path.resolve())
+            improved = run_inheritance_reresolve(writer.driver, repo_path_str, vector_resolver)
+            info_logger(f"[INHERIT-RESOLVE] Post-resolution complete: {improved} edges improved")
+        except Exception as _ie:
+            info_logger(f"[INHERIT-RESOLVE] Post-resolution failed (skipping): {_ie}")
+
     if job_id:
         job_manager.update_job(job_id, status=JobStatus.COMPLETED, end_time=datetime.now())

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -6,6 +6,20 @@ from typing import Any, Dict, List, Optional, Tuple
 from ....cli.config_manager import get_config_value
 from ....utils.debug_log import info_logger
 
+# Confidence score for each resolution tier.
+# Higher = more certain the edge points to the correct target.
+_TIER_CONFIDENCE: Dict[int, float] = {
+    1: 1.00,  # explicit this/self/super receiver — definitionally same-class
+    2: 0.95,  # local function or class defined in the same file
+    3: 0.88,  # inferred receiver type + FQN import key (Phase 1 adds FQN entries)
+    4: 0.72,  # inferred receiver type + short-name (possible first-match bias)
+    5: 0.90,  # unique short name — only one file in the graph defines it
+    6: 0.85,  # FQN key in imports_map via qualified import declaration
+    7: 0.70,  # FQN matched as path-substring across multiple candidates
+    8: 0.25,  # alphabetical-first of multiple candidates (wrong most of the time)
+    9: 0.08,  # same-file fallback for obj.method() — definitionally wrong
+}
+
 
 def resolve_function_call(
     call: Dict[str, Any],
@@ -22,6 +36,7 @@ def resolve_function_call(
 
     resolved_called_name = called_name
     resolved_path = None
+    resolution_tier = 9  # default: same-file fallback
     full_call = call.get("full_name", called_name)
     base_obj = full_call.split(".")[0] if "." in full_call else None
 
@@ -32,16 +47,35 @@ def resolve_function_call(
     else:
         lookup_name = base_obj if base_obj else called_name
 
+    # ── Tier 1: explicit self/this/super — same-class, always correct ──────────
     if base_obj in ("self", "this", "super", "super()", "cls", "@") and not is_chained_call:
         resolved_path = caller_file_path
+        resolution_tier = 1
+
+    # ── Tier 2: call target defined locally in the same file ───────────────────
     elif lookup_name in local_names:
         resolved_path = caller_file_path
+        resolution_tier = 2
+
+    # ── Tier 3/4: receiver type inferred from variable declaration ─────────────
     elif call.get("inferred_obj_type"):
         obj_type = call["inferred_obj_type"]
-        possible_paths = imports_map.get(obj_type, [])
-        if len(possible_paths) > 0:
-            resolved_path = possible_paths[0]
+        # Tier 3: FQN lookup — only when local import gives us the exact package.
+        # Phase 1 adds FQN entries to imports_map so `imports_map[fqn]` has 1 path.
+        if obj_type in local_imports:
+            fqn = local_imports[obj_type]
+            fqn_paths = imports_map.get(fqn, [])
+            if len(fqn_paths) == 1:
+                resolved_path = fqn_paths[0]
+                resolution_tier = 3
+        # Tier 4: short-name lookup (legacy — may be first-match biased)
+        if not resolved_path:
+            possible_paths = imports_map.get(obj_type, [])
+            if possible_paths:
+                resolved_path = possible_paths[0]
+                resolution_tier = 4
 
+    # ── Tier 5/6/7: lookup by call-site name (no inferred type) ───────────────
     if not resolved_path:
         possible_paths = imports_map.get(lookup_name, [])
         if not possible_paths and lookup_name in local_imports:
@@ -53,53 +87,62 @@ def resolve_function_call(
                 if called_name == base_obj or called_name == call["name"]:
                     resolved_called_name = imported_name
         if len(possible_paths) == 1:
+            # Tier 5: globally unique short name — high confidence
             resolved_path = possible_paths[0]
-        elif len(possible_paths) > 1:
-            if lookup_name in local_imports:
-                full_import_name = local_imports[lookup_name]
-                if full_import_name in imports_map:
-                    direct_paths = imports_map[full_import_name]
-                    if direct_paths and len(direct_paths) == 1:
-                        resolved_path = direct_paths[0]
-                if not resolved_path:
-                    for path in possible_paths:
-                        if full_import_name.replace(".", "/") in path:
-                            resolved_path = path
-                            break
+            resolution_tier = 5
+        elif len(possible_paths) > 1 and lookup_name in local_imports:
+            full_import_name = local_imports[lookup_name]
+            # Tier 6: FQN key in imports_map (added by Phase 1 pre_scan changes)
+            fqn_paths = imports_map.get(full_import_name, [])
+            if fqn_paths and len(fqn_paths) == 1:
+                resolved_path = fqn_paths[0]
+                resolution_tier = 6
+            # Tier 7: FQN as path-substring across candidates
+            if not resolved_path:
+                fqn_as_path = full_import_name.replace(".", "/")
+                for p in possible_paths:
+                    if fqn_as_path in p:
+                        resolved_path = p
+                        resolution_tier = 7
+                        break
 
-    if not resolved_path:
-        is_unresolved_external = True
-    else:
-        is_unresolved_external = False
-
-    if not resolved_path:
-        possible_paths = imports_map.get(lookup_name, [])
-        if len(possible_paths) > 0:
-            if lookup_name in local_imports:
-                pass
-            else:
-                pass
+    # ── Tier 8/9: last-resort fallbacks ────────────────────────────────────────
     if not resolved_path:
         if called_name in local_names:
+            # Re-check with the bare called_name (covers chained-call edge cases)
             resolved_path = caller_file_path
-            is_unresolved_external = False
+            resolution_tier = 2
         elif resolved_called_name in imports_map and imports_map[resolved_called_name]:
             candidates = imports_map[resolved_called_name]
-            for path in candidates:
-                for imp_name in local_imports.values():
-                    if imp_name.replace(".", "/") in path:
-                        resolved_path = path
-                        is_unresolved_external = False
+            # Try to match any candidate via a local import path hint
+            for p in candidates:
+                for imp_fqn in local_imports.values():
+                    if imp_fqn.replace(".", "/") in p:
+                        resolved_path = p
+                        resolution_tier = 7
                         break
                 if resolved_path:
                     break
+            # Tier 8: alphabetical first of multiple candidates
             if not resolved_path:
                 resolved_path = candidates[0]
+                resolution_tier = 8
         else:
+            # Tier 9: same-file fallback — wrong for any obj.method() call
             resolved_path = caller_file_path
+            resolution_tier = 9
+
+    # Determine whether this resolution is "external" (unresolvable target).
+    # Tier 9 for non-self/super calls means we gave up — treat as external.
+    is_unresolved_external = (
+        resolution_tier == 9
+        and base_obj not in ("self", "this", "super", "super()", "cls", "@")
+    )
 
     if skip_external and is_unresolved_external:
         return None
+
+    confidence = _TIER_CONFIDENCE.get(resolution_tier, 0.1)
 
     caller_context = call.get("context")
     if caller_context and len(caller_context) == 3 and caller_context[0] is not None:
@@ -114,6 +157,8 @@ def resolve_function_call(
             "line_number": call["line_number"],
             "args": call.get("args", []),
             "full_call_name": call.get("full_name", called_name),
+            "confidence": confidence,
+            "resolution_tier": resolution_tier,
         }
     return {
         "type": "file",
@@ -123,6 +168,8 @@ def resolve_function_call(
         "line_number": call["line_number"],
         "args": call.get("args", []),
         "full_call_name": call.get("full_name", called_name),
+        "confidence": confidence,
+        "resolution_tier": resolution_tier,
     }
 
 

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -20,6 +20,15 @@ _TIER_CONFIDENCE: Dict[int, float] = {
     9: 0.08,  # same-file fallback for obj.method() — definitionally wrong
 }
 
+# Human-readable confidence labels surfaced on graph edges (#885)
+def _confidence_label(tier: int, is_unresolved_external: bool) -> str:
+    """Map a resolution tier to EXTRACTED / INFERRED / AMBIGUOUS."""
+    if is_unresolved_external or tier >= 8:
+        return "AMBIGUOUS"
+    if tier in (1, 2, 5, 6):
+        return "EXTRACTED"
+    return "INFERRED"
+
 
 def resolve_function_call(
     call: Dict[str, Any],
@@ -143,6 +152,7 @@ def resolve_function_call(
         return None
 
     confidence = _TIER_CONFIDENCE.get(resolution_tier, 0.1)
+    conf_label = _confidence_label(resolution_tier, is_unresolved_external)
 
     caller_context = call.get("context")
     if caller_context and len(caller_context) == 3 and caller_context[0] is not None:
@@ -158,6 +168,7 @@ def resolve_function_call(
             "args": call.get("args", []),
             "full_call_name": call.get("full_name", called_name),
             "confidence": confidence,
+            "confidence_label": conf_label,
             "resolution_tier": resolution_tier,
         }
     return {
@@ -169,6 +180,7 @@ def resolve_function_call(
         "args": call.get("args", []),
         "full_call_name": call.get("full_name", called_name),
         "confidence": confidence,
+        "confidence_label": conf_label,
         "resolution_tier": resolution_tier,
     }
 

--- a/src/codegraphcontext/tools/indexing/resolution/inheritance.py
+++ b/src/codegraphcontext/tools/indexing/resolution/inheritance.py
@@ -50,6 +50,7 @@ def resolve_inheritance_link(
             "path": caller_file_path,
             "parent_name": target_class_name,
             "resolved_parent_file_path": resolved_path,
+            "confidence_label": "EXTRACTED",
         }
     return None
 

--- a/src/codegraphcontext/tools/indexing/resolution/post_resolution.py
+++ b/src/codegraphcontext/tools/indexing/resolution/post_resolution.py
@@ -1,0 +1,205 @@
+"""Post-resolution pass: tighten low-confidence CALLS edges using INHERITS graph.
+
+This module is called AFTER the initial CALLS graph is written.  It looks for
+edges with confidence < 0.5 (tiers 8 and 9) where the call target has a
+unique implementor that can be determined from the INHERITS graph.
+
+Algorithm for each low-confidence CALLS edge (caller → called_name → same_file):
+  1. Find all Function nodes with name = called_name across the codebase
+  2. Find which of those are in classes that INHERIT from a common base
+  3. If the caller file imports exactly one of those base types, resolve to
+     the matching implementor
+  4. Update the CALLS edge: set called_file_path, confidence, resolution_tier=10
+
+Tier 10 = inheritance-graph resolved (confidence: 0.78)
+
+This pass requires an active Neo4j driver.  It is called from pipeline.py
+after `writer.write_function_call_groups()`.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional, Set
+
+from ....utils.debug_log import info_logger, warning_logger
+
+# Tier 10: resolved via inheritance graph (better than tier 8 first-match bias)
+_TIER_INHERIT_CONFIDENCE = 0.78
+_TIER_INHERIT = 10
+
+# Tier 11: inheritance + embedding similarity
+_TIER_EMBED_CONFIDENCE = 0.82
+_TIER_EMBED = 11
+
+
+def run_inheritance_reresolve(
+    driver: Any,
+    repo_path: str,
+    vector_resolver: Optional[Any] = None,
+) -> int:
+    """Re-resolve low-confidence CALLS edges using INHERITS graph + optional embeddings.
+
+    Returns the number of edges that were improved.
+    """
+    t0 = time.time()
+    improved = 0
+
+    # Normalise repo_path to a directory prefix so STARTS WITH is safe:
+    # "/opt/repos/myapp" must not accidentally match "/opt/repos/myapp_extra".
+    repo_path_prefix = repo_path.rstrip("/") + "/"
+
+    # Step 1: find all low-confidence same-file CALLS edges (tier 8 or 9)
+    # These are edges where the resolver gave up and pointed to the caller's file.
+    with driver.session() as session:
+        low_confidence = list(session.run(
+            """
+            MATCH (caller)-[c:CALLS]->(called)
+            WHERE (caller.path STARTS WITH $repo_path_prefix
+                   OR called.path STARTS WITH $repo_path_prefix)
+              AND c.resolution_tier IN [8, 9]
+            RETURN
+                caller.name AS caller_name,
+                caller.path AS caller_path,
+                caller.line_number AS caller_line,
+                called.name AS called_name,
+                c.line_number AS call_line,
+                c.full_call_name AS full_call_name,
+                c.args AS args
+            """,
+            repo_path_prefix=repo_path_prefix,
+        ))
+
+    info_logger(f"[INHERIT-RESOLVE] Found {len(low_confidence)} low-confidence edges to re-examine")
+    if not low_confidence:
+        return 0
+
+    # Step 2: batch-fetch all candidate implementations in a single query.
+    # Using UNWIND + IN instead of N separate round-trips prevents session
+    # timeouts on large repos and is orders-of-magnitude faster.
+    name_to_impls: Dict[str, List[Dict[str, Any]]] = {}
+
+    # Guard: skip edges whose called_name is null/empty (e.g. calls to external Modules)
+    unique_names: Set[str] = {
+        row["called_name"] for row in low_confidence if row["called_name"]
+    }
+
+    _NAMES_BATCH = 500  # stay well under Cypher parameter-list limits
+    unique_names_list = list(unique_names)
+    with driver.session() as session:
+        for _i in range(0, len(unique_names_list), _NAMES_BATCH):
+            chunk = unique_names_list[_i : _i + _NAMES_BATCH]
+            result = session.run(
+                """
+                UNWIND $names AS name
+                MATCH (cls:Class)-[:CONTAINS]->(fn:Function {name: name})
+                WHERE fn.path STARTS WITH $repo_path_prefix
+                OPTIONAL MATCH (cls)-[:INHERITS]->(parent:Class)
+                RETURN fn.name AS queried_name, fn.path AS path,
+                       fn.line_number AS line_number,
+                       cls.name AS class_name, cls.qualified_name AS class_qname,
+                       parent.name AS parent_name, parent.qualified_name AS parent_qname
+                """,
+                names=chunk,
+                repo_path_prefix=repo_path_prefix,
+            )
+            for row in result:
+                name_to_impls.setdefault(row["queried_name"], []).append(dict(row))
+
+    # Step 3: for each low-confidence edge, check if INHERITS narrows candidates
+    # Strategy:
+    #   a) If only 1 candidate exists across the entire repo → use it (tier 10)
+    #   b) If multiple exist → filter to those in a class that INHERITS from something
+    #      (prefer polymorphic implementations over utility helpers)
+    #   c) If vector_resolver available → use embedding similarity to pick the best
+    improvements: List[Dict[str, Any]] = []
+
+    for row in low_confidence:
+        called_name = row["called_name"]
+        if not called_name:  # skip null/empty call targets (external module refs etc.)
+            continue
+        caller_path = row["caller_path"]
+        impls = name_to_impls.get(called_name, [])
+
+        # Skip if no candidates or all candidates are the caller itself
+        candidates = [impl for impl in impls if impl["path"] != caller_path]
+        if not candidates:
+            continue
+
+        best_path = None
+        confidence = _TIER_INHERIT_CONFIDENCE
+        tier = _TIER_INHERIT
+
+        if len(candidates) == 1:
+            # Unambiguous: single implementation outside the caller file
+            best_path = candidates[0]["path"]
+        else:
+            # Multiple candidates — prefer those that are part of an INHERITS hierarchy
+            inheriting = [c for c in candidates if c.get("parent_name")]
+            pool = inheriting if inheriting else candidates
+
+            if len(pool) == 1:
+                best_path = pool[0]["path"]
+            elif vector_resolver is not None:
+                # Use embedding similarity to disambiguate
+                vec_path = vector_resolver.resolve(
+                    called_name=called_name,
+                    caller_qualified_name=None,
+                    candidate_paths=[c["path"] for c in pool],
+                    repo_path=repo_path,
+                )
+                if vec_path:
+                    best_path = vec_path
+                    confidence = _TIER_EMBED_CONFIDENCE
+                    tier = _TIER_EMBED
+            # else: too ambiguous without vector — skip
+
+        if best_path is None:
+            continue
+
+        improvements.append({
+            "caller_path": caller_path,
+            "caller_name": row["caller_name"],
+            "caller_line": row["caller_line"],
+            "called_name": called_name,
+            "call_line": row["call_line"],
+            "new_called_path": best_path,
+            "confidence": confidence,
+            "resolution_tier": tier,
+        })
+
+    if not improvements:
+        info_logger(f"[INHERIT-RESOLVE] No improvable edges found in {time.time()-t0:.1f}s")
+        return 0
+
+    info_logger(f"[INHERIT-RESOLVE] Re-resolving {len(improvements)} edges...")
+
+    # Step 4: write updated edges in batches
+    batch_size = 500
+    with driver.session() as session:
+        for i in range(0, len(improvements), batch_size):
+            batch = improvements[i : i + batch_size]
+            session.run(
+                """
+                UNWIND $batch AS row
+                MATCH (caller {name: row.caller_name, path: row.caller_path})
+                WHERE row.caller_line IS NULL OR caller.line_number = row.caller_line
+                MATCH (new_called:Function {name: row.called_name, path: row.new_called_path})
+                OPTIONAL MATCH (caller)-[old_edge:CALLS]->(old_called {name: row.called_name})
+                  WHERE old_edge.resolution_tier IN [8, 9]
+                DELETE old_edge
+                WITH caller, new_called, row
+                MERGE (caller)-[c:CALLS {called_name: row.called_name}]->(new_called)
+                SET c.line_number = coalesce(row.call_line, c.line_number),
+                    c.confidence = row.confidence,
+                    c.resolution_tier = row.resolution_tier,
+                    c.resolution_method = 'inheritance'
+                """,
+                batch=batch,
+            )
+            improved += len(batch)
+
+    info_logger(
+        f"[INHERIT-RESOLVE] Improved {improved} CALLS edges in {time.time()-t0:.1f}s"
+    )
+    return improved

--- a/src/codegraphcontext/tools/indexing/schema_contract.py
+++ b/src/codegraphcontext/tools/indexing/schema_contract.py
@@ -24,6 +24,15 @@ NODE_LABELS = frozenset({
     "Annotation",
     "Module",
     "Parameter",
+    # Build graph nodes (#888)
+    "MavenModule",
+    "GradleModule",
+    "ExternalLibrary",
+    # Datasource architecture graph (#843 scoped)
+    "Datasource",
+    "DbTable",
+    "DbColumn",
+    "RedisKeyPattern",
 })
 
 RELATIONSHIP_TYPES = frozenset({
@@ -34,6 +43,21 @@ RELATIONSHIP_TYPES = frozenset({
     "HAS_PARAMETER",
     "INCLUDES",
     "IMPLEMENTS",
+    # Spring DI semantic edges (#887)
+    "INJECTS",
+    "EXPOSES_ENDPOINT",
+    "PROVIDES_BEAN",
+    # Build graph edges (#888)
+    "MODULE_DEPENDS_ON",
+    "USES_LIBRARY",
+    "CHILD_MODULE",
+    "FILE_BELONGS_TO",
+    # Datasource architecture graph (#843 scoped)
+    "READS",
+    "WRITES",
+    "MAPS_TO",
+    "HAS_COLUMN",
+    "STORED_IN",
 })
 
 # Identity properties used in MERGE for code entities (path = absolute file path)

--- a/src/codegraphcontext/tools/indexing/vector_resolver.py
+++ b/src/codegraphcontext/tools/indexing/vector_resolver.py
@@ -1,0 +1,137 @@
+"""Vector-similarity-based call resolution using pre-computed Function embeddings.
+
+This module is used as the final tiebreaker in `resolve_function_call` when
+heuristic tiers 1–8 cannot produce a high-confidence answer.  It queries the
+Neo4j vector index to find the Function node whose embedding is most similar
+to a query constructed from the call context.
+
+Architecture:
+  - VectorResolver wraps a live Neo4j driver session
+  - `resolve(call, caller_context, candidates)` returns the best candidate path
+    or None if no candidate clears the similarity threshold
+  - The resolver is instantiated once per indexing run and passed into
+    `build_function_call_groups` as an optional argument (Phase 4 wiring)
+
+Requires:
+  - Function nodes must have been embedded via embeddings.EmbeddingPipeline
+  - Neo4j vector index "function_embeddings" must exist
+  - An embedder compatible with the one used during embedding generation
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from ...utils.debug_log import info_logger, warning_logger
+
+_VECTOR_INDEX_NAME = "function_embeddings"
+_DEFAULT_THRESHOLD = 0.75  # cosine similarity floor
+_DEFAULT_TOP_K = 5
+
+
+class VectorResolver:
+    """Use Neo4j ANN vector search to pick the best Function among candidates."""
+
+    def __init__(
+        self,
+        driver: Any,
+        threshold: float = _DEFAULT_THRESHOLD,
+        top_k: int = _DEFAULT_TOP_K,
+    ):
+        self.driver = driver
+        self.threshold = threshold
+        self.top_k = top_k
+        self._embedder = None  # lazy-loaded
+
+    def _get_embedder(self):
+        if self._embedder is None:
+            # Import here to avoid circular deps and to keep the embedder lazy
+            from codegraphcontext.tools.indexing.embeddings import _get_embedder
+            self._embedder = _get_embedder()
+        return self._embedder
+
+    def _embed_query(self, text: str) -> List[float]:
+        return self._get_embedder().embed_batch([text])[0]
+
+    def resolve(
+        self,
+        called_name: str,
+        caller_qualified_name: Optional[str],
+        candidate_paths: List[str],
+        repo_path: str,
+    ) -> Optional[str]:
+        """Return the file path of the best-matching Function among candidates.
+
+        Args:
+            called_name: The short method name being called (e.g. "execute").
+            caller_qualified_name: FQN of the calling function for context.
+            candidate_paths: File paths that define `called_name`; we restrict
+                the ANN search to these paths.
+            repo_path: Path prefix to scope the index query.
+
+        Returns:
+            The file path of the best candidate, or None if below threshold.
+        """
+        if not candidate_paths:
+            return None
+
+        query_text = f"{caller_qualified_name or ''} calls {called_name}"
+        try:
+            query_vec = self._embed_query(query_text)
+        except Exception as e:
+            warning_logger(f"[VECTOR] Embed query failed: {e}")
+            return None
+
+        with self.driver.session() as session:
+            try:
+                # Expand top_k to cover all candidates so we never miss the right one.
+                # A fixed top_k=5 would silently drop candidates when len(paths) > 5.
+                effective_top_k = max(self.top_k, len(candidate_paths))
+                result = session.run(
+                    f"""
+                    CALL db.index.vector.queryNodes(
+                        '{_VECTOR_INDEX_NAME}', $top_k, $vec
+                    ) YIELD node AS fn, score
+                    WHERE fn.name = $name
+                      AND fn.path IN $paths
+                    RETURN fn.path AS path, score
+                    ORDER BY score DESC
+                    LIMIT 1
+                    """,
+                    top_k=effective_top_k,
+                    vec=query_vec,
+                    name=called_name,
+                    paths=candidate_paths,
+                )
+                row = result.single()
+                if row and row["score"] >= self.threshold:
+                    return row["path"]
+            except Exception as e:
+                warning_logger(f"[VECTOR] ANN query failed: {e}")
+
+        return None
+
+    def resolve_bulk(
+        self,
+        calls: List[Dict[str, Any]],
+        repo_path: str,
+    ) -> Dict[int, str]:
+        """Resolve a list of calls in one pass; returns {call_index: resolved_path}.
+
+        Each call dict must have:
+          - "called_name": str
+          - "candidate_paths": List[str]
+          - "caller_qualified_name": Optional[str]
+        """
+        results: Dict[int, str] = {}
+        for idx, call in enumerate(calls):
+            resolved = self.resolve(
+                called_name=call["called_name"],
+                caller_qualified_name=call.get("caller_qualified_name"),
+                candidate_paths=call["candidate_paths"],
+                repo_path=repo_path,
+            )
+            if resolved:
+                results[idx] = resolved
+        return results

--- a/src/codegraphcontext/tools/languages/csharp.py
+++ b/src/codegraphcontext/tools/languages/csharp.py
@@ -110,6 +110,10 @@ class CSharpTreeSitterParser:
 
             tree = self.parser.parse(bytes(source_code, "utf8"))
 
+            # Extract namespace declaration for package_name (e.g. "com.ea.nucleus.billing")
+            namespace_match = re.search(r'\bnamespace\s+([\w.]+)', source_code)
+            package_name = namespace_match.group(1) if namespace_match else None
+
             parsed_functions = []
             parsed_classes = []
             parsed_interfaces = []
@@ -156,6 +160,7 @@ class CSharpTreeSitterParser:
                 "function_calls": parsed_calls,
                 "is_dependency": is_dependency,
                 "lang": self.language_name,
+                "package_name": package_name,
             }
 
         except Exception as e:

--- a/src/codegraphcontext/tools/languages/go.py
+++ b/src/codegraphcontext/tools/languages/go.py
@@ -165,14 +165,14 @@ class GoTreeSitterParser:
 
     def parse(self, path: Path, is_dependency: bool = False, index_source: bool = False) -> Dict:
         """Parses a file and returns its structure in a standardized dictionary format."""
-        # This method orchestrates the parsing of a single file.
-        # It calls specialized `_find_*` methods for each language construct.
-        # The returned dictionary should map a specific key (e.g., 'functions', 'interfaces')
-        # to a list of dictionaries, where each dictionary represents a single code construct.
-        # The GraphBuilder will then use these keys to create nodes with corresponding labels.
         self.index_source = index_source
         with open(path, "r", encoding="utf-8") as f:
             source_code = f.read()
+
+        # Extract Go package declaration for package_name field on File nodes
+        import re as _re
+        pkg_match = _re.search(r'^\s*package\s+(\w+)', source_code, _re.MULTILINE)
+        package_name = pkg_match.group(1) if pkg_match else None
 
         tree = self.parser.parse(bytes(source_code, "utf8"))
         root_node = tree.root_node
@@ -194,6 +194,7 @@ class GoTreeSitterParser:
             "function_calls": function_calls,
             "is_dependency": is_dependency,
             "lang": self.language_name,
+            "package_name": package_name,
         }
 
     def _find_functions(self, root_node):

--- a/src/codegraphcontext/tools/languages/gradle.py
+++ b/src/codegraphcontext/tools/languages/gradle.py
@@ -1,0 +1,115 @@
+"""Parse build.gradle / build.gradle.kts files to extract Gradle build graph data (#888)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from codegraphcontext.utils.debug_log import error_logger, info_logger
+
+# Matches: implementation("group:artifact:version") or compile 'g:a:v'
+_DEP_PATTERN = re.compile(
+    r"""(?:implementation|api|compile|testImplementation|runtimeOnly|compileOnly|testRuntimeOnly|annotationProcessor)\s*[\('"]([\w.\-]+):([\w.\-]+):?([\w.\-]*)['"\)]""",
+    re.MULTILINE,
+)
+
+# Matches: project(':module-name') or project(":module-name")
+_PROJECT_DEP_PATTERN = re.compile(r"""project\(['"]:([\w.\-/]+)['"]\)""")
+
+# Matches: rootProject.name = "name" or settings include(':module')
+_SETTINGS_INCLUDE_PATTERN = re.compile(r"""include\(['"]:([\w.\-/]+)['"]\)""")
+
+# configuration keyword for inter-module deps
+_CONFIG_PREFIX_PATTERN = re.compile(
+    r"""^(implementation|api|compile|testImplementation|runtimeOnly|compileOnly)\s+project""",
+    re.MULTILINE,
+)
+
+
+class GradleParser:
+    """Parses a build.gradle / build.gradle.kts and returns build graph records."""
+
+    def parse(self, gradle_path: Path) -> Optional[Dict[str, Any]]:
+        """Parse *gradle_path* and return a dict with keys:
+            modules             List[dict] — GradleModule node records
+            inter_module_deps   List[dict] — MODULE_DEPENDS_ON records
+            external_libs       List[dict] — ExternalLibrary + USES_LIBRARY records
+        """
+        try:
+            source = gradle_path.read_text(encoding="utf-8", errors="ignore")
+        except Exception as exc:
+            error_logger(f"[GRADLE] Cannot read {gradle_path}: {exc}")
+            return None
+
+        # Derive module name from directory name (mirrors Gradle convention)
+        module_name = gradle_path.parent.name
+        if module_name == "" or gradle_path.parent == gradle_path.parent.parent:
+            module_name = "root"
+
+        module_record = {
+            "name": module_name,
+            "build_file": str(gradle_path),
+        }
+
+        inter_module_deps: List[Dict[str, Any]] = []
+        external_libs: List[Dict[str, Any]] = []
+
+        # Extract external dependencies
+        for m in _DEP_PATTERN.finditer(source):
+            group_id, artifact_id, version = m.group(1), m.group(2), m.group(3)
+            # Determine configuration from the full line
+            line_start = source.rfind("\n", 0, m.start()) + 1
+            line_text = source[line_start : source.find("\n", m.start())]
+            cfg_match = re.match(r"\s*(\w+)\s", line_text)
+            configuration = cfg_match.group(1) if cfg_match else "implementation"
+            external_libs.append({
+                "src_name": module_name,
+                "group_id": group_id,
+                "artifact_id": artifact_id,
+                "version": version,
+                "configuration": configuration,
+            })
+
+        # Extract inter-module project dependencies
+        for m in re.finditer(r"""(\w+)\s+project\(['"]:([\w.\-/]+)['"]\)""", source):
+            configuration = m.group(1)
+            tgt_name = m.group(2).lstrip("/").replace("/", ":")
+            # Derive simple name (last segment after colon)
+            tgt_simple = tgt_name.split(":")[-1]
+            inter_module_deps.append({
+                "src_name": module_name,
+                "tgt_name": tgt_simple,
+                "configuration": configuration,
+            })
+
+        return {
+            "modules": [module_record],
+            "inter_module_deps": inter_module_deps,
+            "external_libs": external_libs,
+        }
+
+
+def parse_repo_gradle(repo_root: Path) -> Dict[str, Any]:
+    """Walk *repo_root* for build.gradle / build.gradle.kts and merge into one dict."""
+    parser = GradleParser()
+    merged: Dict[str, Any] = {
+        "modules": [],
+        "inter_module_deps": [],
+        "external_libs": [],
+    }
+
+    for gradle_path in sorted(repo_root.rglob("build.gradle*")):
+        relative = gradle_path.relative_to(repo_root)
+        if any(part in ("build", ".gradle", ".git") for part in relative.parts):
+            continue
+        result = parser.parse(gradle_path)
+        if result:
+            for key in merged:
+                merged[key].extend(result.get(key, []))
+
+    info_logger(
+        f"[GRADLE] Discovered {len(merged['modules'])} Gradle modules, "
+        f"{len(merged['external_libs'])} external lib references."
+    )
+    return merged

--- a/src/codegraphcontext/tools/languages/java.py
+++ b/src/codegraphcontext/tools/languages/java.py
@@ -93,6 +93,12 @@ class JavaTreeSitterParser:
 
             tree = self.parser.parse(bytes(source_code, "utf8"))
 
+            # Extract package declaration for qualified_name construction and FQN resolution
+            package_name = None
+            pkg_match = re.search(r'^\s*package\s+([\w.]+)\s*;', source_code, re.MULTILINE)
+            if pkg_match:
+                package_name = pkg_match.group(1)
+
             parsed_functions = []
             parsed_classes = []
             parsed_variables = []
@@ -107,9 +113,9 @@ class JavaTreeSitterParser:
                 results = execute_query(self.language, query, tree.root_node)
 
                 if capture_name == "functions":
-                    parsed_functions = self._parse_functions(results, source_code, path)
+                    parsed_functions = self._parse_functions(results, source_code, path, package_name)
                 elif capture_name == "classes":
-                    parsed_classes = self._parse_classes(results, source_code, path)
+                    parsed_classes = self._parse_classes(results, source_code, path, package_name)
                 elif capture_name == "imports":
                     parsed_imports = self._parse_imports(results, source_code)
                 elif capture_name == "variables":
@@ -132,6 +138,7 @@ class JavaTreeSitterParser:
                 "function_calls": parsed_calls,
                 "is_dependency": is_dependency,
                 "lang": self.language_name,
+                "package_name": package_name,
             }
 
         except Exception as e:
@@ -171,7 +178,7 @@ class JavaTreeSitterParser:
         if not node: return ""
         return node.text.decode("utf-8")
 
-    def _parse_functions(self, captures: list, source_code: str, path: Path) -> list[Dict[str, Any]]:
+    def _parse_functions(self, captures: list, source_code: str, path: Path, package_name: Optional[str] = None) -> list[Dict[str, Any]]:
         functions = []
         # Group by node identity or stable key to avoid duplicates
         seen_nodes = set()
@@ -213,6 +220,13 @@ class JavaTreeSitterParser:
                             "class_context": context_name if context_type and "class" in context_type else None
                         }
 
+                        if package_name:
+                            class_ctx = context_name if (context_type and "class" in context_type) else None
+                            if class_ctx:
+                                func_data["qualified_name"] = f"{package_name}.{class_ctx}.{func_name}"
+                            else:
+                                func_data["qualified_name"] = f"{package_name}.{func_name}"
+
                         if self.index_source:
                             func_data["source"] = source_text
                         
@@ -224,7 +238,7 @@ class JavaTreeSitterParser:
 
         return functions
 
-    def _parse_classes(self, captures: list, source_code: str, path: Path) -> list[Dict[str, Any]]:
+    def _parse_classes(self, captures: list, source_code: str, path: Path, package_name: Optional[str] = None) -> list[Dict[str, Any]]:
         classes = []
         seen_nodes = set()
 
@@ -278,6 +292,9 @@ class JavaTreeSitterParser:
                             "path": str(path),
                             "lang": self.language_name,
                         }
+
+                        if package_name:
+                            class_data["qualified_name"] = f"{package_name}.{class_name}"
 
                         if self.index_source:
                             class_data["source"] = source_text
@@ -479,13 +496,23 @@ def pre_scan_java(files: list[Path], parser_wrapper) -> dict:
         try:
             with open(path, 'r', encoding='utf-8', errors='ignore') as f:
                 content = f.read()
-            
+
+            # Extract package for FQN construction (e.g. com.ea.nexus.billing.BillingService)
+            pkg_match = re.search(r'^\s*package\s+([\w.]+)\s*;', content, re.MULTILINE)
+            file_package = pkg_match.group(1) if pkg_match else None
+
             class_matches = re.finditer(r'\b(?:public\s+|private\s+|protected\s+)?(?:static\s+)?(?:abstract\s+)?(?:final\s+)?class\s+(\w+)', content)
             for match in class_matches:
                 class_name = match.group(1)
                 if class_name not in name_to_files:
                     name_to_files[class_name] = []
                 name_to_files[class_name].append(str(path))
+                # Also register under FQN so Phase 2 qualified-import lookups resolve
+                if file_package:
+                    fqn = f"{file_package}.{class_name}"
+                    if fqn not in name_to_files:
+                        name_to_files[fqn] = []
+                    name_to_files[fqn].append(str(path))
             
             interface_matches = re.finditer(r'\b(?:public\s+|private\s+|protected\s+)?interface\s+(\w+)', content)
             for match in interface_matches:
@@ -493,6 +520,11 @@ def pre_scan_java(files: list[Path], parser_wrapper) -> dict:
                 if interface_name not in name_to_files:
                     name_to_files[interface_name] = []
                 name_to_files[interface_name].append(str(path))
+                if file_package:
+                    fqn = f"{file_package}.{interface_name}"
+                    if fqn not in name_to_files:
+                        name_to_files[fqn] = []
+                    name_to_files[fqn].append(str(path))
                 
         except Exception as e:
             error_logger(f"Error pre-scanning Java file {path}: {e}")

--- a/src/codegraphcontext/tools/languages/java.py
+++ b/src/codegraphcontext/tools/languages/java.py
@@ -1,8 +1,83 @@
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import re
 from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logger, warning_logger
 from codegraphcontext.utils.tree_sitter_manager import execute_query
+
+# Spring stereotype annotations → canonical label written to the graph (#887)
+_SPRING_CLASS_STEREOTYPES: Dict[str, str] = {
+    "Controller": "CONTROLLER",
+    "RestController": "REST_CONTROLLER",
+    "Service": "SERVICE",
+    "Repository": "REPOSITORY",
+    "Component": "COMPONENT",
+    "Configuration": "CONFIGURATION",
+    "ControllerAdvice": "CONTROLLER_ADVICE",
+    "RestControllerAdvice": "REST_CONTROLLER_ADVICE",
+}
+
+# Spring HTTP mapping annotations → HTTP method string (#887)
+_SPRING_HTTP_MAPPINGS: Dict[str, Optional[str]] = {
+    "RequestMapping": None,   # method determined from `method` attribute
+    "GetMapping": "GET",
+    "PostMapping": "POST",
+    "PutMapping": "PUT",
+    "DeleteMapping": "DELETE",
+    "PatchMapping": "PATCH",
+}
+
+# Annotations that indicate dependency injection (#887)
+_SPRING_INJECT_ANNOTATIONS = frozenset({"Autowired", "Inject", "Resource"})
+
+# ── ORM / Datasource annotation constants (#843) ─────────────────────────────
+
+# JPA / Hibernate class-level annotations that map a class to a DB table
+_JPA_TABLE_ANNOTATIONS = frozenset({"Entity", "Table"})
+
+# Spring Data Cassandra class-level annotations
+_CASSANDRA_TABLE_ANNOTATIONS = frozenset({"CassandraTable", "PrimaryTable"})
+# @Table is shared between JPA and Cassandra — resolved by import context
+
+# Spring Data Redis
+_REDIS_HASH_ANNOTATIONS = frozenset({"RedisHash"})
+
+# MyBatis / Spring Data @Query — methods that carry raw SQL or CQL strings
+_SQL_QUERY_ANNOTATIONS = frozenset({"Query", "Select", "Insert", "Update", "Delete",
+                                     "NamedQuery", "NamedNativeQuery"})
+
+# Determines READ vs WRITE from a SQL/CQL string
+_WRITE_PREFIXES = ("INSERT", "UPDATE", "DELETE", "MERGE", "TRUNCATE", "REPLACE")
+
+
+def _parse_sql_tables(sql: str) -> List[str]:
+    """Extract table names from a SQL/CQL string without a full parser.
+
+    Handles: FROM x, JOIN x, INTO x, UPDATE x, TABLE x
+    Returns lowercase table names.
+    """
+    sql_upper = sql.upper()
+    tables = []
+    for kw in ("FROM", "JOIN", "INTO", "UPDATE", "TABLE"):
+        for m in re.finditer(rf"\b{kw}\s+([`'\"]?)([\w.]+)\1", sql_upper):
+            raw = m.group(2)
+            # Strip schema prefix: schema.table → table
+            tables.append(raw.split(".")[-1].lower())
+    return list(dict.fromkeys(tables))  # deduplicate preserving order
+
+
+def _sql_operation(sql: str) -> str:
+    """Return 'READS' or 'WRITES' based on SQL DML prefix."""
+    stripped = sql.strip().upper()
+    for prefix in _WRITE_PREFIXES:
+        if stripped.startswith(prefix):
+            return "WRITES"
+    return "READS"
+
+
+def _extract_annotation_path(args_text: str) -> Optional[str]:
+    """Extract the first string literal from annotation arguments, e.g. '("/api/users")' -> '/api/users'."""
+    m = re.search(r'"([^"]*)"', args_text)
+    return m.group(1) if m else None
 
 JAVA_QUERIES = {
     "functions": """
@@ -129,6 +204,12 @@ class JavaTreeSitterParser:
                 elif capture_name == "calls":
                     parsed_calls = self._parse_calls(results, source_code, var_type_map)
 
+            # Spring injection extraction (#887) — needs tree + parsed_classes
+            spring_injections = self._extract_spring_injections(tree, path, parsed_classes)
+
+            # ORM / datasource mapping extraction (#843)
+            orm_mappings = self._extract_orm_mappings(tree, path, parsed_classes, parsed_functions)
+
             return {
                 "path": str(path),
                 "functions": parsed_functions,
@@ -136,6 +217,8 @@ class JavaTreeSitterParser:
                 "variables": parsed_variables,
                 "imports": parsed_imports,
                 "function_calls": parsed_calls,
+                "spring_injections": spring_injections,
+                "orm_mappings": orm_mappings,
                 "is_dependency": is_dependency,
                 "lang": self.language_name,
                 "package_name": package_name,
@@ -150,6 +233,7 @@ class JavaTreeSitterParser:
                 "variables": [],
                 "imports": [],
                 "function_calls": [],
+                "orm_mappings": [],
                 "is_dependency": is_dependency,
                 "lang": self.language_name,
             }
@@ -177,6 +261,34 @@ class JavaTreeSitterParser:
     def _get_node_text(self, node: Any) -> str:
         if not node: return ""
         return node.text.decode("utf-8")
+
+    # ── Annotation helpers (#887) ───────────────────────────────────────────
+
+    def _get_annotation_details(self, ann_node: Any) -> Tuple[str, str]:
+        """Return (annotation_name, annotation_args_text) for an annotation/marker_annotation node."""
+        name_node = ann_node.child_by_field_name("name")
+        args_node = ann_node.child_by_field_name("arguments")
+        ann_name = self._get_node_text(name_node) if name_node else ""
+        ann_args = self._get_node_text(args_node) if args_node else ""
+        return ann_name, ann_args
+
+    def _get_node_annotations(self, node: Any) -> List[Tuple[str, str]]:
+        """Return list of (name, args_text) for all annotations on a node's modifiers."""
+        # child_by_field_name("modifiers") is unreliable across tree-sitter-java versions;
+        # fall back to scanning children by node type.
+        modifiers = node.child_by_field_name("modifiers")
+        if not modifiers:
+            for child in node.children:
+                if child.type == "modifiers":
+                    modifiers = child
+                    break
+        if not modifiers:
+            return []
+        result = []
+        for child in modifiers.children:
+            if child.type in ("annotation", "marker_annotation"):
+                result.append(self._get_annotation_details(child))
+        return result
 
     def _parse_functions(self, captures: list, source_code: str, path: Path, package_name: Optional[str] = None) -> list[Dict[str, Any]]:
         functions = []
@@ -221,6 +333,7 @@ class JavaTreeSitterParser:
                         }
 
                         if package_name:
+                            func_data["package_name"] = package_name
                             class_ctx = context_name if (context_type and "class" in context_type) else None
                             if class_ctx:
                                 func_data["qualified_name"] = f"{package_name}.{class_ctx}.{func_name}"
@@ -229,7 +342,21 @@ class JavaTreeSitterParser:
 
                         if self.index_source:
                             func_data["source"] = source_text
-                        
+
+                        # Spring HTTP mapping / @Transactional detection (#887)
+                        for ann_name, ann_args in self._get_node_annotations(node):
+                            if ann_name in _SPRING_HTTP_MAPPINGS:
+                                implicit_method = _SPRING_HTTP_MAPPINGS[ann_name]
+                                if implicit_method:
+                                    func_data["http_method"] = implicit_method
+                                else:
+                                    # @RequestMapping: try to read method= attribute
+                                    m = re.search(r'method\s*=\s*RequestMethod\.(\w+)', ann_args)
+                                    func_data["http_method"] = m.group(1) if m else "ANY"
+                                func_data["http_path"] = _extract_annotation_path(ann_args)
+                            elif ann_name == "Transactional":
+                                func_data["transactional"] = True
+
                         functions.append(func_data)
                         
                 except Exception as e:
@@ -296,6 +423,18 @@ class JavaTreeSitterParser:
                         if package_name:
                             class_data["qualified_name"] = f"{package_name}.{class_name}"
 
+                        # Spring stereotype detection (#887)
+                        for ann_name, ann_args in self._get_node_annotations(node):
+                            if ann_name in _SPRING_CLASS_STEREOTYPES:
+                                class_data["spring_stereotype"] = _SPRING_CLASS_STEREOTYPES[ann_name]
+                                # @RequestMapping on the class gives a path prefix
+                                break
+                        # Also check if class-level @RequestMapping is present (path prefix)
+                        for ann_name, ann_args in self._get_node_annotations(node):
+                            if ann_name == "RequestMapping":
+                                class_data["request_mapping_prefix"] = _extract_annotation_path(ann_args)
+                                break
+
                         if self.index_source:
                             class_data["source"] = source_text
                         
@@ -359,6 +498,226 @@ class JavaTreeSitterParser:
                      })
 
         return variables
+
+    def _extract_orm_mappings(
+        self,
+        tree: Any,
+        path: Path,
+        parsed_classes: List[Dict[str, Any]],
+        parsed_functions: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Walk the tree and emit ORM mapping records for #843.
+
+        Detects:
+        - @Entity + @Table(name=...)  → JPA class→table mapping
+        - @Table(value=...)           → Cassandra (Spring Data Cassandra)
+        - @RedisHash(value=...)       → Spring Data Redis
+        - @Query / @Select / @Insert / @Update / @Delete with SQL strings
+        - @NamedQuery / @NamedNativeQuery (class-level named queries)
+        - MyBatis @Select / @Insert / @Update / @Delete on methods
+
+        Returns list of dicts with type "class_table" | "method_query":
+          class_table: {kind, class_name, class_path, orm_table, line_number}
+          method_query: {kind, method_name, class_name, method_path, db_tables, operation, sql, line_number}
+        """
+        if not (parsed_classes or parsed_functions):
+            return []
+
+        # Build quick lookup: line -> class name
+        class_ranges = []
+        for cls in parsed_classes:
+            class_ranges.append((cls["line_number"], cls.get("end_line", 999999), cls["name"]))
+
+        def _class_at_line(line: int) -> Optional[str]:
+            for start, end, cname in class_ranges:
+                if start <= line <= end:
+                    return cname
+            return None
+
+        mappings: List[Dict[str, Any]] = []
+
+        def _walk(node: Any) -> None:  # noqa: C901
+            # ── CLASS-LEVEL annotations ────────────────────────────────────
+            if node.type in ("class_declaration", "interface_declaration", "annotation_type_declaration"):
+                annotations = self._get_node_annotations(node)
+                ann_map = {n: args for n, args in annotations}
+                line = node.start_point[0] + 1
+
+                name_node = node.child_by_field_name("name")
+                class_name = self._get_node_text(name_node) if name_node else None
+
+                if "Entity" in ann_map:
+                    # JPA entity: look for @Table(name=...)
+                    table_name = None
+                    if "Table" in ann_map:
+                        t_args = ann_map["Table"] or ""
+                        m = re.search(r'name\s*=\s*"([^"]+)"', t_args)
+                        if not m:
+                            m = re.search(r'"([^"]+)"', t_args)
+                        table_name = m.group(1) if m else (class_name.lower() if class_name else None)
+                    elif class_name:
+                        table_name = class_name.lower()  # JPA default: snake_case of class name
+
+                    if class_name and table_name:
+                        mappings.append({
+                            "kind": "class_table",
+                            "datastore": "mysql",
+                            "class_name": class_name,
+                            "class_path": str(path),
+                            "orm_table": table_name,
+                            "line_number": line,
+                        })
+
+                elif "Table" in ann_map and "Entity" not in ann_map:
+                    # Could be Spring Data Cassandra @Table(value="...")
+                    t_args = ann_map["Table"] or ""
+                    m = re.search(r'value\s*=\s*"([^"]+)"', t_args)
+                    if not m:
+                        m = re.search(r'"([^"]+)"', t_args)
+                    table_name = m.group(1) if m else (class_name.lower() if class_name else None)
+                    if class_name and table_name:
+                        mappings.append({
+                            "kind": "class_table",
+                            "datastore": "cassandra",
+                            "class_name": class_name,
+                            "class_path": str(path),
+                            "orm_table": table_name,
+                            "line_number": line,
+                        })
+
+                if "RedisHash" in ann_map:
+                    rh_args = ann_map["RedisHash"] or ""
+                    m = re.search(r'value\s*=\s*"([^"]+)"', rh_args)
+                    if not m:
+                        m = re.search(r'"([^"]+)"', rh_args)
+                    key_prefix = m.group(1) if m else (class_name or "")
+                    if class_name:
+                        mappings.append({
+                            "kind": "class_table",
+                            "datastore": "redis",
+                            "class_name": class_name,
+                            "class_path": str(path),
+                            "orm_table": key_prefix,
+                            "line_number": line,
+                        })
+
+                # @NamedQuery / @NamedNativeQuery on the class
+                for ann_name in ("NamedQuery", "NamedNativeQuery"):
+                    if ann_name in ann_map:
+                        args_text = ann_map[ann_name] or ""
+                        m_sql = re.search(r'query\s*=\s*"([^"]+)"', args_text)
+                        if m_sql:
+                            sql = m_sql.group(1)
+                            tables = _parse_sql_tables(sql)
+                            op = _sql_operation(sql)
+                            if class_name:
+                                mappings.append({
+                                    "kind": "method_query",
+                                    "datastore": "mysql",
+                                    "method_name": None,
+                                    "class_name": class_name,
+                                    "method_path": str(path),
+                                    "db_tables": tables,
+                                    "operation": op,
+                                    "sql": sql[:200],
+                                    "line_number": line,
+                                })
+
+            # ── METHOD-LEVEL annotations ───────────────────────────────────
+            elif node.type in ("method_declaration", "constructor_declaration"):
+                annotations = self._get_node_annotations(node)
+                ann_map = {n: args for n, args in annotations}
+                line = node.start_point[0] + 1
+                class_name = _class_at_line(line)
+
+                name_node = node.child_by_field_name("name")
+                method_name = self._get_node_text(name_node) if name_node else None
+
+                for ann_name in _SQL_QUERY_ANNOTATIONS:
+                    if ann_name in ann_map:
+                        args_text = ann_map[ann_name] or ""
+                        # Extract raw SQL string: first quoted string in the annotation args
+                        m = re.search(r'"([^"]{4,})"', args_text)
+                        if m:
+                            sql = m.group(1)
+                            tables = _parse_sql_tables(sql)
+                            op = _sql_operation(sql)
+                            if tables or op:
+                                mappings.append({
+                                    "kind": "method_query",
+                                    "datastore": "mysql",
+                                    "method_name": method_name,
+                                    "class_name": class_name,
+                                    "method_path": str(path),
+                                    "db_tables": tables,
+                                    "operation": op,
+                                    "sql": sql[:200],
+                                    "line_number": line,
+                                })
+                            break  # only one SQL annotation per method expected
+
+            for child in node.children:
+                _walk(child)
+
+        _walk(tree.root_node)
+        return mappings
+
+    def _extract_spring_injections(
+        self,
+        tree: Any,
+        path: Path,
+        parsed_classes: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Walk field_declaration nodes and emit injection records for @Autowired/@Inject fields.
+
+        Returns a list of dicts with keys:
+            injector_class, injector_path, injected_class, field_name, inject_line
+        """
+        if not parsed_classes:
+            return []
+
+        # Build quick lookup: line range -> class name
+        class_ranges = []
+        for cls in parsed_classes:
+            class_ranges.append((cls["line_number"], cls.get("end_line", 999999), cls["name"]))
+
+        def _class_at_line(line: int) -> Optional[str]:
+            for start, end, name in class_ranges:
+                if start <= line <= end:
+                    return name
+            return None
+
+        injections: List[Dict[str, Any]] = []
+
+        def _walk(node: Any) -> None:
+            if node.type == "field_declaration":
+                annotations = self._get_node_annotations(node)
+                ann_names = {n for n, _ in annotations}
+                if ann_names & _SPRING_INJECT_ANNOTATIONS:
+                    # Get declared type (the field type, e.g. UserService)
+                    type_node = node.child_by_field_name("type")
+                    if type_node:
+                        field_type = self._strip_generic(self._get_node_text(type_node))
+                        # Get field variable name
+                        for child in node.children:
+                            if child.type == "variable_declarator":
+                                name_node = child.child_by_field_name("name")
+                                if name_node:
+                                    field_line = node.start_point[0] + 1
+                                    injector_cls = _class_at_line(field_line)
+                                    if injector_cls:
+                                        injections.append({
+                                            "injector_class": injector_cls,
+                                            "injector_path": str(path),
+                                            "injected_class": field_type,
+                                            "field_name": self._get_node_text(name_node),
+                                            "inject_line": field_line,
+                                        })
+            for child in node.children:
+                _walk(child)
+
+        _walk(tree.root_node)
+        return injections
 
     def _parse_imports(self, captures: list, source_code: str) -> list[dict]:
         imports = []

--- a/src/codegraphcontext/tools/languages/java.py
+++ b/src/codegraphcontext/tools/languages/java.py
@@ -48,6 +48,32 @@ _SQL_QUERY_ANNOTATIONS = frozenset({"Query", "Select", "Insert", "Update", "Dele
 # Determines READ vs WRITE from a SQL/CQL string
 _WRITE_PREFIXES = ("INSERT", "UPDATE", "DELETE", "MERGE", "TRUNCATE", "REPLACE")
 
+# Spring Data repository base interfaces — presence means the interface is a repo
+_SPRING_DATA_REPO_BASES = frozenset({
+    "JpaRepository", "CrudRepository", "PagingAndSortingRepository",
+    "ListCrudRepository", "ListPagingAndSortingRepository",
+    "MongoRepository", "ReactiveMongoRepository",
+    "CassandraRepository", "ReactiveCassandraRepository",
+    "R2dbcRepository", "CoroutineCrudRepository",
+})
+
+# Spring Data derived-query method prefixes → READS
+_SPRING_DATA_READS_PREFIXES = (
+    "findby", "findall", "findfirst", "findtop", "finddistinct",
+    "readby", "getby", "queryby", "searchby",
+    "countby", "existsby",
+    "find", "read", "get", "count", "exists", "fetch", "load", "retrieve",
+)
+
+# Spring Data derived-query method prefixes → WRITES
+_SPRING_DATA_WRITES_PREFIXES = (
+    "saveall", "saveandflushthem", "saveandflush", "saveallandflush",
+    "save", "insertall", "insert", "updateall", "update",
+    "deleteall", "deletebyid", "deleteallinbatch", "deleteinbatch",
+    "deleteby", "delete", "removeall", "removeby", "remove",
+    "flush", "create",
+)
+
 
 def _parse_sql_tables(sql: str) -> List[str]:
     """Extract table names from a SQL/CQL string without a full parser.
@@ -411,6 +437,27 @@ class JavaTreeSitterParser:
                                     if child.type in ('type_identifier', 'generic_type', 'scoped_type_identifier'):
                                         bases.append(self._get_node_text(child))
 
+                        # Look for extends_interfaces (interface extends another interface)
+                        # Tree-sitter uses a different field for interface_declaration.
+                        # Scan by node type since child_by_field_name may not expose it.
+                        extends_ifaces_node = (
+                            node.child_by_field_name('extends_interfaces')
+                            or next(
+                                (c for c in node.children if c.type == 'extends_interfaces'),
+                                None,
+                            )
+                        )
+                        if extends_ifaces_node:
+                            iface_list = next(
+                                (c for c in extends_ifaces_node.children
+                                 if c.type in ('type_list', 'interface_type_list')),
+                                None,
+                            )
+                            candidates = iface_list.children if iface_list else extends_ifaces_node.children
+                            for child in candidates:
+                                if child.type in ('type_identifier', 'generic_type', 'scoped_type_identifier'):
+                                    bases.append(self._get_node_text(child))
+
                         class_data = {
                             "name": class_name,
                             "line_number": start_line,
@@ -660,6 +707,62 @@ class JavaTreeSitterParser:
                 _walk(child)
 
         _walk(tree.root_node)
+
+        # ── Spring Data repository derived-query methods ───────────────────
+        # For interfaces extending JpaRepository<Entity, ID> etc., emit
+        # READS/WRITES records that the writer resolves via MAPS_TO hop.
+        for cls in parsed_classes:
+            if str(path) != cls.get("path"):
+                continue
+            bases = cls.get("bases", [])
+            entity_class: Optional[str] = None
+            for base_str in bases:
+                for repo_base in _SPRING_DATA_REPO_BASES:
+                    if repo_base in base_str:
+                        # Extract first generic arg: JpaRepository<UserAuth, Long> → UserAuth
+                        m = re.search(r'<\s*([A-Za-z][A-Za-z0-9_]*)', base_str)
+                        if m:
+                            entity_class = m.group(1)
+                        break
+                if entity_class:
+                    break
+
+            if not entity_class:
+                continue
+
+            cls_start = cls["line_number"]
+            cls_end = cls.get("end_line", 999999)
+
+            for fn in parsed_functions:
+                if fn.get("path") != str(path):
+                    continue
+                fn_line = fn.get("line_number", 0)
+                if not (cls_start <= fn_line <= cls_end):
+                    continue
+
+                method_name = fn.get("name", "")
+                if not method_name:
+                    continue
+
+                mn_lower = method_name.lower()
+                # Check WRITES first (longer prefixes must come first — handled by tuple order)
+                if any(mn_lower.startswith(p) for p in _SPRING_DATA_WRITES_PREFIXES):
+                    operation = "WRITES"
+                elif any(mn_lower.startswith(p) for p in _SPRING_DATA_READS_PREFIXES):
+                    operation = "READS"
+                else:
+                    continue
+
+                mappings.append({
+                    "kind": "spring_data_method",
+                    "entity_class": entity_class,
+                    "method_name": method_name,
+                    "class_name": cls["name"],
+                    "method_path": str(path),
+                    "operation": operation,
+                    "line_number": fn_line,
+                })
+
         return mappings
 
     def _extract_spring_injections(

--- a/src/codegraphcontext/tools/languages/maven.py
+++ b/src/codegraphcontext/tools/languages/maven.py
@@ -1,0 +1,165 @@
+"""Parse pom.xml files to extract Maven build graph data (#888)."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from codegraphcontext.utils.debug_log import error_logger, info_logger
+
+_MVN_NS = "http://maven.apache.org/POM/4.0.0"
+
+
+def _ns(tag: str) -> str:
+    """Return a namespace-qualified tag, e.g. 'groupId' -> '{http://...}groupId'."""
+    return f"{{{_MVN_NS}}}{tag}"
+
+
+def _text(element: Any, tag: str, default: str = "") -> str:
+    child = element.find(_ns(tag))
+    if child is None:
+        child = element.find(tag)  # also try without namespace
+    return (child.text or "").strip() if child is not None else default
+
+
+class MavenParser:
+    """Parses a pom.xml file and returns structured build graph data."""
+
+    def parse(self, pom_path: Path) -> Optional[Dict[str, Any]]:
+        """Parse *pom_path* and return a dict compatible with GraphWriter.write_maven_build_graph().
+
+        Keys returned:
+            modules         List[dict]  — MavenModule node records
+            inter_module_deps  List[dict]  — inter-module MODULE_DEPENDS_ON records
+            external_libs   List[dict]  — ExternalLibrary node + USES_LIBRARY records
+            child_relations List[dict]  — CHILD_MODULE edge records
+        """
+        try:
+            tree = ET.parse(pom_path)
+            root = tree.getroot()
+        except Exception as exc:
+            error_logger(f"[MAVEN] Cannot parse {pom_path}: {exc}")
+            return None
+
+        # Resolve effective groupId/version — may be inherited from parent
+        parent_el = root.find(_ns("parent"))
+        parent_group = _text(parent_el, "groupId") if parent_el is not None else ""
+        parent_version = _text(parent_el, "version") if parent_el is not None else ""
+
+        group_id = _text(root, "groupId") or parent_group
+        artifact_id = _text(root, "artifactId")
+        version = _text(root, "version") or parent_version
+        packaging = _text(root, "packaging") or "jar"
+
+        if not artifact_id:
+            return None
+
+        this_module = {
+            "group_id": group_id,
+            "artifact_id": artifact_id,
+            "version": version,
+            "packaging": packaging,
+            "pom_path": str(pom_path),
+        }
+
+        # ── Child modules declared in <modules> section ───────────────────
+        child_artifact_ids: List[str] = []
+        modules_el = root.find(_ns("modules"))
+        if modules_el is None:
+            modules_el = root.find("modules")
+        if modules_el is not None:
+            for mod_el in modules_el:
+                child_dir = (mod_el.text or "").strip()
+                if child_dir:
+                    # Use directory name as a proxy for artifactId when we don't know yet
+                    child_artifact_ids.append(child_dir)
+
+        # ── Dependencies ─────────────────────────────────────────────────
+        inter_module_deps: List[Dict[str, Any]] = []
+        external_libs: List[Dict[str, Any]] = []
+
+        # Property interpolation for common version placeholders
+        properties: Dict[str, str] = {}
+        props_el = root.find(_ns("properties"))
+        if props_el is None:
+            props_el = root.find("properties")
+        if props_el is not None:
+            for prop in props_el:
+                tag = prop.tag.replace(f"{{{_MVN_NS}}}", "")
+                properties[tag] = (prop.text or "").strip()
+
+        def _resolve_version(v: str) -> str:
+            if v.startswith("${") and v.endswith("}"):
+                key = v[2:-1]
+                return properties.get(key, v)
+            return v
+
+        deps_container = root.find(_ns("dependencies"))
+        if deps_container is None:
+            deps_container = root.find("dependencies")
+
+        if deps_container is not None:
+            for dep in deps_container:
+                dep_group = _text(dep, "groupId")
+                dep_artifact = _text(dep, "artifactId")
+                dep_version = _resolve_version(_text(dep, "version"))
+                dep_scope = _text(dep, "scope") or "compile"
+
+                if not dep_artifact:
+                    continue
+
+                # Heuristic: if groupId matches this POM's group → inter-module dep
+                if dep_group and dep_group == group_id:
+                    inter_module_deps.append({
+                        "src_artifact_id": artifact_id,
+                        "tgt_artifact_id": dep_artifact,
+                        "scope": dep_scope,
+                    })
+                else:
+                    external_libs.append({
+                        "src_artifact_id": artifact_id,
+                        "group_id": dep_group,
+                        "artifact_id": dep_artifact,
+                        "version": dep_version,
+                        "scope": dep_scope,
+                    })
+
+        child_relations = [
+            {"parent_artifact_id": artifact_id, "child_artifact_id": c}
+            for c in child_artifact_ids
+        ]
+
+        return {
+            "modules": [this_module],
+            "inter_module_deps": inter_module_deps,
+            "external_libs": external_libs,
+            "child_relations": child_relations,
+        }
+
+
+def parse_repo_maven(repo_root: Path) -> Dict[str, Any]:
+    """Walk *repo_root* for all pom.xml files and merge into a single build graph dict."""
+    parser = MavenParser()
+    merged: Dict[str, Any] = {
+        "modules": [],
+        "inter_module_deps": [],
+        "external_libs": [],
+        "child_relations": [],
+    }
+
+    for pom_path in sorted(repo_root.rglob("pom.xml")):
+        # Skip very deep paths (e.g. target/ directories)
+        relative = pom_path.relative_to(repo_root)
+        if any(part in ("target", "build", ".git") for part in relative.parts):
+            continue
+        result = parser.parse(pom_path)
+        if result:
+            for key in merged:
+                merged[key].extend(result.get(key, []))
+
+    info_logger(
+        f"[MAVEN] Discovered {len(merged['modules'])} pom.xml modules, "
+        f"{len(merged['external_libs'])} external lib references."
+    )
+    return merged

--- a/src/codegraphcontext/tools/languages/mybatis.py
+++ b/src/codegraphcontext/tools/languages/mybatis.py
@@ -1,0 +1,185 @@
+"""MyBatis XML mapper parser — extracts READS/WRITES operations from *Mapper.xml files.
+
+Each mapper file has the form:
+    <mapper namespace="com.example.FooMapper">
+        <select id="findAll">SELECT ... FROM foo_table ...</select>
+        <insert id="insert">INSERT INTO foo_table ...</insert>
+        <update id="update">UPDATE foo_table ...</update>
+        <delete id="delete">DELETE FROM foo_table ...</delete>
+    </mapper>
+
+The ``id`` attribute matches the Java interface method name.
+Table names are extracted from the SQL text; when SQL is absent the mapper
+class name is converted to a snake_case table name as a heuristic
+(e.g. ``MailHistoryMapper`` → ``mail_history``).
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from codegraphcontext.utils.debug_log import error_logger, info_logger
+
+# Tags that represent write operations
+_WRITE_TAGS = frozenset({"insert", "update", "delete"})
+_READ_TAGS = frozenset({"select"})
+_ALL_OP_TAGS = _WRITE_TAGS | _READ_TAGS
+
+
+def _camel_to_snake(name: str) -> str:
+    """Convert CamelCase to snake_case (e.g. MailHistory → mail_history)."""
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _class_name_to_table(class_name: str) -> Optional[str]:
+    """Derive a table name heuristic from a mapper class name.
+
+    ``MailHistoryMapper`` → ``mail_history``
+    ``UserMapper`` → ``user``
+    Returns *None* when the input is empty or only ``Mapper``.
+    """
+    stem = re.sub(r"Mapper$", "", class_name).strip()
+    if not stem:
+        return None
+    return _camel_to_snake(stem)
+
+
+def _extract_sql(element: ET.Element) -> str:
+    """Return the concatenated text content of an XML element (handles CDATA)."""
+    parts = []
+    if element.text:
+        parts.append(element.text)
+    for child in element:
+        if child.text:
+            parts.append(child.text)
+        if child.tail:
+            parts.append(child.tail)
+    if element.tail:
+        parts.append(element.tail)
+    return " ".join(parts)
+
+
+def _parse_sql_tables(sql: str) -> List[str]:
+    """Extract table names from a SQL string (best-effort, no full parser)."""
+    sql_upper = sql.upper()
+    tables: List[str] = []
+    for kw in ("FROM", "JOIN", "INTO", "UPDATE", "TABLE"):
+        for m in re.finditer(rf"\b{kw}\s+[`'\"]?([\w.]+)[`'\"]?", sql_upper):
+            raw = m.group(1)
+            # Strip schema prefix: schema.table → table
+            tables.append(raw.split(".")[-1].lower())
+    # Deduplicate, preserving order
+    seen: set = set()
+    result: List[str] = []
+    for t in tables:
+        if t not in seen:
+            seen.add(t)
+            result.append(t)
+    return result
+
+
+def parse_mybatis_mapper(file_path: Path) -> List[Dict[str, Any]]:
+    """Parse a single MyBatis XML mapper file and return operation records.
+
+    Each record has:
+        method_name  – Java interface method name (= XML ``id`` attribute)
+        class_name   – Short name of the mapper interface (e.g. ``MailHistoryMapper``)
+        db_tables    – List of table names touched
+        operation    – ``"READS"`` or ``"WRITES"``
+        mapper_path  – Absolute path of the XML file (for diagnostics)
+    """
+    records: List[Dict[str, Any]] = []
+    try:
+        tree = ET.parse(str(file_path))
+        root = tree.getroot()
+
+        # Root must be <mapper namespace="...">
+        if root.tag != "mapper":
+            return records
+
+        namespace = root.get("namespace", "")
+        # class_name = last segment of the namespace FQCN
+        class_name = namespace.split(".")[-1] if namespace else file_path.stem
+
+        for child in root:
+            tag = child.tag.lower() if child.tag else ""
+            if tag not in _ALL_OP_TAGS:
+                continue
+
+            method_id = child.get("id", "")
+            if not method_id:
+                continue
+
+            operation = "READS" if tag in _READ_TAGS else "WRITES"
+
+            sql_text = _extract_sql(child)
+            tables = _parse_sql_tables(sql_text)
+
+            # Fallback: infer table from mapper class name
+            if not tables:
+                inferred = _class_name_to_table(class_name)
+                if inferred:
+                    tables = [inferred]
+
+            if not tables:
+                # Still nothing — skip (no useful edge to write)
+                continue
+
+            records.append({
+                "method_name": method_id,
+                "class_name": class_name,
+                "db_tables": tables,
+                "operation": operation,
+                "mapper_path": str(file_path),
+            })
+
+    except ET.ParseError as e:
+        error_logger(f"[MYBATIS] XML parse error in {file_path}: {e}")
+    except Exception as e:
+        error_logger(f"[MYBATIS] Error parsing {file_path}: {e}")
+
+    return records
+
+
+def find_and_parse_mybatis_mappers(repo_path: Path) -> List[Dict[str, Any]]:
+    """Walk *repo_path* for MyBatis mapper XML files and return all operation records.
+
+    A file is treated as a mapper when it matches ``*Mapper.xml`` *or* when its
+    root element is ``<mapper>``.  Target directories (``target/``, ``build/``,
+    ``out/``) are skipped to avoid duplicates from compiled artefacts.
+    """
+    skip_dirs = {"target", "build", "out", ".git", "node_modules", "__pycache__"}
+    all_records: List[Dict[str, Any]] = []
+    file_count = 0
+
+    for xml_file in repo_path.rglob("*.xml"):
+        # Skip build output directories
+        if any(part in skip_dirs for part in xml_file.parts):
+            continue
+
+        is_mapper_by_name = xml_file.name.endswith("Mapper.xml")
+
+        if not is_mapper_by_name:
+            # Quick pre-screen: check for '<mapper' in first 512 bytes
+            try:
+                with open(xml_file, "rb") as fh:
+                    header = fh.read(512).decode("utf-8", errors="ignore")
+                if "<mapper" not in header:
+                    continue
+            except Exception:
+                continue
+
+        records = parse_mybatis_mapper(xml_file)
+        if records:
+            all_records.extend(records)
+            file_count += 1
+
+    info_logger(
+        f"[MYBATIS] Parsed {file_count} mapper files, "
+        f"{len(all_records)} operation records found"
+    )
+    return all_records

--- a/src/codegraphcontext/tools/query_tool_languages/java_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/java_toolkit.py
@@ -1,5 +1,252 @@
-class JavaToolkit:
-    """Template placeholder for future implementation."""
+"""Java-specific analysis toolkit (#889).
 
-    def get_cypher_query(query: str) -> str:
-        raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")
+Provides Spring-aware query methods used by the ``advanced_language_query_tool``
+and directly accessible via MCP tools ``find_java_spring_endpoints`` /
+``find_java_spring_beans``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class JavaToolkit:
+    """Spring-aware Java analysis methods backed by CodeFinder / raw Cypher."""
+
+    def __init__(self, code_finder: Any):
+        """
+        Args:
+            code_finder: A ``CodeFinder`` instance (or compatible duck-type).
+        """
+        self._cf = code_finder
+        self._driver = code_finder.driver
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    def _run(self, query: str, **params) -> List[Dict]:
+        try:
+            with self._driver.session() as session:
+                result = session.run(query, **params)
+                return [dict(r) for r in result]
+        except Exception as exc:
+            return [{"_error": str(exc)}]
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def find_spring_endpoints(
+        self,
+        http_method: Optional[str] = None,
+        path_pattern: Optional[str] = None,
+        repo_path: Optional[str] = None,
+    ) -> List[Dict]:
+        """Return Spring HTTP endpoint functions.
+
+        Args:
+            http_method:  Optional filter, e.g. 'GET', 'POST'.
+            path_pattern: Optional URL path substring, e.g. '/api/users'.
+            repo_path:    Optional repo root to restrict results.
+
+        Returns:
+            List of dicts with keys: method, path, handler, file, line_number.
+        """
+        conditions = ["fn.http_method IS NOT NULL"]
+        params: Dict[str, Any] = {}
+        if http_method:
+            conditions.append("fn.http_method = $http_method")
+            params["http_method"] = http_method.upper()
+        if path_pattern:
+            conditions.append("fn.http_path CONTAINS $path_pattern")
+            params["path_pattern"] = path_pattern
+        if repo_path:
+            conditions.append("fn.path STARTS WITH $repo_path")
+            params["repo_path"] = repo_path
+
+        where = " AND ".join(conditions)
+        return self._run(
+            f"""
+            MATCH (fn:Function)
+            WHERE {where}
+            RETURN fn.http_method AS method, fn.http_path AS path,
+                   fn.name AS handler, fn.path AS file,
+                   fn.line_number AS line_number
+            ORDER BY fn.http_path, fn.http_method
+            LIMIT 100
+            """,
+            **params,
+        )
+
+    def find_beans_by_stereotype(
+        self,
+        stereotype: Optional[str] = None,
+        repo_path: Optional[str] = None,
+    ) -> List[Dict]:
+        """Return Spring bean classes, optionally filtered by stereotype.
+
+        Args:
+            stereotype: One of CONTROLLER, REST_CONTROLLER, SERVICE,
+                        REPOSITORY, COMPONENT, CONFIGURATION.
+            repo_path:  Optional repo root to restrict results.
+
+        Returns:
+            List of dicts with keys: name, stereotype, file, line_number,
+            injection_count.
+        """
+        conditions = ["c.spring_stereotype IS NOT NULL"]
+        params: Dict[str, Any] = {}
+        if stereotype:
+            conditions.append("c.spring_stereotype = $stereotype")
+            params["stereotype"] = stereotype.upper()
+        if repo_path:
+            conditions.append("c.path STARTS WITH $repo_path")
+            params["repo_path"] = repo_path
+
+        where = " AND ".join(conditions)
+        return self._run(
+            f"""
+            MATCH (c:Class)
+            WHERE {where}
+            OPTIONAL MATCH ()-[:INJECTS]->(c)
+            WITH c, count(*) AS injection_count
+            RETURN c.name AS name, c.spring_stereotype AS stereotype,
+                   c.path AS file, c.line_number AS line_number,
+                   injection_count
+            ORDER BY stereotype, name
+            LIMIT 200
+            """,
+            **params,
+        )
+
+    def find_spring_injection_targets(
+        self,
+        class_name: str,
+        repo_path: Optional[str] = None,
+    ) -> List[Dict]:
+        """Return all classes that inject *class_name* via @Autowired / @Inject.
+
+        Args:
+            class_name: The injected class to look up.
+            repo_path:  Optional repo root to restrict results.
+
+        Returns:
+            List of dicts with keys: injector, file, field_name, inject_line.
+        """
+        conditions = ["injected.name = $class_name"]
+        params: Dict[str, Any] = {"class_name": class_name}
+        if repo_path:
+            conditions.append("injector.path STARTS WITH $repo_path")
+            params["repo_path"] = repo_path
+
+        where = " AND ".join(conditions)
+        return self._run(
+            f"""
+            MATCH (injector:Class)-[r:INJECTS]->(injected:Class)
+            WHERE {where}
+            RETURN injector.name AS injector, injector.path AS file,
+                   r.field_name AS field_name, r.inject_line AS inject_line
+            ORDER BY injector.name
+            LIMIT 100
+            """,
+            **params,
+        )
+
+    def find_transactional_methods(
+        self,
+        repo_path: Optional[str] = None,
+    ) -> List[Dict]:
+        """Return all @Transactional-annotated functions.
+
+        Args:
+            repo_path: Optional repo root to restrict results.
+
+        Returns:
+            List of dicts with keys: name, file, line_number.
+        """
+        conditions = ["fn.transactional = true"]
+        params: Dict[str, Any] = {}
+        if repo_path:
+            conditions.append("fn.path STARTS WITH $repo_path")
+            params["repo_path"] = repo_path
+
+        where = " AND ".join(conditions)
+        return self._run(
+            f"""
+            MATCH (fn:Function)
+            WHERE {where}
+            RETURN fn.name AS name, fn.path AS file,
+                   fn.line_number AS line_number
+            ORDER BY fn.path, fn.line_number
+            LIMIT 200
+            """,
+            **params,
+        )
+
+    def find_maven_module_deps(
+        self,
+        artifact_id: str,
+    ) -> Dict[str, Any]:
+        """Return internal and external dependencies of a Maven module.
+
+        Args:
+            artifact_id: The Maven artifactId to look up.
+
+        Returns:
+            Dict with keys: internal_deps, external_libs.
+        """
+        internal = self._run(
+            """
+            MATCH (src:MavenModule {artifact_id: $artifact_id})-[r:MODULE_DEPENDS_ON]->(tgt:MavenModule)
+            RETURN tgt.artifact_id AS artifact_id, tgt.group_id AS group_id,
+                   tgt.version AS version, r.scope AS scope
+            ORDER BY tgt.artifact_id
+            """,
+            artifact_id=artifact_id,
+        )
+        external = self._run(
+            """
+            MATCH (src:MavenModule {artifact_id: $artifact_id})-[r:USES_LIBRARY]->(lib:ExternalLibrary)
+            RETURN lib.group_id AS group_id, lib.artifact_id AS artifact_id,
+                   lib.version AS version, r.scope AS scope
+            ORDER BY lib.artifact_id
+            """,
+            artifact_id=artifact_id,
+        )
+        return {"internal_deps": internal, "external_libs": external}
+
+    def find_ambiguous_calls(
+        self,
+        repo_path: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict]:
+        """Return CALLS edges with AMBIGUOUS confidence — potential mis-resolutions.
+
+        Args:
+            repo_path: Optional repo root to restrict results.
+            limit:     Max rows to return.
+
+        Returns:
+            List of dicts with keys: caller, callee, resolution_tier, file.
+        """
+        conditions = ["c.confidence_label = 'AMBIGUOUS'"]
+        params: Dict[str, Any] = {"limit": limit}
+        if repo_path:
+            conditions.append("caller.path STARTS WITH $repo_path")
+            params["repo_path"] = repo_path
+
+        where = " AND ".join(conditions)
+        return self._run(
+            f"""
+            MATCH (caller)-[c:CALLS]->(callee)
+            WHERE {where}
+            RETURN caller.name AS caller, callee.name AS callee,
+                   c.resolution_tier AS resolution_tier, caller.path AS file
+            ORDER BY c.resolution_tier DESC
+            LIMIT $limit
+            """,
+            **params,
+        )
+
+    # Legacy shim — keeps existing callers working
+    def get_cypher_query(self, query: str) -> str:
+        raise NotImplementedError(
+            "Use find_spring_endpoints(), find_beans_by_stereotype(), etc. instead."
+        )

--- a/src/codegraphcontext/tools/report_generator.py
+++ b/src/codegraphcontext/tools/report_generator.py
@@ -1,0 +1,368 @@
+"""CGC Report Generator (#884).
+
+Generates a CGC_REPORT.md summarising:
+- God nodes (highest in-degree functions/classes)
+- Most complex functions
+- Cross-module surprising connections
+- Spring endpoint and bean summary (--java flag)
+- Suggested Cypher queries
+
+Usage::
+
+    from codegraphcontext.tools.report_generator import generate_report
+    markdown = generate_report(db_manager, output_path=Path("CGC_REPORT.md"))
+"""
+
+from __future__ import annotations
+
+import textwrap
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..utils.debug_log import info_logger
+
+
+def _run_cypher(driver: Any, query: str, params: Optional[Dict] = None) -> List[Dict]:
+    """Execute a read-only Cypher query and return a list of record dicts."""
+    try:
+        with driver.session() as session:
+            result = session.run(query, **(params or {}))
+            return [dict(record) for record in result]
+    except Exception as exc:
+        return [{"_error": str(exc)}]
+
+
+def _h2(title: str) -> str:
+    return f"\n## {title}\n"
+
+
+def _h3(title: str) -> str:
+    return f"\n### {title}\n"
+
+
+def _table(headers: List[str], rows: List[List[Any]]) -> str:
+    """Render a simple markdown table."""
+    sep = " | ".join("---" for _ in headers)
+    head = " | ".join(headers)
+    body = "\n".join(" | ".join(str(c) for c in row) for row in rows)
+    return f"| {head} |\n| {sep} |\n" + "\n".join(f"| {' | '.join(str(c) for c in r)} |" for r in rows)
+
+
+def _code_block(cypher: str) -> str:
+    return f"```cypher\n{textwrap.dedent(cypher).strip()}\n```"
+
+
+# ── Individual report sections ────────────────────────────────────────────────
+
+def _section_god_nodes(driver: Any, limit: int = 15) -> str:
+    """Functions / classes with the highest number of incoming CALLS edges."""
+    rows = _run_cypher(
+        driver,
+        """
+        MATCH ()-[:CALLS]->(target)
+        WITH target, count(*) AS in_degree
+        WHERE in_degree > 1
+        RETURN labels(target)[0] AS kind, target.name AS name,
+               target.path AS path, in_degree
+        ORDER BY in_degree DESC
+        LIMIT $limit
+        """,
+        {"limit": limit},
+    )
+    if not rows or "_error" in rows[0]:
+        return ""
+
+    out = _h2("God Nodes — Highest Fan-In")
+    out += (
+        "_These nodes are called from many places. High fan-in increases risk: "
+        "a change here affects every caller._\n\n"
+    )
+    table_rows = []
+    for r in rows:
+        path = str(r.get("path") or "")
+        short_path = path.split("/")[-2] + "/" + path.split("/")[-1] if "/" in path else path
+        table_rows.append([r.get("kind", "?"), r.get("name", "?"), short_path, r.get("in_degree", 0)])
+    out += _table(["Kind", "Name", "File", "In-degree"], table_rows)
+    out += "\n"
+    return out
+
+
+def _section_complexity(driver: Any, limit: int = 15) -> str:
+    """Most complex functions by cyclomatic complexity."""
+    rows = _run_cypher(
+        driver,
+        """
+        MATCH (fn:Function)
+        WHERE fn.cyclomatic_complexity IS NOT NULL AND fn.cyclomatic_complexity > 1
+        RETURN fn.name AS name, fn.path AS path,
+               fn.cyclomatic_complexity AS complexity
+        ORDER BY complexity DESC
+        LIMIT $limit
+        """,
+        {"limit": limit},
+    )
+    if not rows or "_error" in rows[0]:
+        return ""
+
+    out = _h2("Most Complex Functions")
+    out += "_Cyclomatic complexity > 10 is a refactoring candidate._\n\n"
+    table_rows = []
+    for r in rows:
+        path = str(r.get("path") or "")
+        short_path = "/".join(path.split("/")[-2:]) if "/" in path else path
+        table_rows.append([r.get("name", "?"), short_path, r.get("complexity", "?")])
+    out += _table(["Function", "File", "Cyclomatic Complexity"], table_rows)
+    out += "\n"
+    return out
+
+
+def _section_cross_module_calls(driver: Any, limit: int = 20) -> str:
+    """Cross-directory (cross-module) CALLS edges — potential surprising connections."""
+    rows = _run_cypher(
+        driver,
+        """
+        MATCH (caller)-[c:CALLS]->(callee)
+        WHERE caller.path IS NOT NULL AND callee.path IS NOT NULL
+          AND caller.path <> callee.path
+        WITH caller, callee, c,
+             [p IN split(caller.path, '/') WHERE p <> '' | p][-3] AS caller_pkg,
+             [p IN split(callee.path, '/') WHERE p <> '' | p][-3] AS callee_pkg
+        WHERE caller_pkg IS NOT NULL AND callee_pkg IS NOT NULL
+          AND caller_pkg <> callee_pkg
+        RETURN caller.name AS caller_name, caller.path AS caller_path,
+               callee.name AS callee_name, callee.path AS callee_path,
+               c.confidence_label AS label
+        LIMIT $limit
+        """,
+        {"limit": limit},
+    )
+    if not rows or "_error" in rows[0]:
+        return ""
+
+    out = _h2("Cross-Module Connections")
+    out += "_Calls that cross package boundaries — review for unexpected coupling._\n\n"
+    table_rows = []
+    for r in rows:
+        cp = str(r.get("caller_path") or "")
+        dp = str(r.get("callee_path") or "")
+        short_cp = "/".join(cp.split("/")[-2:]) if "/" in cp else cp
+        short_dp = "/".join(dp.split("/")[-2:]) if "/" in dp else dp
+        table_rows.append([
+            r.get("caller_name", "?"),
+            short_cp,
+            r.get("callee_name", "?"),
+            short_dp,
+            r.get("label") or "—",
+        ])
+    out += _table(["Caller", "Caller File", "Callee", "Callee File", "Confidence"], table_rows)
+    out += "\n"
+    return out
+
+
+def _section_dead_code(driver: Any, limit: int = 20) -> str:
+    """Functions with no incoming CALLS edges (potential dead code)."""
+    rows = _run_cypher(
+        driver,
+        """
+        MATCH (fn:Function)
+        WHERE fn.is_dependency IS NULL OR fn.is_dependency = false
+        AND NOT ()-[:CALLS]->(fn)
+        RETURN fn.name AS name, fn.path AS path
+        ORDER BY fn.path, fn.name
+        LIMIT $limit
+        """,
+        {"limit": limit},
+    )
+    if not rows or "_error" in rows[0]:
+        return ""
+
+    out = _h2("Potential Dead Code")
+    out += "_Functions with zero callers (not guaranteed dead — may be entry points or called via reflection)._\n\n"
+    table_rows = []
+    for r in rows:
+        path = str(r.get("path") or "")
+        short_path = "/".join(path.split("/")[-2:]) if "/" in path else path
+        table_rows.append([r.get("name", "?"), short_path])
+    out += _table(["Function", "File"], table_rows)
+    out += "\n"
+    return out
+
+
+def _section_spring_endpoints(driver: Any) -> str:
+    """Spring HTTP endpoints — table of method, path, handler function."""
+    rows = _run_cypher(
+        driver,
+        """
+        MATCH (fn:Function)
+        WHERE fn.http_method IS NOT NULL
+        RETURN fn.http_method AS method, fn.http_path AS path,
+               fn.name AS handler, fn.path AS file
+        ORDER BY fn.http_path, fn.http_method
+        """,
+    )
+    if not rows or "_error" in rows[0] or not rows:
+        return ""
+
+    out = _h2("Spring HTTP Endpoints")
+    table_rows = []
+    for r in rows:
+        file_path = str(r.get("file") or "")
+        short_fp = "/".join(file_path.split("/")[-2:]) if "/" in file_path else file_path
+        table_rows.append([
+            r.get("method", "?"),
+            r.get("path") or "—",
+            r.get("handler", "?"),
+            short_fp,
+        ])
+    out += _table(["HTTP Method", "Path", "Handler", "File"], table_rows)
+    out += "\n"
+    return out
+
+
+def _section_spring_beans(driver: Any) -> str:
+    """Spring bean stereotype summary."""
+    rows = _run_cypher(
+        driver,
+        """
+        MATCH (c:Class)
+        WHERE c.spring_stereotype IS NOT NULL
+        RETURN c.spring_stereotype AS stereotype, count(*) AS count
+        ORDER BY count DESC
+        """,
+    )
+    if not rows or "_error" in rows[0] or not rows:
+        return ""
+
+    out = _h2("Spring Bean Stereotypes")
+    table_rows = [[r.get("stereotype", "?"), r.get("count", 0)] for r in rows]
+    out += _table(["Stereotype", "Count"], table_rows)
+    out += "\n"
+    return out
+
+
+def _section_maven_modules(driver: Any) -> str:
+    """Maven module dependency summary."""
+    rows = _run_cypher(
+        driver,
+        """
+        MATCH (m:MavenModule)
+        OPTIONAL MATCH (m)-[:MODULE_DEPENDS_ON]->(dep:MavenModule)
+        RETURN m.artifact_id AS module, m.version AS version,
+               collect(dep.artifact_id) AS internal_deps
+        ORDER BY m.artifact_id
+        LIMIT 30
+        """,
+    )
+    if not rows or "_error" in rows[0] or not rows:
+        return ""
+
+    out = _h2("Maven Module Graph")
+    table_rows = []
+    for r in rows:
+        deps = r.get("internal_deps") or []
+        table_rows.append([r.get("module", "?"), r.get("version", "?"), len(deps)])
+    out += _table(["Module", "Version", "Internal Deps"], table_rows)
+    out += "\n"
+    return out
+
+
+def _section_suggested_queries() -> str:
+    out = _h2("Suggested Cypher Queries")
+    out += "_Copy these into `execute_cypher_query` to explore further._\n"
+
+    queries = [
+        (
+            "Callers of a specific function",
+            """
+            MATCH (caller)-[:CALLS]->(fn:Function {name: 'yourFunctionName'})
+            RETURN caller.name, caller.path LIMIT 20
+            """,
+        ),
+        (
+            "Class hierarchy for a specific class",
+            """
+            MATCH path = (c:Class {name: 'YourClass'})-[:INHERITS*]->(parent)
+            RETURN [n IN nodes(path) | n.name] AS hierarchy
+            """,
+        ),
+        (
+            "Most-injected Spring beans",
+            """
+            MATCH ()-[:INJECTS]->(bean:Class)
+            RETURN bean.name, count(*) AS injection_count
+            ORDER BY injection_count DESC LIMIT 10
+            """,
+        ),
+        (
+            "All external library dependencies",
+            """
+            MATCH (m:MavenModule)-[:USES_LIBRARY]->(lib:ExternalLibrary)
+            RETURN m.artifact_id, lib.group_id, lib.artifact_id, lib.version
+            ORDER BY lib.artifact_id
+            """,
+        ),
+        (
+            "CALLS edges with low confidence (potential mis-resolutions)",
+            """
+            MATCH (a)-[c:CALLS]->(b)
+            WHERE c.confidence_label = 'AMBIGUOUS'
+            RETURN a.name, b.name, c.resolution_tier, a.path LIMIT 20
+            """,
+        ),
+    ]
+
+    for title, query in queries:
+        out += _h3(title)
+        out += _code_block(query) + "\n"
+    return out
+
+
+# ── Public entry point ───────────────────────────────────────────────────────
+
+def generate_report(
+    db_manager: Any,
+    output_path: Optional[Path] = None,
+    include_java: bool = False,
+    god_node_limit: int = 15,
+    complexity_limit: int = 15,
+    cross_module_limit: int = 20,
+) -> str:
+    """Generate a CGC_REPORT.md and return the markdown string.
+
+    Args:
+        db_manager:      DatabaseManager instance.
+        output_path:     If provided, write the report to this path.
+        include_java:    Include Spring/Maven sections (--java flag).
+        god_node_limit:  Max rows for god-nodes section.
+        complexity_limit: Max rows for complexity section.
+        cross_module_limit: Max rows for cross-module section.
+
+    Returns:
+        The full report as a markdown string.
+    """
+    driver = db_manager.get_driver()
+    now = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+
+    sections = []
+    sections.append(f"# CGC Report\n\n_Generated: {now}_\n")
+    sections.append(_section_god_nodes(driver, god_node_limit))
+    sections.append(_section_complexity(driver, complexity_limit))
+    sections.append(_section_cross_module_calls(driver, cross_module_limit))
+    sections.append(_section_dead_code(driver))
+
+    if include_java:
+        sections.append(_section_spring_endpoints(driver))
+        sections.append(_section_spring_beans(driver))
+        sections.append(_section_maven_modules(driver))
+
+    sections.append(_section_suggested_queries())
+
+    report = "\n".join(s for s in sections if s)
+
+    if output_path:
+        output_path = Path(output_path)
+        output_path.write_text(report, encoding="utf-8")
+        info_logger(f"[REPORT] Written to {output_path}")
+
+    return report

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -378,6 +378,7 @@ def test_all_canonical_cli_commands_run_with_kuzudb(kuzudb_env, cli_test_stubs):
         ["n"],
         ["export", bundle_export],
         ["load", bundle_file],
+        ["report"],
     ]
 
     source_inventory = _inventory_from_main_source()

--- a/tests/unit/parsers/test_java_package_qualified_names.py
+++ b/tests/unit/parsers/test_java_package_qualified_names.py
@@ -1,0 +1,260 @@
+"""
+Unit tests for Phase 1 — package_name extraction and qualified_name construction
+in the Java tree-sitter parser.
+
+Covers:
+  - package_name field on the parse() return dict (File node data)
+  - qualified_name on Function nodes (package.ClassName.methodName)
+  - qualified_name on Class nodes (package.ClassName)
+  - Files without a package declaration (default/unnamed package)
+  - FQN entries in pre_scan_java imports_map
+"""
+
+import os
+import tempfile
+import pytest
+from unittest.mock import MagicMock
+from pathlib import Path
+
+from codegraphcontext.tools.languages.java import JavaTreeSitterParser, pre_scan_java
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def parser():
+    manager = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "java"
+    wrapper.language = manager.get_language_safe("java")
+    wrapper.parser = manager.create_parser("java")
+    return JavaTreeSitterParser(wrapper)
+
+
+def _write_and_parse(parser, src: str) -> dict:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".java", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(src)
+        tmp = f.name
+    try:
+        return parser.parse(Path(tmp))
+    finally:
+        os.unlink(tmp)
+
+
+# ---------------------------------------------------------------------------
+# Sample sources
+# ---------------------------------------------------------------------------
+
+BILLING_SERVICE_SRC = """\
+package com.example.acme.billing;
+
+public class BillingService {
+    public void processPayment(String orderId) {
+        // implementation
+    }
+
+    public int calculateTotal(int qty, int price) {
+        return qty * price;
+    }
+}
+"""
+
+INTERFACE_SRC = """\
+package com.example.acme.auth;
+
+public interface Authenticator {
+    boolean authenticate(String token);
+}
+"""
+
+NO_PACKAGE_SRC = """\
+public class StandaloneUtil {
+    public void doSomething() {}
+}
+"""
+
+INNER_CLASS_SRC = """\
+package com.example.acme.core;
+
+public class Outer {
+    public static class Inner {
+        public void innerMethod() {}
+    }
+
+    public void outerMethod() {}
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests: package_name on file data (Phase 1 — File nodes)
+# ---------------------------------------------------------------------------
+
+class TestPackageNameExtraction:
+
+    def test_package_name_present_when_declared(self, parser):
+        """parse() must return package_name matching the Java package statement."""
+        data = _write_and_parse(parser, BILLING_SERVICE_SRC)
+        assert data["package_name"] == "com.example.acme.billing"
+
+    def test_package_name_for_interface(self, parser):
+        """Interface files must also export package_name."""
+        data = _write_and_parse(parser, INTERFACE_SRC)
+        assert data["package_name"] == "com.example.acme.auth"
+
+    def test_package_name_is_none_without_declaration(self, parser):
+        """Files with no package statement must return package_name=None."""
+        data = _write_and_parse(parser, NO_PACKAGE_SRC)
+        assert data["package_name"] is None
+
+    def test_package_name_key_always_present(self, parser):
+        """The package_name key must always be in the result dict, even when None."""
+        data = _write_and_parse(parser, NO_PACKAGE_SRC)
+        assert "package_name" in data
+
+
+# ---------------------------------------------------------------------------
+# Tests: qualified_name on Function nodes (Phase 1 — Function nodes)
+# ---------------------------------------------------------------------------
+
+class TestFunctionQualifiedName:
+
+    def test_method_qualified_name_includes_package_and_class(self, parser):
+        """A class method qualified_name must be package.ClassName.methodName."""
+        data = _write_and_parse(parser, BILLING_SERVICE_SRC)
+        methods = {f["name"]: f for f in data["functions"]}
+
+        assert "processPayment" in methods
+        assert methods["processPayment"]["qualified_name"] == (
+            "com.example.acme.billing.BillingService.processPayment"
+        )
+
+    def test_all_methods_have_qualified_name(self, parser):
+        """Every method in a packaged class must have a non-empty qualified_name."""
+        data = _write_and_parse(parser, BILLING_SERVICE_SRC)
+        for fn in data["functions"]:
+            assert "qualified_name" in fn, f"No qualified_name on {fn['name']}"
+            assert fn["qualified_name"], f"Empty qualified_name on {fn['name']}"
+
+    def test_method_qualified_name_uses_actual_method_name(self, parser):
+        """calculateTotal qualified_name must end with the correct method name."""
+        data = _write_and_parse(parser, BILLING_SERVICE_SRC)
+        methods = {f["name"]: f for f in data["functions"]}
+        assert methods["calculateTotal"]["qualified_name"].endswith(".calculateTotal")
+
+    def test_no_qualified_name_without_package(self, parser):
+        """Methods in files with no package declaration must not have qualified_name."""
+        data = _write_and_parse(parser, NO_PACKAGE_SRC)
+        for fn in data["functions"]:
+            assert "qualified_name" not in fn or fn.get("qualified_name") is None, (
+                f"Unexpected qualified_name on {fn['name']} in packageless file"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests: qualified_name on Class nodes (Phase 1 — Class nodes)
+# ---------------------------------------------------------------------------
+
+class TestClassQualifiedName:
+
+    def test_class_qualified_name_is_package_dot_classname(self, parser):
+        """Class qualified_name must be package.ClassName."""
+        data = _write_and_parse(parser, BILLING_SERVICE_SRC)
+        classes = {c["name"]: c for c in data["classes"]}
+
+        assert "BillingService" in classes
+        assert classes["BillingService"]["qualified_name"] == (
+            "com.example.acme.billing.BillingService"
+        )
+
+    def test_interface_qualified_name(self, parser):
+        """Interface nodes must also carry qualified_name."""
+        data = _write_and_parse(parser, INTERFACE_SRC)
+        classes = {c["name"]: c for c in data["classes"]}
+        assert "Authenticator" in classes
+        assert classes["Authenticator"]["qualified_name"] == "com.example.acme.auth.Authenticator"
+
+    def test_no_class_qualified_name_without_package(self, parser):
+        """Classes in packageless files must not have qualified_name."""
+        data = _write_and_parse(parser, NO_PACKAGE_SRC)
+        for cls in data["classes"]:
+            assert "qualified_name" not in cls or cls.get("qualified_name") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: pre_scan_java FQN entries (Phase 1 — imports_map enrichment)
+# ---------------------------------------------------------------------------
+
+class TestPreScanJavaFQNEntries:
+
+    def test_pre_scan_adds_fqn_entry(self, tmp_path):
+        """pre_scan_java must add com.example.acme.billing.BillingService -> [path] entry."""
+        java_file = tmp_path / "BillingService.java"
+        java_file.write_text(BILLING_SERVICE_SRC, encoding="utf-8")
+
+        manager = get_tree_sitter_manager()
+        wrapper = MagicMock()
+        wrapper.language_name = "java"
+        wrapper.language = manager.get_language_safe("java")
+        wrapper.parser = manager.create_parser("java")
+
+        result = pre_scan_java([java_file], wrapper)
+
+        assert "com.example.acme.billing.BillingService" in result, (
+            "FQN entry missing — Phase 2 qualified-import resolution will not work"
+        )
+        assert str(java_file) in result["com.example.acme.billing.BillingService"]
+
+    def test_pre_scan_retains_short_name_entry(self, tmp_path):
+        """pre_scan_java must still register the short name BillingService -> [path]."""
+        java_file = tmp_path / "BillingService.java"
+        java_file.write_text(BILLING_SERVICE_SRC, encoding="utf-8")
+
+        manager = get_tree_sitter_manager()
+        wrapper = MagicMock()
+        wrapper.language_name = "java"
+        wrapper.language = manager.get_language_safe("java")
+        wrapper.parser = manager.create_parser("java")
+
+        result = pre_scan_java([java_file], wrapper)
+
+        assert "BillingService" in result, "Short-name entry must be kept for backward compat"
+        assert str(java_file) in result["BillingService"]
+
+    def test_pre_scan_adds_interface_fqn(self, tmp_path):
+        """pre_scan_java must add FQN entries for interfaces as well as classes."""
+        java_file = tmp_path / "Authenticator.java"
+        java_file.write_text(INTERFACE_SRC, encoding="utf-8")
+
+        manager = get_tree_sitter_manager()
+        wrapper = MagicMock()
+        wrapper.language_name = "java"
+        wrapper.language = manager.get_language_safe("java")
+        wrapper.parser = manager.create_parser("java")
+
+        result = pre_scan_java([java_file], wrapper)
+
+        assert "com.example.acme.auth.Authenticator" in result
+        assert str(java_file) in result["com.example.acme.auth.Authenticator"]
+
+    def test_pre_scan_no_fqn_without_package(self, tmp_path):
+        """Files without a package declaration must not produce FQN entries."""
+        java_file = tmp_path / "StandaloneUtil.java"
+        java_file.write_text(NO_PACKAGE_SRC, encoding="utf-8")
+
+        manager = get_tree_sitter_manager()
+        wrapper = MagicMock()
+        wrapper.language_name = "java"
+        wrapper.language = manager.get_language_safe("java")
+        wrapper.parser = manager.create_parser("java")
+
+        result = pre_scan_java([java_file], wrapper)
+
+        # No dotted FQN keys should appear for this class
+        fqn_keys = [k for k in result if "." in k and "StandaloneUtil" in k]
+        assert not fqn_keys, f"Unexpected FQN keys for packageless class: {fqn_keys}"

--- a/tests/unit/parsers/test_java_parser.py
+++ b/tests/unit/parsers/test_java_parser.py
@@ -225,3 +225,139 @@ class TestJavaCrossFileResolution:
                 assert resolved["called_file_path"] == service_path, (
                     f"WorkService has no DI fields; expected self-resolution for '{call['name']}'"
                 )
+
+
+# ---------------------------------------------------------------------------
+# ORM / datasource mapping extraction tests (#843)
+# ---------------------------------------------------------------------------
+
+JPA_ENTITY_SRC = """
+package com.example;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.Column;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "created_at")
+    private java.time.Instant createdAt;
+}
+"""
+
+CASSANDRA_TABLE_SRC = """
+package com.example;
+
+import org.springframework.data.cassandra.core.mapping.Table;
+
+@Table(value = "events")
+public class EventEntity {
+    private String id;
+}
+"""
+
+REDIS_HASH_SRC = """
+package com.example;
+
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(value = "session")
+public class SessionData {
+    private String token;
+}
+"""
+
+SPRING_QUERY_SRC = """
+package com.example;
+
+import org.springframework.data.jpa.repository.Query;
+
+public interface UserRepository {
+    @Query("SELECT u FROM users u WHERE u.id = :id")
+    User findById(Long id);
+
+    @Query("INSERT INTO audit_log(user_id, action) VALUES (:userId, :action)")
+    void logAction(Long userId, String action);
+}
+"""
+
+MYBATIS_SRC = """
+package com.example;
+
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Insert;
+
+public interface UserMapper {
+    @Select("SELECT * FROM users WHERE id = #{id}")
+    User selectById(int id);
+
+    @Insert("INSERT INTO orders(user_id, total) VALUES(#{userId}, #{total})")
+    int createOrder(int userId, double total);
+}
+"""
+
+
+class TestOrmMappingExtraction:
+    def test_jpa_entity_table_mapping(self, parser):
+        data = _write_and_parse(parser, JPA_ENTITY_SRC)
+        orm = data.get("orm_mappings", [])
+        class_maps = [r for r in orm if r["kind"] == "class_table"]
+        assert len(class_maps) == 1
+        assert class_maps[0]["orm_table"] == "users"
+        assert class_maps[0]["datastore"] == "mysql"
+        assert class_maps[0]["class_name"] == "User"
+
+    def test_cassandra_table_mapping(self, parser):
+        data = _write_and_parse(parser, CASSANDRA_TABLE_SRC)
+        orm = data.get("orm_mappings", [])
+        class_maps = [r for r in orm if r["kind"] == "class_table"]
+        assert len(class_maps) == 1
+        assert class_maps[0]["orm_table"] == "events"
+        assert class_maps[0]["datastore"] == "cassandra"
+
+    def test_redis_hash_mapping(self, parser):
+        data = _write_and_parse(parser, REDIS_HASH_SRC)
+        orm = data.get("orm_mappings", [])
+        class_maps = [r for r in orm if r["kind"] == "class_table"]
+        assert len(class_maps) == 1
+        assert class_maps[0]["orm_table"] == "session"
+        assert class_maps[0]["datastore"] == "redis"
+
+    def test_spring_query_read_detection(self, parser):
+        data = _write_and_parse(parser, SPRING_QUERY_SRC)
+        orm = data.get("orm_mappings", [])
+        reads = [r for r in orm if r.get("operation") == "READS"]
+        assert any("users" in r.get("db_tables", []) for r in reads), (
+            "Expected a READS edge to 'users'"
+        )
+
+    def test_spring_query_write_detection(self, parser):
+        data = _write_and_parse(parser, SPRING_QUERY_SRC)
+        orm = data.get("orm_mappings", [])
+        writes = [r for r in orm if r.get("operation") == "WRITES"]
+        assert any("audit_log" in r.get("db_tables", []) for r in writes), (
+            "Expected a WRITES edge to 'audit_log'"
+        )
+
+    def test_mybatis_select_annotation(self, parser):
+        data = _write_and_parse(parser, MYBATIS_SRC)
+        orm = data.get("orm_mappings", [])
+        reads = [r for r in orm if r.get("operation") == "READS"]
+        assert any("users" in r.get("db_tables", []) for r in reads)
+
+    def test_mybatis_insert_annotation(self, parser):
+        data = _write_and_parse(parser, MYBATIS_SRC)
+        orm = data.get("orm_mappings", [])
+        writes = [r for r in orm if r.get("operation") == "WRITES"]
+        assert any("orders" in r.get("db_tables", []) for r in writes)
+
+    def test_orm_mappings_key_present(self, parser):
+        """orm_mappings key must always be present in parse() output."""
+        data = _write_and_parse(parser, CONTROLLER_SRC)
+        assert "orm_mappings" in data
+        assert isinstance(data["orm_mappings"], list)
+

--- a/tests/unit/parsers/test_java_parser.py
+++ b/tests/unit/parsers/test_java_parser.py
@@ -361,3 +361,77 @@ class TestOrmMappingExtraction:
         assert "orm_mappings" in data
         assert isinstance(data["orm_mappings"], list)
 
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Spring Data repository derived-query method detection
+# ──────────────────────────────────────────────────────────────────────────────
+
+SPRING_DATA_REPO_SRC = """\
+package com.example.db;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface UserAuthenticationRepository extends JpaRepository<UserAuthentication, Long> {
+
+    Optional<UserAuthentication> findByUserId(String userId);
+
+    List<UserAuthentication> findByEmailAndStatus(String email, String status);
+
+    long countByStatus(String status);
+
+    boolean existsByUserId(String userId);
+
+    void deleteByUserId(String userId);
+
+    List<UserAuthentication> findAllByCreatedAtAfter(long timestamp);
+}
+
+public interface OrderRepository extends CrudRepository<Order, Long> {
+
+    List<Order> findByCustomerId(String customerId);
+
+    void deleteById(Long id);
+}
+"""
+
+
+class TestSpringDataRepoDetection:
+    def test_spring_data_reads_emitted(self, parser):
+        data = _write_and_parse(parser, SPRING_DATA_REPO_SRC)
+        orm = data.get("orm_mappings", [])
+        spring_reads = [r for r in orm if r.get("kind") == "spring_data_method" and r.get("operation") == "READS"]
+        assert len(spring_reads) >= 4, f"Expected >=4 READS, got {len(spring_reads)}: {spring_reads}"
+
+    def test_spring_data_writes_emitted(self, parser):
+        data = _write_and_parse(parser, SPRING_DATA_REPO_SRC)
+        orm = data.get("orm_mappings", [])
+        spring_writes = [r for r in orm if r.get("kind") == "spring_data_method" and r.get("operation") == "WRITES"]
+        method_names = [r["method_name"] for r in spring_writes]
+        assert "deleteByUserId" in method_names, f"Expected deleteByUserId in WRITES, got: {method_names}"
+
+    def test_spring_data_entity_class_extracted(self, parser):
+        data = _write_and_parse(parser, SPRING_DATA_REPO_SRC)
+        orm = data.get("orm_mappings", [])
+        spring = [r for r in orm if r.get("kind") == "spring_data_method"]
+        user_auth_methods = [r for r in spring if r.get("entity_class") == "UserAuthentication"]
+        assert len(user_auth_methods) >= 1, f"Expected entity_class=UserAuthentication, got: {[r.get('entity_class') for r in spring]}"
+
+    def test_spring_data_crud_repo_detected(self, parser):
+        data = _write_and_parse(parser, SPRING_DATA_REPO_SRC)
+        orm = data.get("orm_mappings", [])
+        order_methods = [r for r in orm if r.get("kind") == "spring_data_method" and r.get("entity_class") == "Order"]
+        assert len(order_methods) >= 1, f"Expected Order entity methods, got: {order_methods}"
+
+    def test_spring_data_class_name_set(self, parser):
+        data = _write_and_parse(parser, SPRING_DATA_REPO_SRC)
+        orm = data.get("orm_mappings", [])
+        spring = [r for r in orm if r.get("kind") == "spring_data_method"]
+        for r in spring:
+            assert r.get("class_name"), f"class_name missing on {r}"
+            assert r.get("method_name"), f"method_name missing on {r}"
+            assert r.get("method_path"), f"method_path missing on {r}"
+            assert r.get("entity_class"), f"entity_class missing on {r}"
+

--- a/tests/unit/tools/test_calls_resolution_tiers.py
+++ b/tests/unit/tools/test_calls_resolution_tiers.py
@@ -1,0 +1,323 @@
+"""
+Unit tests for Phase 2+3 — resolution tier waterfall and confidence scoring
+in calls.py.
+
+Covers:
+  - Tier 1: self/this/super receiver → confidence 1.00
+  - Tier 2: local name → confidence 0.95
+  - Tier 3: inferred_obj_type with FQN in imports_map → confidence 0.88
+  - Tier 4: inferred_obj_type with short-name fallback → confidence 0.72
+  - Tier 5: globally unique short name → confidence 0.90
+  - Tier 6: FQN key from qualified import → confidence 0.85
+  - Tier 7: FQN path-substring match → confidence 0.70
+  - Tier 8: alphabetical-first of multiple candidates → confidence 0.25
+  - Tier 9: same-file fallback for obj.method() → confidence 0.08
+  - confidence and resolution_tier are always present in the return dict
+  - skip_external still suppresses definitionally-external (tier 9) calls
+  - return dict structure is unchanged (no removed keys)
+"""
+
+import pytest
+from codegraphcontext.tools.indexing.resolution.calls import resolve_function_call, _TIER_CONFIDENCE
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _call(called_name, full_name=None, inferred_obj_type=None, context=("caller_fn", None, 1)):
+    return {
+        "name": called_name,
+        "full_name": full_name or called_name,
+        "line_number": 5,
+        "args": [],
+        "inferred_obj_type": inferred_obj_type,
+        "context": context,
+    }
+
+
+CALLER = "/repo/Controller.java"
+
+
+def resolve(call_dict, local_names=None, local_imports=None, imports_map=None, skip_external=False):
+    return resolve_function_call(
+        call_dict,
+        caller_file_path=CALLER,
+        local_names=local_names or set(),
+        local_imports=local_imports or {},
+        imports_map=imports_map or {},
+        skip_external=skip_external,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: return shape (backward-compat check)
+# ---------------------------------------------------------------------------
+
+class TestReturnShape:
+
+    def test_confidence_always_present(self):
+        result = resolve(_call("helper"), local_names={"helper"})
+        assert result is not None
+        assert "confidence" in result
+
+    def test_resolution_tier_always_present(self):
+        result = resolve(_call("helper"), local_names={"helper"})
+        assert result is not None
+        assert "resolution_tier" in result
+
+    def test_legacy_keys_still_present(self):
+        """Existing consumers must not break — all original keys must be returned."""
+        result = resolve(_call("helper"), local_names={"helper"})
+        assert result is not None
+        for key in ("caller_name", "caller_file_path", "called_name", "called_file_path",
+                    "line_number", "args", "full_call_name", "type"):
+            assert key in result, f"Legacy key '{key}' missing from resolve_function_call result"
+
+    def test_file_type_when_no_caller_context(self):
+        """A call with context=None must return type='file' (backward compat)."""
+        result = resolve(_call("helper", context=None), local_names={"helper"})
+        assert result is not None
+        assert result["type"] == "file"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier 1 — self/this/super
+# ---------------------------------------------------------------------------
+
+class TestTier1SelfReceiver:
+
+    def test_this_receiver_resolves_to_caller(self):
+        result = resolve(_call("execute", full_name="this.execute"))
+        assert result["called_file_path"] == CALLER
+
+    def test_this_receiver_tier_is_1(self):
+        result = resolve(_call("execute", full_name="this.execute"))
+        assert result["resolution_tier"] == 1
+
+    def test_this_receiver_confidence_is_1(self):
+        result = resolve(_call("execute", full_name="this.execute"))
+        assert result["confidence"] == _TIER_CONFIDENCE[1]
+
+    def test_super_receiver_resolves_to_caller(self):
+        result = resolve(_call("execute", full_name="super.execute"))
+        assert result["called_file_path"] == CALLER
+        assert result["resolution_tier"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier 2 — local name
+# ---------------------------------------------------------------------------
+
+class TestTier2LocalName:
+
+    def test_local_function_resolves_to_caller(self):
+        result = resolve(_call("helper"), local_names={"helper"})
+        assert result["called_file_path"] == CALLER
+
+    def test_local_function_tier_is_2(self):
+        result = resolve(_call("helper"), local_names={"helper"})
+        assert result["resolution_tier"] == 2
+
+    def test_local_function_confidence(self):
+        result = resolve(_call("helper"), local_names={"helper"})
+        assert result["confidence"] == _TIER_CONFIDENCE[2]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier 3 — inferred_obj_type + FQN key
+# ---------------------------------------------------------------------------
+
+class TestTier3InferredFQN:
+
+    def test_fqn_import_resolves_cross_file(self):
+        """When local_imports has the FQN and imports_map[FQN] has exactly 1 path, use Tier 3."""
+        imports_map = {
+            "BillingService": ["/repo/a/BillingService.java", "/repo/b/BillingService.java"],
+            "com.example.acme.billing.BillingService": ["/repo/a/BillingService.java"],
+        }
+        local_imports = {"BillingService": "com.example.acme.billing.BillingService"}
+        call_dict = _call("processPayment", full_name="billingService.processPayment",
+                          inferred_obj_type="BillingService")
+
+        result = resolve(call_dict, local_imports=local_imports, imports_map=imports_map)
+
+        assert result is not None
+        assert result["called_file_path"] == "/repo/a/BillingService.java"
+        assert result["resolution_tier"] == 3
+        assert result["confidence"] == _TIER_CONFIDENCE[3]
+
+    def test_tier3_over_tier4_when_fqn_resolves(self):
+        """Tier 3 (FQN) must win over Tier 4 (short-name first-match)."""
+        imports_map = {
+            "BillingService": ["/repo/z/BillingService.java"],  # only 1 — would be Tier 4
+            "com.example.acme.billing.BillingService": ["/repo/a/BillingService.java"],
+        }
+        local_imports = {"BillingService": "com.example.acme.billing.BillingService"}
+        call_dict = _call("charge", full_name="bs.charge", inferred_obj_type="BillingService")
+
+        result = resolve(call_dict, local_imports=local_imports, imports_map=imports_map)
+
+        assert result["resolution_tier"] == 3
+        assert result["called_file_path"] == "/repo/a/BillingService.java"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier 4 — inferred_obj_type + short-name fallback
+# ---------------------------------------------------------------------------
+
+class TestTier4InferredShortName:
+
+    def test_short_name_fallback_when_no_fqn_key(self):
+        """When no FQN key exists, fall back to short-name first-match (Tier 4)."""
+        imports_map = {"WorkService": ["/repo/WorkService.java"]}
+        call_dict = _call("doWork", full_name="ws.doWork", inferred_obj_type="WorkService")
+
+        result = resolve(call_dict, imports_map=imports_map)
+
+        assert result["called_file_path"] == "/repo/WorkService.java"
+        assert result["resolution_tier"] == 4
+        assert result["confidence"] == _TIER_CONFIDENCE[4]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier 5 — globally unique short name
+# ---------------------------------------------------------------------------
+
+class TestTier5UniqueShortName:
+
+    def test_unique_name_in_imports_map(self):
+        imports_map = {"parseRequest": ["/repo/RequestParser.java"]}
+        result = resolve(_call("parseRequest"), imports_map=imports_map)
+
+        assert result["called_file_path"] == "/repo/RequestParser.java"
+        assert result["resolution_tier"] == 5
+        assert result["confidence"] == _TIER_CONFIDENCE[5]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier 6 — FQN key from qualified import
+# ---------------------------------------------------------------------------
+
+class TestTier6QualifiedImport:
+
+    def test_fqn_direct_lookup_in_imports_map(self):
+        """When local_imports[name]=FQN and imports_map[FQN] has 1 path → Tier 6."""
+        imports_map = {
+            "AuthService": ["/repo/a/AuthService.java", "/repo/b/AuthService.java"],
+            "com.example.acme.auth.AuthService": ["/repo/a/AuthService.java"],
+        }
+        # no inferred_obj_type — pure Tier 6 path via call-site name lookup
+        local_imports = {"AuthService": "com.example.acme.auth.AuthService"}
+        call_dict = _call("AuthService")  # calling the class as a constructor/factory
+
+        result = resolve(call_dict, local_imports=local_imports, imports_map=imports_map)
+
+        assert result["called_file_path"] == "/repo/a/AuthService.java"
+        assert result["resolution_tier"] == 6
+        assert result["confidence"] == _TIER_CONFIDENCE[6]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier 7 — FQN path-substring match
+# ---------------------------------------------------------------------------
+
+class TestTier7PathSubstring:
+
+    def test_fqn_as_path_substring(self):
+        """When FQN can't resolve directly but matches as a file-path substring → Tier 7."""
+        imports_map = {
+            "AuthService": [
+                "/opt/repos/myapp/acme.auth/src/main/java/com/example/acme/auth/AuthService.java",
+                "/opt/repos/myapp/acme.authv2/src/main/java/com/example/acme/authv2/AuthService.java",
+            ]
+        }
+        local_imports = {"AuthService": "com.example.acme.auth.AuthService"}
+        call_dict = _call("AuthService")
+
+        result = resolve(call_dict, local_imports=local_imports, imports_map=imports_map)
+
+        assert "com/example/acme/auth/AuthService" in result["called_file_path"]
+        assert result["resolution_tier"] == 7
+        assert result["confidence"] == _TIER_CONFIDENCE[7]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier 8 — alphabetical-first of multiple candidates
+# ---------------------------------------------------------------------------
+
+class TestTier8AlphabeticalFirst:
+
+    def test_multiple_candidates_no_import_hint(self):
+        """When multiple paths, no import hint, no obj type → Tier 8 first-match."""
+        imports_map = {
+            "execute": ["/repo/a/ActionA.java", "/repo/b/ActionB.java"],
+        }
+        result = resolve(_call("execute"), imports_map=imports_map)
+
+        assert result["called_file_path"] in ("/repo/a/ActionA.java", "/repo/b/ActionB.java")
+        assert result["resolution_tier"] == 8
+        assert result["confidence"] == _TIER_CONFIDENCE[8]
+
+    def test_tier8_confidence_is_low(self):
+        """Tier 8 is a last-resort guess — confidence must be below 0.5."""
+        assert _TIER_CONFIDENCE[8] < 0.5
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier 9 — same-file fallback
+# ---------------------------------------------------------------------------
+
+class TestTier9SameFileFallback:
+
+    def test_unresolvable_obj_call_falls_back_to_caller(self):
+        """obj.method() with no type info and no imports_map match → same-file fallback."""
+        call_dict = _call("execute", full_name="sequence.execute")
+        result = resolve(call_dict)
+
+        assert result["called_file_path"] == CALLER
+        assert result["resolution_tier"] == 9
+        assert result["confidence"] == _TIER_CONFIDENCE[9]
+
+    def test_tier9_confidence_is_very_low(self):
+        """Tier 9 is definitionally wrong for obj.method() — confidence must be < 0.2."""
+        assert _TIER_CONFIDENCE[9] < 0.2
+
+    def test_skip_external_suppresses_tier9(self):
+        """When skip_external=True, unresolvable obj.method() calls must return None."""
+        call_dict = _call("execute", full_name="sequence.execute")
+        result = resolve(call_dict, skip_external=True)
+        assert result is None
+
+    def test_skip_external_does_not_suppress_tier1(self):
+        """self.method() is not external — skip_external must not suppress it."""
+        call_dict = _call("execute", full_name="this.execute")
+        result = resolve(call_dict, skip_external=True)
+        assert result is not None
+
+    def test_skip_external_does_not_suppress_tier2(self):
+        """Local name resolution is not external — skip_external must not suppress it."""
+        result = resolve(_call("helper"), local_names={"helper"}, skip_external=True)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: tier ordering (lower tier = higher confidence only where monotonic)
+# ---------------------------------------------------------------------------
+
+class TestTierConfidenceOrdering:
+
+    def test_tier1_highest_confidence(self):
+        """Tier 1 (certain) must have the highest confidence of all tiers."""
+        max_conf = max(v for k, v in _TIER_CONFIDENCE.items() if k != 1)
+        assert _TIER_CONFIDENCE[1] > max_conf
+
+    def test_tier9_lowest_confidence(self):
+        """Tier 9 (same-file fallback) must have the lowest confidence."""
+        min_other = min(v for k, v in _TIER_CONFIDENCE.items() if k != 9)
+        assert _TIER_CONFIDENCE[9] < min_other
+
+    def test_all_confidences_in_range(self):
+        """All confidence values must be in [0.0, 1.0]."""
+        for tier, conf in _TIER_CONFIDENCE.items():
+            assert 0.0 <= conf <= 1.0, f"Tier {tier} confidence {conf} out of range"

--- a/tests/unit/tools/test_embeddings_and_vector_resolver.py
+++ b/tests/unit/tools/test_embeddings_and_vector_resolver.py
@@ -1,0 +1,328 @@
+"""
+Unit tests for Phase 4 — EmbeddingPipeline and VectorResolver.
+
+Uses only mocked Neo4j driver and embedder to stay unit-test fast (no network,
+no real DB, no GPU).  Tests verify the fetch/embed/write pipeline logic and the
+ANN resolver's candidate selection behaviour.
+"""
+
+import pytest
+from unittest.mock import MagicMock, call, patch
+
+
+# ---------------------------------------------------------------------------
+# Minimal Neo4j stubs (consistent pattern with test_graph_builder_perf_fixes.py)
+# ---------------------------------------------------------------------------
+
+class _FakeRow(dict):
+    """dict that also supports attribute access like a Record."""
+    def __getattr__(self, item):
+        try:
+            return self[item]
+        except KeyError:
+            raise AttributeError(item)
+
+
+class _FakeResult:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    def single(self):
+        return _FakeRow(self._rows[0]) if self._rows else None
+
+    def __iter__(self):
+        return iter(_FakeRow(r) for r in self._rows)
+
+
+class _RecordingSession:
+    def __init__(self, responses=None):
+        self.calls = []
+        self._responses = list(responses or [])
+        self._idx = 0
+
+    def run(self, query, **kwargs):
+        self.calls.append({"query": query, "kwargs": kwargs})
+        result = self._responses[self._idx] if self._idx < len(self._responses) else _FakeResult()
+        self._idx += 1
+        return result
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeDriver:
+    def __init__(self, session):
+        self._session = session
+
+    def session(self):
+        return self._session
+
+
+# ---------------------------------------------------------------------------
+# Tests: EmbeddingPipeline
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingPipeline:
+
+    def _make_pipeline(self, session):
+        from codegraphcontext.tools.indexing.embeddings import EmbeddingPipeline
+        driver = _FakeDriver(session)
+        return EmbeddingPipeline(driver, batch_size=2)
+
+    def test_run_does_nothing_when_no_unembedded_nodes(self):
+        """If the fetch query returns no rows, no embed or write calls should occur."""
+        session = _RecordingSession(responses=[
+            _FakeResult([]),  # ensure_vector_index
+            _FakeResult([]),  # fetch_unembedded → empty
+        ])
+        pipeline = self._make_pipeline(session)
+
+        mock_embedder = MagicMock()
+        mock_embedder.dim = 384
+
+        with patch("codegraphcontext.tools.indexing.embeddings._get_embedder", return_value=mock_embedder):
+            pipeline.run("/opt/repos/myapp")
+
+        mock_embedder.embed_batch.assert_not_called()
+
+    def test_run_calls_embed_batch_for_each_batch(self):
+        """With 3 nodes and batch_size=2, embed_batch must be called twice."""
+        nodes = [
+            {"path": "/a.java", "name": "execute", "line_number": 1,
+             "qualified_name": "com.example.billing.BillingService.execute",
+             "docstring": None, "parameters": []},
+            {"path": "/b.java", "name": "process", "line_number": 5,
+             "qualified_name": None, "docstring": "processes order", "parameters": ["orderId"]},
+            {"path": "/c.java", "name": "validate", "line_number": 10,
+             "qualified_name": "com.example.auth.Authenticator.validate",
+             "docstring": None, "parameters": ["token"]},
+        ]
+        session = _RecordingSession(responses=[
+            _FakeResult([]),  # ensure_vector_index
+            _FakeResult(nodes),  # fetch_unembedded
+            _FakeResult([]),  # write batch 1
+            _FakeResult([]),  # write batch 2
+        ])
+        pipeline = self._make_pipeline(session)  # batch_size=2
+
+        mock_embedder = MagicMock()
+        mock_embedder.dim = 384
+        mock_embedder.embed_batch.return_value = [[0.1] * 384, [0.2] * 384]
+
+        with patch("codegraphcontext.tools.indexing.embeddings._get_embedder", return_value=mock_embedder):
+            pipeline.run("/opt/repos/myapp")
+
+        assert mock_embedder.embed_batch.call_count == 2
+
+    def test_run_writes_embeddings_back_to_neo4j(self):
+        """Each Write call must include an UNWIND query that sets f.embedding."""
+        nodes = [
+            {"path": "/a.java", "name": "execute", "line_number": 1,
+             "qualified_name": None, "docstring": None, "parameters": []},
+        ]
+        session = _RecordingSession(responses=[
+            _FakeResult([]),   # ensure_vector_index
+            _FakeResult(nodes),
+            _FakeResult([]),   # write
+        ])
+        pipeline = self._make_pipeline(session)
+
+        mock_embedder = MagicMock()
+        mock_embedder.dim = 384
+        mock_embedder.embed_batch.return_value = [[0.5] * 384]
+
+        with patch("codegraphcontext.tools.indexing.embeddings._get_embedder", return_value=mock_embedder):
+            pipeline.run("/opt/repos/myapp")
+
+        write_queries = [c["query"] for c in session.calls if "embedding" in c["query"].lower()]
+        assert write_queries, "Expected at least one query that sets f.embedding"
+        assert any("UNWIND" in q for q in write_queries), "Write must use UNWIND for batching"
+
+    def test_vector_index_creation_is_first_call(self):
+        """Vector index DDL must be issued before any embed or write calls."""
+        nodes = [
+            {"path": "/a.java", "name": "fn", "line_number": 1,
+             "qualified_name": None, "docstring": None, "parameters": []},
+        ]
+        session = _RecordingSession(responses=[
+            _FakeResult([]),   # ensure_vector_index
+            _FakeResult(nodes),
+            _FakeResult([]),
+        ])
+        pipeline = self._make_pipeline(session)
+
+        mock_embedder = MagicMock()
+        mock_embedder.dim = 384
+        mock_embedder.embed_batch.return_value = [[0.1] * 384]
+
+        with patch("codegraphcontext.tools.indexing.embeddings._get_embedder", return_value=mock_embedder):
+            pipeline.run("/opt/repos/myapp")
+
+        first_query = session.calls[0]["query"]
+        assert "INDEX" in first_query.upper() or "VECTOR" in first_query.upper(), (
+            "First DB call must create the vector index; got: " + first_query[:80]
+        )
+
+    def test_embed_batch_failure_skips_batch_but_continues(self):
+        """An embedder failure on one batch must not crash the pipeline."""
+        nodes = [
+            {"path": "/a.java", "name": "fn1", "line_number": 1,
+             "qualified_name": None, "docstring": None, "parameters": []},
+            {"path": "/b.java", "name": "fn2", "line_number": 2,
+             "qualified_name": None, "docstring": None, "parameters": []},
+            {"path": "/c.java", "name": "fn3", "line_number": 3,
+             "qualified_name": None, "docstring": None, "parameters": []},
+        ]
+        session = _RecordingSession(responses=[
+            _FakeResult([]),    # ensure_vector_index
+            _FakeResult(nodes),
+            _FakeResult([]),    # write for successful batch
+        ])
+        pipeline = self._make_pipeline(session)  # batch_size=2
+
+        mock_embedder = MagicMock()
+        mock_embedder.dim = 384
+        # First batch fails, second succeeds
+        mock_embedder.embed_batch.side_effect = [RuntimeError("API error"), [[0.1] * 384]]
+
+        with patch("codegraphcontext.tools.indexing.embeddings._get_embedder", return_value=mock_embedder):
+            # Must not raise
+            pipeline.run("/opt/repos/myapp")
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_text
+# ---------------------------------------------------------------------------
+
+class TestBuildText:
+
+    def test_includes_qualified_name_when_present(self):
+        from codegraphcontext.tools.indexing.embeddings import _build_text
+        fn = {"name": "execute", "qualified_name": "com.example.acme.BillingService.execute"}
+        text = _build_text(fn)
+        assert "com.example.acme.BillingService.execute" in text
+
+    def test_falls_back_to_name_without_qualified_name(self):
+        from codegraphcontext.tools.indexing.embeddings import _build_text
+        fn = {"name": "doWork"}
+        text = _build_text(fn)
+        assert "doWork" in text
+
+    def test_includes_docstring_when_present(self):
+        from codegraphcontext.tools.indexing.embeddings import _build_text
+        fn = {"name": "process", "docstring": "Processes the incoming payment request."}
+        text = _build_text(fn)
+        assert "Processes the incoming payment request." in text
+
+    def test_includes_parameters(self):
+        from codegraphcontext.tools.indexing.embeddings import _build_text
+        fn = {"name": "find", "parameters": ["orderId", "userId"]}
+        text = _build_text(fn)
+        assert "orderId" in text
+        assert "userId" in text
+
+    def test_empty_function_node_does_not_crash(self):
+        from codegraphcontext.tools.indexing.embeddings import _build_text
+        text = _build_text({})
+        assert isinstance(text, str)
+
+
+# ---------------------------------------------------------------------------
+# Tests: VectorResolver
+# ---------------------------------------------------------------------------
+
+class TestVectorResolver:
+
+    def _make_resolver(self, session, threshold=0.75):
+        from codegraphcontext.tools.indexing.vector_resolver import VectorResolver
+        driver = _FakeDriver(session)
+        resolver = VectorResolver(driver, threshold=threshold)
+        return resolver
+
+    def _patch_embedder(self, resolver, vec=None):
+        """Inject a mock embedder that returns a fixed vector."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed_batch.return_value = [vec or ([0.1] * 384)]
+        resolver._embedder = mock_embedder
+
+    def test_returns_none_when_no_candidates(self):
+        session = _RecordingSession()
+        resolver = self._make_resolver(session)
+        self._patch_embedder(resolver)
+
+        result = resolver.resolve("execute", None, [], "/opt/repos/myapp")
+        assert result is None
+
+    def test_returns_path_above_threshold(self):
+        session = _RecordingSession(responses=[
+            _FakeResult([{"path": "/repo/BillingService.java", "score": 0.92}])
+        ])
+        resolver = self._make_resolver(session, threshold=0.75)
+        self._patch_embedder(resolver)
+
+        result = resolver.resolve(
+            "execute",
+            "com.example.acme.billing.BillingService.handle",
+            ["/repo/BillingService.java"],
+            "/opt/repos/myapp",
+        )
+        assert result == "/repo/BillingService.java"
+
+    def test_returns_none_below_threshold(self):
+        session = _RecordingSession(responses=[
+            _FakeResult([{"path": "/repo/GenericAction.java", "score": 0.50}])
+        ])
+        resolver = self._make_resolver(session, threshold=0.75)
+        self._patch_embedder(resolver)
+
+        result = resolver.resolve("execute", None, ["/repo/GenericAction.java"], "/opt/repos/myapp")
+        assert result is None
+
+    def test_returns_none_on_embedder_failure(self):
+        session = _RecordingSession()
+        resolver = self._make_resolver(session)
+        mock_embedder = MagicMock()
+        mock_embedder.embed_batch.side_effect = RuntimeError("network error")
+        resolver._embedder = mock_embedder
+
+        result = resolver.resolve("execute", None, ["/repo/A.java"], "/opt/repos/myapp")
+        assert result is None
+
+    def test_returns_none_on_db_failure(self):
+        session = _RecordingSession(responses=[_FakeResult([])])
+        session.run = MagicMock(side_effect=RuntimeError("connection refused"))
+        resolver = self._make_resolver(session)
+        self._patch_embedder(resolver)
+
+        result = resolver.resolve("execute", None, ["/repo/A.java"], "/opt/repos/myapp")
+        assert result is None
+
+    def test_resolve_bulk_maps_indices_to_paths(self):
+        """resolve_bulk must return a dict mapping call index → resolved path."""
+        session = _RecordingSession(responses=[
+            _FakeResult([{"path": "/repo/A.java", "score": 0.95}]),
+            _FakeResult([]),  # second call finds no match above threshold
+        ])
+        resolver = self._make_resolver(session, threshold=0.75)
+        self._patch_embedder(resolver)
+
+        calls = [
+            {"called_name": "execute", "candidate_paths": ["/repo/A.java"], "caller_qualified_name": None},
+            {"called_name": "validate", "candidate_paths": ["/repo/B.java"], "caller_qualified_name": None},
+        ]
+        result = resolver.resolve_bulk(calls, "/opt/repos/myapp")
+
+        assert 0 in result
+        assert result[0] == "/repo/A.java"
+        assert 1 not in result  # below threshold
+
+    def test_resolve_bulk_empty_input(self):
+        session = _RecordingSession()
+        resolver = self._make_resolver(session)
+        self._patch_embedder(resolver)
+
+        result = resolver.resolve_bulk([], "/opt/repos/myapp")
+        assert result == {}


### PR DESCRIPTION
## Summary

Closes #884, #885, #887, #888, #889, #847

This PR ships Phases 1–5 of the CGC Java enrichment roadmap, validated against two large enterprise Java codebases (Codebase A: 55K functions, Codebase B: 285K functions).

All changes are **non-breaking and additive** — new properties/edges on fresh index, zero behaviour change for existing users who don't re-index.

---

## Phase 1 — Java parser enrichment (#884, #885)

### `Function.package_name` (#884)
- `java.py`: propagates file-level `package_name` onto every `func_data` dict
- Result: 92% of functions now carry `package_name` (50,813/55,195 on Codebase A; 261,900/284,571 on Codebase B)
- Enables namespace-scoped Cypher queries without fragile path-string matching

### `CALLS.confidence_label` + `INHERITS.confidence_label` (#885)
- Every CALLS edge now carries `confidence_label`: EXTRACTED / INFERRED / AMBIGUOUS
- Agents can filter to high-confidence paths: `WHERE r.confidence_label = 'EXTRACTED'`
- Codebase A: 123K EXTRACTED, 58K INFERRED, 5K AMBIGUOUS out of 194K total
- Codebase B: 659K EXTRACTED, 247K INFERRED, 59K AMBIGUOUS out of 966K total

### `Function.http_method` / `http_path` empty-string fix
- `writer.py` batch normalization: absent string properties are now stored as `null` (absent) not `""`
- Was: 264 functions had `http_method = ""`. Now: 0
- Only functions with an actual HTTP annotation carry the property

---

## Phase 2 — Spring semantic graph (#887, #888)

### INJECTS edges (#887)
- `java.py`: scans `@Autowired`/`@Inject` fields and creates INJECTS edges (injector Class → injected Class)
- `writer.write_spring_inject_links()`: batch MERGE in writer
- Codebase A: 2,017 INJECTS edges. Codebase B: 2,931 INJECTS edges

### Spring stereotypes (#887)
- `Class.spring_stereotype`: CONTROLLER, REST_CONTROLLER, SERVICE, COMPONENT, CONFIGURATION, CONTROLLER_ADVICE
- Codebase A: 326 CONTROLLER, 34 REST_CONTROLLER, 19 SERVICE, 17 CONFIGURATION, 15 COMPONENT

### Maven build graph (#888)
- `maven.py`: parses `pom.xml` — emits `MavenModule` nodes + `MODULE_DEPENDS_ON` edges (incl. transitive)
- `gradle.py`: same for `build.gradle` → `GradleModule` nodes
- Codebase A: 49 modules, 226 dependency edges. Codebase B: 550 modules
- `writer.write_maven_graph()`: batch MERGE for module graph

---

## Phase 3 — ORM / datasource linkage (#843 scoped)

### MyBatis XML mapper parser
- `mybatis.py`: walks `*Mapper.xml` files, emits READS/WRITES edges (Function → DbTable)
- `<insert>`/`<update>`/`<delete>` → WRITES; `<select>` → READS
- Table names extracted from SQL text; fallback = snake_case of mapper class name
- `writer.write_mybatis_links()`: wired into pipeline after ORM annotation scan

### Datasource ingesters
- `datasources/mysql_ingester.py`: scans MySQL schema → DbTable/DbColumn nodes
- `datasources/cassandra_ingester.py`: scans Cassandra keyspaces → DbTable nodes
- `datasources/redis_ingester.py`: scans Redis key patterns → RedisKeyPattern nodes

---

## Phase 4 — Vector embeddings (#847)
- `ENABLE_VECTOR_RESOLVE=true`: generates sentence-transformer embeddings for Function nodes
- Stored as `Function.embedding` (Neo4j vector index)
- FalkorDB/KuzuDB: gracefully skipped with warning (no crash)

---

## Phase 5 — Inheritance-aware re-resolution (#847)
- Post-index phase: re-resolves AMBIGUOUS CALLS edges via `INHERITS` graph
- Converts abstract→concrete method dispatch to CALLS with `confidence_label = 'EXTRACTED'`
- Codebase A: 203 inheritance-resolved edges. Dramatically reduces residual ambiguity in deep hierarchies

---

## Tooling (#889)

### `cgc report` command (#884)
- `report_generator.py`: architectural summary — god nodes, complexity hotspots, Spring endpoints, Maven graph, dead code candidates
- `analysis_handlers.py`: new MCP handlers for report + enriched queries

### `JavaToolkit` + `find_java_endpoints` MCP tool (#889)
- `java_toolkit.py`: enhanced query tools for Spring/Maven/ORM graph traversal
- Exposed via MCP in `tool_definitions.py` + `server.py`

---

## Validation — Codebase A (55K functions, 493s index)

| Metric | Before | After |
|---|---|---|
| `Function.package_name` | 0 | **50,813** |
| `Function.http_method = ""` | 264 | **0** |
| CALLS with `confidence_label` | 0 | **194,333** |
| `INJECTS` edges | 0 | **2,017** |
| `MavenModule` nodes | 0 | **49** |
| HTTP endpoints | 0 | **359** |

## Validation — Codebase B (285K functions, 3,761s index)

| Metric | Count |
|---|---|
| Functions with `package_name` | 261,900 / 284,571 (92%) |
| CALLS EXTRACTED | 658,639 |
| CALLS INFERRED | 246,575 |
| CALLS AMBIGUOUS | 59,401 |
| `INJECTS` edges | 2,931 |
| `MavenModule` nodes | 550 |
| HTTP endpoints | 336 |
| `WRITES` edges | 2 (Cassandra `@Query DELETE`) |

---

## Tests

158 unit tests passing. 61 new parser tests added (`test_java_parser.py`). 1 pre-existing unrelated failure (`test_readme_exists`).

```
python -m pytest tests/unit/ -q
# 158 passed, 1 failed (pre-existing), 2 skipped in 124.93s
```

---

## Breaking changes

None. All new properties and edge types are additive. Existing queries are unaffected. A re-index is required to see new properties on existing graphs.

The one behavior change (`null` instead of `""` for absent string properties) fixes incorrect data — no valid query would check `WHERE fn.http_method = ""`.

---

## Phase 6 — Spring Data repository READS/WRITES (this commit)

### `write_spring_data_repo_links` (#843)
- `java.py`: detects interfaces extending `JpaRepository`, `CrudRepository`, `MongoRepository` etc.
- Extracts entity class from generic parameter: `JpaRepository<UserAuth, Long>` → `UserAuth`
- `_parse_classes`: now also parses `extends_interfaces` on `interface_declaration` nodes (tree-sitter uses `type_list` child, not `superclass`) — fixes INHERITS edges for interfaces too
- Emits `spring_data_method` records for each `findBy*`/`deleteBy*`/`save*` method
- `writer.write_spring_data_repo_links()`: two-hop Cypher — matches Function → entity Class via MAPS_TO → DbTable
- No table name required at parse time; resolved at write time from existing MAPS_TO graph
- Pipeline: wired after `write_query_links`
- 5 new unit tests — 264 total passing

**Before**: JPA `@Entity` classes had MAPS_TO edges but zero READS/WRITES from repo methods  
**After**: `UserAuthenticationRepository.findByUserId()` → READS → `USER_ACCOUNT_AUTH` (via UserAuthenticationDB → MAPS_TO)

---

## Out of scope (tracked separately)
- #886: Git hook integration (`cgc hook install/uninstall`)
- FalkorDB/KuzuDB vector index support
- Cross-repo embedding similarity