### PR TITLE
fix(viz): reject write Cypher on /api/graph (CWE-943)

### DIFF
--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -3,6 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, FileResponse
 from pathlib import Path
+import re
 import uvicorn
 import json
 import os
@@ -30,6 +31,23 @@ _static_dir: Optional[str] = None
 def set_db_manager(manager: DatabaseManager):
     global db_manager
     db_manager = manager
+
+# Forbidden Cypher write keywords. Mirrors src/codegraphcontext/tools/handlers/query_handlers.py
+# so that the visualization HTTP endpoint enforces the same read-only contract as the
+# MCP tool. Without this, any caller able to reach the viz server (which by default
+# enables permissive CORS) could execute arbitrary write Cypher (CWE-943).
+_FORBIDDEN_CYPHER_KEYWORDS = (
+    'CREATE', 'MERGE', 'DELETE', 'SET', 'REMOVE', 'DROP', 'CALL apoc'
+)
+_STRING_LITERAL_RE = re.compile(r'''"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'''')
+
+def _is_read_only_cypher(query: str) -> bool:
+    """Return True if *query* contains no write keywords (outside string literals)."""
+    stripped = _STRING_LITERAL_RE.sub('', query)
+    for keyword in _FORBIDDEN_CYPHER_KEYWORDS:
+        if re.search(r'\b' + keyword + r'\b', stripped, re.IGNORECASE):
+            return False
+    return True
 
 @app.get("/api/graph")
 async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str] = None):
@@ -76,6 +94,15 @@ async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str]
 
         with db_manager.get_driver().session() as session:
             if cypher_query:
+                if not _is_read_only_cypher(cypher_query):
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            "This endpoint only supports read-only Cypher queries. "
+                            "Prohibited keywords like CREATE, MERGE, DELETE, SET, REMOVE, "
+                            "DROP, or CALL apoc are not allowed."
+                        ),
+                    )
                 print(f"DEBUG: Executing custom query: {cypher_query}", flush=True)
                 result = session.run(cypher_query)
             elif repo_path:
@@ -238,6 +265,9 @@ async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str]
         print(f"API SUCCESS: Returning graph with {len(response_data['nodes'])} nodes and {len(response_data['links'])} links.", file=sys.stderr, flush=True)
         return response_data
 
+    except HTTPException:
+        # Preserve intentional HTTP errors (e.g. 400 for forbidden write queries).
+        raise
     except Exception as e:
         debug_log(f"Error fetching graph: {str(e)}")
         import traceback


### PR DESCRIPTION
## Summary

The visualization server's `GET /api/graph` endpoint accepted an arbitrary `cypher_query` parameter and passed it directly to `session.run()` with no validation. The MCP `execute_cypher_query` tool already enforces a read-only contract via a forbidden-keyword check, but the HTTP endpoint did not. This PR closes that gap by mirroring the same blocklist on the viz endpoint.

- **CWE:** CWE-943 (Improper Neutralization of Special Elements in Data Query Logic)
- **File:** `src/codegraphcontext/viz/server.py` — `get_graph()` (`/api/graph`)
- **Existing reference for the same contract:** `src/codegraphcontext/tools/handlers/query_handlers.py`

## Data flow

1. Client → `GET /api/graph?cypher_query=...` (FastAPI route on the viz server).
2. `cypher_query` flows unmodified into `session.run(cypher_query)` against the Neo4j driver.
3. Because the viz server installs `CORSMiddleware(allow_origins=["*"])` and binds to `127.0.0.1:8000` by default, any web page a developer visits in the same browser can issue cross-origin requests to the local server and execute arbitrary Cypher — including writes (`CREATE`, `MERGE`, `DELETE`, `SET`, `REMOVE`, `DROP`, `CALL apoc.*`) that can corrupt or destroy the indexed graph.

The MCP path for the same database already has a keyword blocklist precisely to prevent this; the HTTP endpoint was simply missing the equivalent guard.

## Fix

Add a small `_is_read_only_cypher()` helper in `viz/server.py` that:

- Strips string literals (so a `"CREATE"` substring inside a literal doesn't trigger a false positive),
- Then matches the same forbidden write keywords used by the MCP handler with a word-boundary regex,
- And returns HTTP 400 with a clear message before the query reaches the driver.

The constants and matching strategy intentionally mirror `query_handlers.py` so the two enforcement points stay in sync.

Diff is +30 lines, one file:

```text
src/codegraphcontext/viz/server.py | 30 ++++++++++++++++++++++++++++++
```

A `try/except HTTPException: raise` guard is added so the existing broad `except Exception` doesn't swallow the 400 and turn it into a 500.

## Testing

- Confirmed before the patch: `curl 'http://127.0.0.1:8000/api/graph?cypher_query=CREATE%20(n:Pwn)%20RETURN%20n'` writes a node to Neo4j.
- After the patch: the same request returns HTTP 400 with the read-only message and never reaches the driver.
- Verified read queries are unaffected: `MATCH (n) RETURN n LIMIT 5` still returns results normally.
- String-literal handling sanity-checked with `MATCH (n) WHERE n.name = "CREATE" RETURN n` — accepted (the keyword is inside a literal and stripped before matching), matching the behavior of the existing MCP handler.

## Why this is exploitable in practice

The preconditions are realistic for the project's normal usage:

- A developer is running `cgc` with the visualizer up (`127.0.0.1:8000`, the default).
- The developer browses the web in the same browser session.
- A page they visit issues `fetch('http://127.0.0.1:8000/api/graph?cypher_query=...')`. Because of the `allow_origins=["*"]` CORS policy, the browser permits the cross-origin request and the attacker's JS can submit any Cypher — including destructive writes — and observe the response.

The fix removes the most damaging class of impact (writes) by applying the same contract the MCP path already enforces.

## Scope and follow-ups (not in this PR)

To keep the change minimal and reviewable, this PR only adds the keyword blocklist. A few related hardening steps are worth tracking separately:

- The `allow_origins=["*"]` CORS policy on a server bound to localhost is itself the root enabler of drive-by exploitation and should be tightened.
- Read-only Cypher still allows arbitrary `MATCH` queries, so an attacker meeting the same preconditions could exfiltrate graph contents. Running viz queries via `session.execute_read(...)` would enforce read-only at the driver level and is a stronger long-term fix than keyword matching.
- The keyword blocklist is shared with the MCP handler by convention; lifting `_FORBIDDEN_CYPHER_KEYWORDS` and `_is_read_only_cypher` into a shared module would prevent drift.

## Adversarial review

Before submitting, we tried to disprove this. We checked whether existing mitigations would prevent exploitation: there is no auth on `/api/graph`, no Origin/Referer check, no CSRF token, the CORS policy is wildcard, and the parallel MCP handler's blocklist is not applied here — so a malicious page in the developer's browser really can reach the endpoint and execute write Cypher. We also considered whether the finding was redundant with some other mitigation (e.g. Neo4j auth or a read-only DB user); the project's default deployment uses a writable user and no network-level restriction, so it isn't.

cc @lewiswigmore
