### PR TITLE
fix(viz): restrict CORS to localhost on visualization server (CWE-942)

### DIFF
--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -14,11 +14,15 @@ from ..utils.debug_log import debug_log
 
 app = FastAPI()
 
-# Enable CORS for development
+# CORS: only allow requests from the local visualization frontend.
+# The server binds to 127.0.0.1 (localhost) so only local origins are legitimate.
+_ALLOWED_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
+    allow_origins=[],
+    allow_origin_regex=_ALLOWED_ORIGIN_REGEX,
+    allow_methods=["GET"],
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
## Summary

The visualization server in `src/codegraphcontext/viz/server.py` configures FastAPI's `CORSMiddleware` with `allow_origins=["*"]` and `allow_methods=["*"]`. Because the server binds to `127.0.0.1` and exposes endpoints that read from the local code graph database (`/api/graph`, which accepts arbitrary Cypher via the `cypher_query` parameter) and serves local files, the wildcard CORS policy lets any website the developer visits make cross-origin requests to the server and read the responses.

This is the classic "localhost CORS" issue (CWE-942: Permissive Cross-domain Policy with Untrusted Domains).

## Vulnerability details

- **File:** `src/codegraphcontext/viz/server.py`
- **CWE:** [CWE-942 — Permissive Cross-domain Policy with Untrusted Domains](https://cwe.mitre.org/data/definitions/942.html)
- **Affected configuration:**
  ```python
  app.add_middleware(
      CORSMiddleware,
      allow_origins=["*"],
      allow_methods=["*"],
      allow_headers=["*"],
  )
  ```
- **Data flow:** Attacker-controlled web page → browser issues cross-origin `fetch()` to `http://127.0.0.1:8000/api/graph?cypher_query=...` → server responds with `Access-Control-Allow-Origin: *` → attacker's JavaScript reads the response body, exfiltrating graph contents or the result of arbitrary Cypher queries against the developer's local Neo4j/Kuzu/FalkorDB instance.

Preconditions for exploitation:
1. A developer has the visualization server running locally (`cgc` viz / `uvicorn` on `127.0.0.1:8000`).
2. That developer visits any attacker-controlled page in the same browser session.

Both are realistic — the viz server is a normal developer workflow, and casual web browsing is an everyday activity.

## Fix

Replace the wildcard origin with an `allow_origin_regex` that only matches `http(s)://localhost` or `http(s)://127.0.0.1` (with an optional port), and restrict allowed methods to `GET` (which is what the current API actually uses):

```python
_ALLOWED_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"

app.add_middleware(
    CORSMiddleware,
    allow_origins=[],
    allow_origin_regex=_ALLOWED_ORIGIN_REGEX,
    allow_methods=["GET"],
    allow_headers=["*"],
)
```

This is a minimal, single-file change (7 insertions, 3 deletions). The local visualization frontend continues to work because it is served from `localhost`/`127.0.0.1` and matches the regex. Cross-origin requests from arbitrary external sites no longer receive CORS approval, so browsers will block the response from being read.

DNS-rebinding does not bypass this fix: the browser sends the original page's `Origin` header (e.g. `https://evil.com`), which does not match the regex, so the server omits the `Access-Control-Allow-Origin` header and the browser blocks the read.

## Testing

- Started the server locally and verified the visualization frontend (served from `127.0.0.1`) still loads graph data normally — `Access-Control-Allow-Origin` is correctly echoed back as the matching localhost origin.
- Issued a cross-origin request with `Origin: https://evil.example`: the response no longer includes `Access-Control-Allow-Origin`, so the browser blocks the response body from being read.
- Confirmed there is no other CORS configuration elsewhere in the codebase that would override this; the viz server is only launched via `cli_helpers` with host `127.0.0.1`.

## Adversarial review

Before submitting, we tried to disprove this finding. We checked whether the server was bound to a non-routable interface that browsers would refuse to reach (it isn't — browsers happily make cross-origin requests to `127.0.0.1`), whether any framework-level protection like CSRF tokens or `SameSite` cookies would block exploitation (the endpoints don't use cookies, they're authenticated only by network reachability, so `SameSite` doesn't help), and whether the endpoints only return non-sensitive data (they don't — `/api/graph` accepts arbitrary Cypher and returns the developer's indexed code graph). None of these mitigations exist, so the wildcard CORS policy is genuinely exploitable on a developer's machine.

cc @lewiswigmore
