### PR TITLE
feat(kotlin): improve Kotlin/JVM callgraph precision and overload resolution

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -2,10 +2,12 @@ import asyncio
 import json
 import uuid
 import urllib.parse
+from collections import Counter
 from pathlib import Path
 import time
 import os
 from typing import Optional, List, Dict, Any
+import typer
 from rich.console import Console
 from rich.table import Table
 from rich.progress import (
@@ -29,6 +31,31 @@ from ..utils.repo_path import any_repo_matches_path
 from .config_manager import resolve_context, ResolvedContext, register_repo_in_context, ensure_first_run_bootstrap
 
 console = Console()
+
+
+def _print_call_resolution_diagnostics(graph_builder: GraphBuilder, limit: int = 5) -> None:
+    diagnostics = getattr(graph_builder, "last_call_resolution_diagnostics", [])
+    if not diagnostics:
+        return
+
+    reason_counts = Counter(d.get("reason", "unknown") for d in diagnostics)
+    summary = ", ".join(
+        f"{reason}={count}" for reason, count in reason_counts.most_common()
+    )
+    console.print(
+        f"[yellow]Skipped {len(diagnostics)} unresolved call relationship(s): {summary}[/yellow]"
+    )
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Call", style="cyan", overflow="fold")
+    table.add_column("Reason", style="yellow")
+    table.add_column("Location", style="dim", overflow="fold")
+    for diagnostic in diagnostics[:limit]:
+        table.add_row(
+            str(diagnostic.get("full_call_name") or ""),
+            str(diagnostic.get("reason") or ""),
+            f"{diagnostic.get('caller_file_path')}:{diagnostic.get('line_number')}",
+        )
+    console.print(table)
 
 
 def _initialize_services(cli_context_flag: Optional[str] = None) -> tuple[Any, Any, Any, ResolvedContext]:
@@ -243,6 +270,7 @@ def index_helper(path: str, context: Optional[str] = None):
         asyncio.run(_run_index_with_progress(graph_builder, path_obj, is_dependency=False, cgcignore_path=ctx.cgcignore_path))
         time_end = time.time()
         elapsed = time_end - time_start
+        _print_call_resolution_diagnostics(graph_builder)
         console.print(f"[green]Successfully finished indexing: {path} in {elapsed:.2f} seconds[/green]")
         
         # Check if auto-watch is enabled
@@ -259,6 +287,7 @@ def index_helper(path: str, context: Optional[str] = None):
             
     except Exception as e:
         console.print(f"[bold red]An error occurred during indexing:[/bold red] {e}")
+        raise typer.Exit(code=1)
     finally:
         db_manager.close_driver()
 
@@ -289,6 +318,7 @@ def add_package_helper(package_name: str, language: str, context: Optional[str] 
 
     try:
         asyncio.run(_run_index_with_progress(graph_builder, package_path, is_dependency=True, cgcignore_path=ctx.cgcignore_path))
+        _print_call_resolution_diagnostics(graph_builder)
         console.print(f"[green]Successfully finished indexing package: {package_name}[/green]")
     except Exception as e:
         console.print(f"[bold red]An error occurred during package indexing:[/bold red] {e}")
@@ -544,9 +574,11 @@ def reindex_helper(path: str, context: Optional[str] = None):
         asyncio.run(_run_index_with_progress(graph_builder, path_obj, is_dependency=False, cgcignore_path=ctx.cgcignore_path))
         time_end = time.time()
         elapsed = time_end - time_start
+        _print_call_resolution_diagnostics(graph_builder)
         console.print(f"[green]Successfully re-indexed: {path} in {elapsed:.2f} seconds[/green]")
     except Exception as e:
         console.print(f"[bold red]An error occurred during re-indexing:[/bold red] {e}")
+        raise typer.Exit(code=1)
     finally:
         db_manager.close_driver()
 

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -586,7 +586,7 @@ def bundle_export(
     services = _initialize_services(context)
     if not all(services[:3]):
         return
-    db_manager, graph_builder, code_finder = services[:3]
+    db_manager, _, code_finder = services[:3]
     
     try:
         output_path = Path(output)
@@ -1975,6 +1975,65 @@ def analyze_chain(
                         args_info = f" [dim]({args_str})[/dim]"
                     
                     console.print(f"{indent}  ⬇ [dim]calls at line {line}[/dim]{args_info}")
+    finally:
+        db_manager.close_driver()
+
+@analyze_app.command("kotlin-call-audit")
+def analyze_kotlin_call_audit(
+    repo_path: Optional[str] = typer.Option(None, "--repo-path", "-r", help="Limit audit to paths under this repository root"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Maximum examples/top names to show"),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+    fail_on_ambiguity: bool = typer.Option(False, "--fail-on-ambiguity", help="Exit non-zero if any ambiguous Kotlin call groups are found"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
+):
+    """
+    Audit Kotlin function call edges for multi-target callsite ambiguity.
+
+    Example:
+        cgc analyze kotlin-call-audit --context elrond-stable --fail-on-ambiguity
+        cgc analyze kotlin-call-audit --json
+    """
+    _load_credentials()
+    services = _initialize_services(context)
+    if not all(services[:3]):
+        return
+    db_manager, _, code_finder = services[:3]
+
+    try:
+        result = code_finder.audit_kotlin_call_ambiguity(repo_path=repo_path, limit=limit)
+        if json_output:
+            console.print_json(json.dumps(result))
+        else:
+            console.print("\n[bold cyan]Kotlin CALLS ambiguity audit[/bold cyan]")
+            summary = Table(show_header=True, header_style="bold magenta", box=box.ROUNDED)
+            summary.add_column("Metric", style="cyan")
+            summary.add_column("Value", style="green")
+            summary.add_row("Kotlin fn→fn CALLS edges", str(result["kotlin_fn_to_fn_edges"]))
+            summary.add_row("Ambiguous groups", str(result["ambiguous_groups"]))
+            summary.add_row("Ambiguous edges", str(result["ambiguous_edges"]))
+            console.print(summary)
+
+            if result["examples"]:
+                examples = Table(show_header=True, header_style="bold magenta", box=box.ROUNDED)
+                examples.add_column("Callsite", style="cyan", overflow="fold")
+                examples.add_column("Call", style="yellow", overflow="fold")
+                examples.add_column("Targets", style="green", overflow="fold")
+                for example in result["examples"]:
+                    targets = "\n".join(
+                        f"{target['context'] or ''}:{target['line_number']} {target['path']}"
+                        for target in example["targets"]
+                    )
+                    examples.add_row(
+                        f"{example.get('caller_name')} {example.get('caller_path')}:{example.get('call_line')}",
+                        str(example.get("full_call_name") or ""),
+                        targets,
+                    )
+                console.print(examples)
+            else:
+                console.print("[green]No ambiguous Kotlin call groups found.[/green]")
+
+        if fail_on_ambiguity and result["ambiguous_groups"]:
+            raise typer.Exit(1)
     finally:
         db_manager.close_driver()
 

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -1199,7 +1199,7 @@ def report(
     """
     _load_credentials()
     output_path = Path(output) if output else Path.cwd() / "CGC_REPORT.md"
-    db_manager, _, _ = _initialize_services(context)
+    db_manager, _, _, _ = _initialize_services(context)
     try:
         from codegraphcontext.tools.report_generator import generate_report
         report_text = generate_report(db_manager, output_path=output_path, include_java=java)

--- a/src/codegraphcontext/core/database_kuzu.py
+++ b/src/codegraphcontext/core/database_kuzu.py
@@ -108,8 +108,8 @@ class KuzuDBManager:
             ("Directory", "path STRING, name STRING, PRIMARY KEY (path)"),
             ("Module", "name STRING, lang STRING, full_import_name STRING, PRIMARY KEY (name)"),
             # For types with composite keys (name, path, line_number), we use a 'uid'
-            ("Function", "uid STRING, name STRING, path STRING, line_number INT64, end_line INT64, source STRING, docstring STRING, lang STRING, cyclomatic_complexity INT64, context STRING, context_type STRING, class_context STRING, is_dependency BOOLEAN, decorators STRING[], args STRING[], http_method STRING, http_path STRING, PRIMARY KEY (uid)"),
-            ("Class", "uid STRING, name STRING, path STRING, line_number INT64, end_line INT64, source STRING, docstring STRING, lang STRING, is_dependency BOOLEAN, decorators STRING[], PRIMARY KEY (uid)"),
+            ("Function", "uid STRING, name STRING, path STRING, line_number INT64, end_line INT64, source STRING, docstring STRING, lang STRING, cyclomatic_complexity INT64, context STRING, context_type STRING, class_context STRING, class_context_line INT64, is_dependency BOOLEAN, decorators STRING[], args STRING[], http_method STRING, http_path STRING, PRIMARY KEY (uid)"),
+            ("Class", "uid STRING, name STRING, path STRING, line_number INT64, end_line INT64, source STRING, docstring STRING, lang STRING, node_type STRING, is_dependency BOOLEAN, decorators STRING[], PRIMARY KEY (uid)"),
             ("Variable", "uid STRING, name STRING, path STRING, line_number INT64, source STRING, docstring STRING, lang STRING, value STRING, context STRING, is_dependency BOOLEAN, PRIMARY KEY (uid)"),
             ("Trait", "uid STRING, name STRING, path STRING, line_number INT64, end_line INT64, source STRING, docstring STRING, lang STRING, is_dependency BOOLEAN, PRIMARY KEY (uid)"),
             ("Interface", "uid STRING, name STRING, path STRING, line_number INT64, end_line INT64, source STRING, docstring STRING, lang STRING, is_dependency BOOLEAN, PRIMARY KEY (uid)"),
@@ -177,6 +177,9 @@ class KuzuDBManager:
             # Spring endpoint properties on Function
             ("Function", "http_method", "STRING"),
             ("Function", "http_path", "STRING"),
+            # Kotlin/JVM precision improvements
+            ("Function", "class_context_line", "INT64"),
+            ("Class", "node_type", "STRING"),
         ]
 
         # REL TABLE GROUP migrations: KuzuDB creates sub-tables named
@@ -470,8 +473,8 @@ class KuzuSessionWrapper:
             'File': {'path', 'name', 'relative_path', 'package_name', 'is_dependency'},
             'Directory': {'path', 'name'},
             'Module': {'name', 'lang', 'full_import_name'},
-            'Function': {'uid', 'name', 'path', 'line_number', 'end_line', 'source', 'docstring', 'lang', 'cyclomatic_complexity', 'context', 'context_type', 'class_context', 'is_dependency', 'decorators', 'args', 'http_method', 'http_path'},
-            'Class': {'uid', 'name', 'path', 'line_number', 'end_line', 'source', 'docstring', 'lang', 'is_dependency', 'decorators'},
+            'Function': {'uid', 'name', 'path', 'line_number', 'end_line', 'source', 'docstring', 'lang', 'cyclomatic_complexity', 'context', 'context_type', 'class_context', 'class_context_line', 'is_dependency', 'decorators', 'args', 'http_method', 'http_path'},
+            'Class': {'uid', 'name', 'path', 'line_number', 'end_line', 'source', 'docstring', 'lang', 'node_type', 'is_dependency', 'decorators'},
             'Variable': {'uid', 'name', 'path', 'line_number', 'source', 'docstring', 'lang', 'value', 'context', 'is_dependency'},
             'Trait': {'uid', 'name', 'path', 'line_number', 'end_line', 'source', 'docstring', 'lang', 'is_dependency'},
             'Interface': {'uid', 'name', 'path', 'line_number', 'end_line', 'source', 'docstring', 'lang', 'is_dependency'},

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -1,5 +1,6 @@
 # src/codegraphcontext/tools/code_finder.py
 import logging
+from collections import Counter
 
 from typing import Any, Dict, List, Literal, Optional
 from pathlib import Path
@@ -38,6 +39,91 @@ def _normalize_identifier(s: str) -> str:
     """
     return s.lower().replace('_', '').replace(' ', '')
 
+
+def summarize_kotlin_call_ambiguity(
+    rows: List[Dict[str, Any]],
+    limit: int = 20,
+) -> Dict[str, Any]:
+    """Summarize multi-target Kotlin function CALLS edges by callsite/name group."""
+    groups: Dict[tuple, Dict[str, Any]] = {}
+    for row in rows:
+        key = (
+            row.get("caller_path"),
+            row.get("caller_line"),
+            row.get("caller_end_line"),
+            row.get("call_line"),
+            row.get("full_call_name"),
+            row.get("target_name"),
+        )
+        target = (
+            row.get("target_path"),
+            row.get("target_line"),
+            row.get("target_context"),
+        )
+        group = groups.setdefault(
+            key,
+            {
+                "caller_name": row.get("caller_name"),
+                "caller_path": row.get("caller_path"),
+                "caller_line": row.get("caller_line"),
+                "caller_end_line": row.get("caller_end_line"),
+                "call_line": row.get("call_line"),
+                "full_call_name": row.get("full_call_name"),
+                "target_name": row.get("target_name"),
+                "args": row.get("args"),
+                "targets": set(),
+            },
+        )
+        group["targets"].add(target)
+
+    ambiguous_groups = [
+        {
+            **{k: v for k, v in group.items() if k != "targets"},
+            "targets": [
+                {
+                    "path": target_path,
+                    "line_number": target_line,
+                    "context": target_context,
+                }
+                for target_path, target_line, target_context in sorted(
+                    group["targets"],
+                    key=lambda target: (
+                        str(target[0] or ""),
+                        target[1] or 0,
+                        str(target[2] or ""),
+                    ),
+                )
+            ],
+            "target_count": len(group["targets"]),
+        }
+        for group in groups.values()
+        if len(group["targets"]) > 1
+    ]
+    ambiguous_groups.sort(
+        key=lambda group: (
+            -group["target_count"],
+            str(group.get("caller_path") or ""),
+            group.get("call_line") or 0,
+            str(group.get("full_call_name") or ""),
+        )
+    )
+    top_names = Counter(
+        group.get("target_name")
+        for group in ambiguous_groups
+        if group.get("target_name")
+    )
+    return {
+        "kotlin_fn_to_fn_edges": len(rows),
+        "ambiguous_groups": len(ambiguous_groups),
+        "ambiguous_edges": sum(group["target_count"] for group in ambiguous_groups),
+        "top_names": [
+            {"name": name, "groups": count}
+            for name, count in top_names.most_common(limit)
+        ],
+        "examples": ambiguous_groups[:limit],
+    }
+
+
 class CodeFinder:
     """Module for finding relevant code snippets and analyzing relationships."""
 
@@ -45,6 +131,35 @@ class CodeFinder:
         self.db_manager = db_manager
         self.driver = self.db_manager.get_driver()
         self._lacks_native_fulltext = getattr(db_manager, 'get_backend_type', lambda: 'neo4j')() != 'neo4j'
+
+    def audit_kotlin_call_ambiguity(
+        self,
+        repo_path: Optional[str] = None,
+        limit: int = 20,
+    ) -> Dict[str, Any]:
+        """Audit Kotlin function-to-function CALLS edges for multi-target callsites."""
+        repo_path = str(Path(repo_path).resolve()) if repo_path else None
+        repo_filter = "AND a.path STARTS WITH $repo_path" if repo_path else ""
+        query = f"""
+            MATCH (a:Function)-[r:CALLS]->(b:Function)
+            WHERE a.path ENDS WITH '.kt'
+              AND b.path ENDS WITH '.kt'
+              {repo_filter}
+            RETURN a.name as caller_name,
+                   a.path as caller_path,
+                   a.line_number as caller_line,
+                   a.end_line as caller_end_line,
+                   r.line_number as call_line,
+                   r.full_call_name as full_call_name,
+                   b.name as target_name,
+                   b.path as target_path,
+                   b.line_number as target_line,
+                   b.context as target_context,
+                   r.args as args
+        """
+        with self.driver.session() as session:
+            rows = session.run(query, repo_path=repo_path).data()
+        return summarize_kotlin_call_ambiguity(rows, limit=limit)
 
     def format_query(self, find_by: Literal["Class", "Function"], fuzzy_search:bool, repo_path: Optional[str] = None) -> str:
         """Format the search query based on the search type and fuzzy search settings."""
@@ -712,38 +827,63 @@ class CodeFinder:
     def find_all_callers(self, function_name: str, path: Optional[str] = None, repo_path: Optional[str] = None) -> List[Dict]:
         """Find all direct and indirect callers of a specific function."""
         with self.driver.session() as session:
-            repo_filter = "AND f.path STARTS WITH $repo_path " if repo_path else ""
-            path_filter = "AND target.path = $path" if path else ""
-            # KùzuDB-compatible: Use anonymous end node and filter with WHERE
-            query = f"""
-                MATCH p = (f:Function)-[:CALLS*]->()
-                WITH f as f, p as p, nodes(p) as path_nodes
-                WITH f as f, path_nodes as path_nodes, path_nodes[size(path_nodes)-1] as target
-                WHERE target.name = $function_name {path_filter} {repo_filter}
-                RETURN DISTINCT f.name AS caller_name, f.path AS caller_file_path, f.line_number AS caller_line_number, f.is_dependency AS caller_is_dependency
-                ORDER BY caller_is_dependency ASC, caller_file_path, caller_line_number
-                LIMIT 50
-            """
-            result = session.run(query, function_name=function_name, path=path, repo_path=repo_path)
+            repo_filter = "AND f.path STARTS WITH $repo_path" if repo_path else ""
+            if path:
+                # KùzuDB-compatible: Use anonymous end node and filter with WHERE
+                query = f"""
+                    MATCH p = (f:Function)-[:CALLS*]->()
+                    WITH f as f, p as p, nodes(p) as path_nodes
+                    WITH f as f, path_nodes as path_nodes, path_nodes[size(path_nodes)-1] as target
+                    WHERE target.name = $function_name AND target.path = $path {repo_filter}
+                    RETURN DISTINCT f.name AS caller_name, f.path AS caller_file_path, f.line_number AS caller_line_number, f.is_dependency AS caller_is_dependency
+                    ORDER BY caller_is_dependency ASC, caller_file_path, caller_line_number
+                    LIMIT 50
+                """
+                result = session.run(query, function_name=function_name, path=path, repo_path=repo_path)
+            else:
+                # KùzuDB-compatible: Use anonymous end node and filter with WHERE
+                query = f"""
+                    MATCH p = (f:Function)-[:CALLS*]->()
+                    WITH f as f, p as p, nodes(p) as path_nodes
+                    WITH f as f, path_nodes as path_nodes, path_nodes[size(path_nodes)-1] as target
+                    WHERE target.name = $function_name {repo_filter}
+                    RETURN DISTINCT f.name AS caller_name, f.path AS caller_file_path, f.line_number AS caller_line_number, f.is_dependency AS caller_is_dependency
+                    ORDER BY caller_is_dependency ASC, caller_file_path, caller_line_number
+                    LIMIT 50
+                """
+                result = session.run(query, function_name=function_name, repo_path=repo_path)
             return result.data()
 
     def find_all_callees(self, function_name: str, path: Optional[str] = None, repo_path: Optional[str] = None) -> List[Dict]:
         """Find all direct and indirect callees of a specific function."""
         with self.driver.session() as session:
             repo_filter = "WHERE f.path STARTS WITH $repo_path" if repo_path else ""
-            path_filter = ", path: $path" if path else ""
-            # KùzuDB-compatible: Use anonymous end node and extract from path
-            query = f"""
-                MATCH (caller:Function {{name: $function_name{path_filter}}})
-                MATCH p = (caller)-[:CALLS*]->()
-                WITH p as p, nodes(p) as path_nodes
-                WITH path_nodes[size(path_nodes)-1] as f
-                {repo_filter}
-                RETURN DISTINCT f.name AS callee_name, f.path AS callee_file_path, f.line_number AS callee_line_number, f.is_dependency AS callee_is_dependency
-                ORDER BY callee_is_dependency ASC, callee_file_path, callee_line_number
-                LIMIT 50
-            """
-            result = session.run(query, function_name=function_name, path=path, repo_path=repo_path)
+            if path:
+                # KùzuDB-compatible: Use anonymous end node and extract from path
+                query = f"""
+                    MATCH (caller:Function {{name: $function_name, path: $path}})
+                    MATCH p = (caller)-[:CALLS*]->()
+                    WITH p as p, nodes(p) as path_nodes
+                    WITH path_nodes[size(path_nodes)-1] as f
+                    {repo_filter}
+                    RETURN DISTINCT f.name AS callee_name, f.path AS callee_file_path, f.line_number AS callee_line_number, f.is_dependency AS callee_is_dependency
+                    ORDER BY callee_is_dependency ASC, callee_file_path, callee_line_number
+                    LIMIT 50
+                """
+                result = session.run(query, function_name=function_name, path=path, repo_path=repo_path)
+            else:
+                # KùzuDB-compatible: Use anonymous end node and extract from path
+                query = f"""
+                    MATCH (caller:Function {{name: $function_name}})
+                    MATCH p = (caller)-[:CALLS*]->()
+                    WITH p as p, nodes(p) as path_nodes
+                    WITH path_nodes[size(path_nodes)-1] as f
+                    {repo_filter}
+                    RETURN DISTINCT f.name AS callee_name, f.path AS callee_file_path, f.line_number AS callee_line_number, f.is_dependency AS callee_is_dependency
+                    ORDER BY callee_is_dependency ASC, callee_file_path, callee_line_number
+                    LIMIT 50
+                """
+                result = session.run(query, function_name=function_name, repo_path=repo_path)
             return result.data()
 
     def find_function_call_chain(self, start_function: str, end_function: str, max_depth: int = 5, start_file: Optional[str] = None, end_file: Optional[str] = None, repo_path: Optional[str] = None) -> List[Dict]:
@@ -761,7 +901,7 @@ class CodeFinder:
                 WITH start as start, end_target as end_target
                 MATCH path = (start)-[:CALLS*1..{max_depth}]->()
                 WITH path as path, end_target as end_target, nodes(path) as func_nodes, relationships(path) as call_rels
-                WITH path as path, func_nodes as func_nodes, call_rels as call_rels, end_target as end_target, func_nodes[size(func_nodes)] as path_end
+                WITH path as path, func_nodes as func_nodes, call_rels as call_rels, end_target as end_target, func_nodes[size(func_nodes)-1] as path_end
                 WHERE path_end.name = end_target.name AND (end_target.path IS NULL OR path_end.path = end_target.path)
                 RETURN func_nodes as function_nodes, call_rels as call_nodes, size(call_rels) as chain_length
                 ORDER BY chain_length ASC

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -32,6 +32,7 @@ class GraphBuilder:
         self.loop = loop
         self.driver = self.db_manager.get_driver()
         self._writer = GraphWriter(self.driver)
+        self.last_call_resolution_diagnostics: list[Dict[str, Any]] = []
         self.parsers = {
             ".py": "python",
             ".ipynb": "python",
@@ -780,7 +781,23 @@ class GraphBuilder:
         file_class_lookup: Optional[Dict[str, set]] = None,
     ) -> None:
         """Resolve and persist CALLS relationships (public API)."""
-        groups = build_function_call_groups(all_file_data, imports_map, file_class_lookup)
+        diagnostics: list[Dict[str, Any]] = []
+        groups = build_function_call_groups(
+            all_file_data,
+            imports_map,
+            file_class_lookup,
+            diagnostics=diagnostics,
+        )
+        self.last_call_resolution_diagnostics = diagnostics
+        if diagnostics:
+            sample = ", ".join(
+                f"{d.get('full_call_name')}:{d.get('reason')}"
+                for d in diagnostics[:5]
+            )
+            info_logger(
+                f"[CALLS] Skipped {len(diagnostics)} unresolved call(s). "
+                f"Sample: {sample}"
+            )
         self._writer.write_function_call_groups(*groups)
 
     def _create_all_function_calls(
@@ -959,6 +976,7 @@ class GraphBuilder:
                         "Falling back to Tree-sitter."
                     )
 
+            self.last_call_resolution_diagnostics = []
             await run_tree_sitter_index_async(
                 path,
                 is_dependency,
@@ -970,6 +988,7 @@ class GraphBuilder:
                 self.get_parser,
                 self.parse_file,
                 self.add_minimal_file_node,
+                call_resolution_diagnostics=self.last_call_resolution_diagnostics,
             )
         except Exception as e:
             error_message = str(e)

--- a/src/codegraphcontext/tools/handlers/analysis_handlers.py
+++ b/src/codegraphcontext/tools/handlers/analysis_handlers.py
@@ -171,7 +171,7 @@ def find_java_spring_endpoints(code_finder: CodeFinder, **args) -> Dict[str, Any
         params["path_pattern"] = path_pattern
 
     if repo_path:
-        conditions.append("fn.path STARTS WITH $repo_path")
+        conditions.append("fn.path CONTAINS $repo_path")
         params["repo_path"] = repo_path
 
     where_clause = " AND ".join(conditions)
@@ -207,7 +207,7 @@ def find_java_spring_beans(code_finder: CodeFinder, **args) -> Dict[str, Any]:
         params["stereotype"] = stereotype.upper()
 
     if repo_path:
-        conditions.append("c.path STARTS WITH $repo_path")
+        conditions.append("c.path CONTAINS $repo_path")
         params["repo_path"] = repo_path
 
     where_clause = " AND ".join(conditions)

--- a/src/codegraphcontext/tools/indexing/discovery.py
+++ b/src/codegraphcontext/tools/indexing/discovery.py
@@ -1,19 +1,35 @@
 """Enumerate files to index with ignore rules."""
 
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import FrozenSet, List, Optional, Set, Tuple
 
 from ...core.cgcignore import build_ignore_spec
 from ...utils.debug_log import debug_log, warning_logger
 from .constants import DEFAULT_IGNORE_PATTERNS
 
+# Generic file types that are added as minimal File nodes (no source parsing).
+# Must stay in sync with GraphBuilder.generic_extensions / generic_filenames.
+_GENERIC_EXTENSIONS: FrozenSet[str] = frozenset({
+    ".toml", ".sh", ".yaml", ".yml", ".json", ".ini", ".cfg",
+    ".md", ".txt", ".env", ".bat", ".ps1", ".dockerignore", ".gitignore",
+})
+_GENERIC_FILENAMES: FrozenSet[str] = frozenset({"Dockerfile", "Makefile"})
+
 
 def discover_files_to_index(
     path: Path,
     cgcignore_path: Optional[str] = None,
+    supported_extensions: Optional[Set[str]] = None,
 ) -> Tuple[List[Path], Path]:
     """
     Returns (files, ignore_root). *ignore_root* is used for .cgcignore relative matching.
+
+    ``supported_extensions`` should be the set of extensions the active parsers
+    handle (e.g. ``set(parsers.keys())``).  When provided, only files whose
+    suffix is in that set OR in the built-in generic extension / filename sets
+    are returned.  This avoids walking tens-of-thousands of ``.properties``,
+    ``.xml``, ``.conf`` etc. files that would produce "No parser found" warnings
+    and contribute nothing to the graph.
     """
     ignore_root = path.resolve() if path.is_dir() else path.resolve().parent
 
@@ -30,7 +46,15 @@ def discover_files_to_index(
         warning_logger(f"Could not load/create .cgcignore: {e}")
 
     all_files = path.rglob("*") if path.is_dir() else [path]
-    files = [f for f in all_files if f.is_file()]
+
+    if supported_extensions is not None:
+        allowed_exts = supported_extensions | _GENERIC_EXTENSIONS
+        files = [
+            f for f in all_files
+            if f.is_file() and (f.suffix in allowed_exts or f.name in _GENERIC_FILENAMES)
+        ]
+    else:
+        files = [f for f in all_files if f.is_file()]
 
     from ...cli.config_manager import get_config_value
 

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -865,6 +865,7 @@ class GraphWriter:
                     SET m.version = row.version,
                         m.packaging = row.packaging,
                         m.pom_path = row.pom_path,
+                        m.path = row.pom_path,
                         m.repo_path = $repo_path
                     """,
                     batch=modules[i : i + batch_size],
@@ -932,7 +933,7 @@ class GraphWriter:
                     """
                     UNWIND $batch AS row
                     MERGE (m:GradleModule {name: row.name})
-                    SET m.build_file = row.build_file, m.repo_path = $repo_path
+                    SET m.build_file = row.build_file, m.path = row.build_file, m.repo_path = $repo_path
                     """,
                     batch=modules[i : i + batch_size],
                     repo_path=repo_path_str,

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -87,14 +87,12 @@ class GraphWriter:
             session.run(
                 """
                 MERGE (f:File {path: $path})
-                SET f.name = $name, f.relative_path = $relative_path, f.is_dependency = $is_dependency,
-                    f.package_name = $package_name
+                SET f.name = $name, f.relative_path = $relative_path, f.is_dependency = $is_dependency
             """,
                 path=file_path_str,
                 name=file_name,
                 relative_path=relative_path,
                 is_dependency=is_dependency,
-                package_name=file_data.get("package_name"),
             )
 
             file_path_obj = Path(file_path_str)
@@ -166,6 +164,9 @@ class GraphWriter:
                             class_fn_batch.append(
                                 {
                                     "class_name": item["class_context"],
+                                    "class_line": item.get("class_context_line", -1)
+                                    if item.get("class_context_line") is not None
+                                    else -1,
                                     "func_name": item["name"],
                                     "func_line": item["line_number"],
                                 }
@@ -268,6 +269,7 @@ class GraphWriter:
                     UNWIND $batch AS row
                     MATCH (c:Class {name: row.class_name, path: $file_path})
                     MATCH (fn:Function {name: row.func_name, path: $file_path, line_number: row.func_line})
+                    WHERE row.class_line < 0 OR c.line_number = row.class_line
                     MERGE (c)-[:CONTAINS]->(fn)
                 """,
                     batch=class_fn_batch,
@@ -313,16 +315,24 @@ class GraphWriter:
                             }
                         )
                 else:
-                    module_name = imp.get("name") or imp.get("source") or imp.get("full_import_name")
-                    if module_name:
-                        other_imports.append(
-                            {
-                                "name": module_name,
-                                "alias": imp.get("alias") or "",
-                                "full_import_name": imp.get("full_import_name") or module_name,
-                                "line_number": imp.get("line_number") or 0,
-                            }
-                        )
+                    module_name = imp.get("name") or imp.get("source")
+                    if not module_name:
+                        continue
+                    full_import_name = (
+                        imp.get("full_import_name")
+                        or imp.get("source")
+                        or module_name
+                    )
+                    other_imports.append(
+                        {
+                            "name": module_name,
+                            "full_import_name": full_import_name,
+                            "imported_name": imp.get("imported_name") or module_name,
+                            "alias": imp.get("alias"),
+                            "line_number": imp.get("line_number"),
+                            "lang": imp.get("lang") or lang,
+                        }
+                    )
 
             if js_imports:
                 session.run(
@@ -345,10 +355,13 @@ class GraphWriter:
                     UNWIND $batch AS row
                     MATCH (f:File {path: $file_path})
                     MERGE (m:Module {name: row.name})
-                    SET m.full_import_name = coalesce(row.full_import_name, m.full_import_name)
+                    SET m.lang = coalesce(row.lang, m.lang),
+                        m.full_import_name = coalesce(row.full_import_name, m.full_import_name)
                     MERGE (f)-[r:IMPORTS]->(m)
                     SET r.line_number = row.line_number,
-                        r.alias = row.alias
+                        r.alias = row.alias,
+                        r.imported_name = row.imported_name,
+                        r.full_import_name = row.full_import_name
                 """,
                     batch=other_imports,
                     file_path=file_path_str,
@@ -451,49 +464,58 @@ class GraphWriter:
             UNWIND $batch AS row
             MATCH (caller:Function {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Function {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
-                c.confidence_label = row.confidence_label
+            WHERE (row.called_line_number < 0 OR called.line_number = row.called_line_number)
+              AND (row.called_context = '' OR called.context = row.called_context)
+            MERGE (caller)-[call:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET call.confidence = row.confidence, call.resolution_tier = row.resolution_tier,
+                call.confidence_label = row.confidence_label
         """
         q_fn_to_cls = """
             UNWIND $batch AS row
             MATCH (caller:Function {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Class {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
-                c.confidence_label = row.confidence_label
+            WHERE row.called_line_number < 0 OR called.line_number = row.called_line_number
+            MERGE (caller)-[call:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET call.confidence = row.confidence, call.resolution_tier = row.resolution_tier,
+                call.confidence_label = row.confidence_label
         """
         q_cls_to_fn = """
             UNWIND $batch AS row
             MATCH (caller:Class {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Function {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
-                c.confidence_label = row.confidence_label
+            WHERE (row.called_line_number < 0 OR called.line_number = row.called_line_number)
+              AND (row.called_context = '' OR called.context = row.called_context)
+            MERGE (caller)-[call:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET call.confidence = row.confidence, call.resolution_tier = row.resolution_tier,
+                call.confidence_label = row.confidence_label
         """
         q_cls_to_cls = """
             UNWIND $batch AS row
             MATCH (caller:Class {name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number})
             MATCH (called:Class {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
-                c.confidence_label = row.confidence_label
+            WHERE row.called_line_number < 0 OR called.line_number = row.called_line_number
+            MERGE (caller)-[call:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET call.confidence = row.confidence, call.resolution_tier = row.resolution_tier,
+                call.confidence_label = row.confidence_label
         """
         q_file_to_fn = """
             UNWIND $batch AS row
             MATCH (caller:File {path: row.caller_file_path})
             MATCH (called:Function {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
-                c.confidence_label = row.confidence_label
+            WHERE (row.called_line_number < 0 OR called.line_number = row.called_line_number)
+              AND (row.called_context = '' OR called.context = row.called_context)
+            MERGE (caller)-[call:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET call.confidence = row.confidence, call.resolution_tier = row.resolution_tier,
+                call.confidence_label = row.confidence_label
         """
         q_file_to_cls = """
             UNWIND $batch AS row
             MATCH (caller:File {path: row.caller_file_path})
             MATCH (called:Class {name: row.called_name, path: row.called_file_path})
-            MERGE (caller)-[c:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
-            SET c.confidence = row.confidence, c.resolution_tier = row.resolution_tier,
-                c.confidence_label = row.confidence_label
+            WHERE row.called_line_number < 0 OR called.line_number = row.called_line_number
+            MERGE (caller)-[call:CALLS {line_number: row.line_number, args: row.args, full_call_name: row.full_call_name}]->(called)
+            SET call.confidence = row.confidence, call.resolution_tier = row.resolution_tier,
+                call.confidence_label = row.confidence_label
         """
         groups: List[Tuple[str, List[Dict], str]] = [
             ("fn→fn", fn_to_fn, q_fn_to_fn),
@@ -504,6 +526,51 @@ class GraphWriter:
             ("file→cls", file_to_cls, q_file_to_cls),
         ]
         total_all = sum(len(g[1]) for g in groups)
+
+        def normalize_call_batch(batch_calls: List[Dict], label: str) -> List[Dict]:
+            normalized = []
+            for call in batch_calls:
+                if not isinstance(call, dict) or not call:
+                    warning_logger(f"[CALLS] {label}: skipping malformed call row: {call!r}")
+                    continue
+
+                called_line_number = call.get("called_line_number")
+                if called_line_number is None:
+                    called_line_number = -1
+                elif isinstance(called_line_number, bool):
+                    warning_logger(
+                        f"[CALLS] {label}: skipping call row with invalid called_line_number: {call!r}"
+                    )
+                    continue
+                else:
+                    try:
+                        called_line_number = int(called_line_number)
+                    except (TypeError, ValueError):
+                        warning_logger(
+                            f"[CALLS] {label}: skipping call row with invalid called_line_number: {call!r}"
+                        )
+                        continue
+
+                called_context = call.get("called_context")
+                if called_context is None:
+                    called_context = ""
+                elif not isinstance(called_context, str):
+                    warning_logger(
+                        f"[CALLS] {label}: skipping call row with invalid called_context: {call!r}"
+                    )
+                    continue
+
+                normalized.append(
+                    {
+                        **call,
+                        "called_line_number": called_line_number,
+                        "called_context": called_context,
+                        "confidence": call.get("confidence", 0.1),
+                        "resolution_tier": call.get("resolution_tier", 9),
+                    }
+                )
+            return normalized
+
         with self.driver.session() as session:
             for label, calls, query in groups:
                 if not calls:
@@ -511,7 +578,9 @@ class GraphWriter:
                     continue
                 t0 = time.time()
                 for i in range(0, len(calls), batch_size):
-                    batch = calls[i : i + batch_size]
+                    batch = normalize_call_batch(calls[i : i + batch_size], label)
+                    if not batch:
+                        continue
                     session.run(query, batch=batch)
                     written = min(i + batch_size, len(calls))
                     if written % 5000 < batch_size or written == len(calls):

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -37,7 +37,7 @@ async def run_tree_sitter_index_async(
     writer.add_repository_to_graph(path, is_dependency)
     repo_name = path.name
 
-    files, _ignore_root = discover_files_to_index(path, cgcignore_path)
+    files, _ignore_root = discover_files_to_index(path, cgcignore_path, supported_extensions=set(parsers.keys()))
 
     if job_id:
         job_manager.update_job(job_id, total_files=len(files))

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -28,6 +28,7 @@ async def run_tree_sitter_index_async(
     get_parser: Callable[[str], Any],
     parse_file: Callable[[Path, Path, bool], Dict[str, Any]],
     add_minimal_file_node: Callable[[Path, Path, bool], None],
+    call_resolution_diagnostics: Optional[List[Dict[str, Any]]] = None,
 ) -> None:
     """Parse all discovered files, write symbols, then inheritance + CALLS."""
     if job_id:
@@ -85,7 +86,12 @@ async def run_tree_sitter_index_async(
     t1 = time.time()
     info_logger(f"Inheritance links created in {t1 - t0:.1f}s. Starting function calls...")
 
-    groups = build_function_call_groups(all_file_data, imports_map, None)
+    groups = build_function_call_groups(
+        all_file_data,
+        imports_map,
+        None,
+        diagnostics=call_resolution_diagnostics,
+    )
     writer.write_function_call_groups(*groups)
     t2 = time.time()
     info_logger(f"Function calls created in {t2 - t1:.1f}s. Total post-processing: {t2 - t0:.1f}s")

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -1500,6 +1500,11 @@ def build_function_call_groups(
             return f"Sequence<{element_type}>"
         return f"List<{element_type}>"
 
+    # Fast path: skip all Kotlin-specific index structures when no Kotlin files present.
+    # For pure Java/Python/JS repos this avoids building extension_method_index and
+    # class_method_index over hundreds of thousands of functions.
+    has_kotlin = any(fd.get("lang") == "kotlin" for fd in all_file_data)
+
     member_return_types: Dict[Tuple[Optional[str], str], str] = {}
     member_return_types_full: Dict[Tuple[Optional[str], str], str] = {}
     member_property_types: Dict[Tuple[Optional[str], str], str] = {}
@@ -1589,21 +1594,22 @@ def build_function_call_groups(
         for func in fd.get("functions", []):
             indexed_func = {**func, "path": fd["path"], "package": package_name}
             function_index.setdefault((file_path, func["name"]), []).append(indexed_func)
-            context_names = function_context_names_for_maps(fd, func, package_name)
-            for context_name in context_names:
-                class_method_names.setdefault(context_name, set()).add(func["name"])
-                class_method_index.setdefault((context_name, func["name"]), []).append(
-                    indexed_func
+            if has_kotlin:
+                context_names = function_context_names_for_maps(fd, func, package_name)
+                for context_name in context_names:
+                    class_method_names.setdefault(context_name, set()).add(func["name"])
+                    class_method_index.setdefault((context_name, func["name"]), []).append(
+                        indexed_func
+                    )
+                receiver_types = type_keys_for_maps(
+                    func.get("receiver_type"),
+                    fd_local_imports,
+                    package_name,
                 )
-            receiver_types = type_keys_for_maps(
-                func.get("receiver_type"),
-                fd_local_imports,
-                package_name,
-            )
-            for receiver_type in receiver_types:
-                extension_method_index.setdefault((receiver_type, func["name"]), []).append(
-                    indexed_func
-                )
+                for receiver_type in receiver_types:
+                    extension_method_index.setdefault((receiver_type, func["name"]), []).append(
+                        indexed_func
+                    )
         for variable in fd.get("variables", []):
             if variable.get("context"):
                 continue
@@ -1619,25 +1625,25 @@ def build_function_call_groups(
             if package_name:
                 global_variable_types[f"{package_name}.{variable_name}"] = variable_type
 
-    needs_member_receiver_types = any(
-        call.get("receiver_base_type") and call.get("receiver_member_name")
-        for fd in all_file_data
-        for call in fd.get("function_calls", [])
-    ) or any(
-        fd.get("lang") == "kotlin" and call.get("base_obj")
-        for fd in all_file_data
-        for call in fd.get("function_calls", [])
-    ) or any(
-        variable.get("initializer_receiver_name")
-        and variable.get("initializer_member_name")
-        for fd in all_file_data
-        for variable in fd.get("variables", [])
-    ) or any(
-        variable.get("initializer_collection_receiver_name")
-        and variable.get("initializer_collection_member_name")
-        for fd in all_file_data
-        for variable in fd.get("variables", [])
-    )
+    # Single-pass check replacing 4 separate O(n) any() scans.
+    needs_member_receiver_types = False
+    if has_kotlin:
+        for fd in all_file_data:
+            is_kotlin = fd.get("lang") == "kotlin"
+            for call in fd.get("function_calls", []):
+                if (call.get("receiver_base_type") and call.get("receiver_member_name")) or \
+                   (is_kotlin and call.get("base_obj")):
+                    needs_member_receiver_types = True
+                    break
+            if needs_member_receiver_types:
+                break
+            for variable in fd.get("variables", []):
+                if (variable.get("initializer_receiver_name") and variable.get("initializer_member_name")) or \
+                   (variable.get("initializer_collection_receiver_name") and variable.get("initializer_collection_member_name")):
+                    needs_member_receiver_types = True
+                    break
+            if needs_member_receiver_types:
+                break
     if needs_member_receiver_types:
         for fd in all_file_data:
             package_name = file_package(fd)
@@ -1733,6 +1739,13 @@ def build_function_call_groups(
         caller_file_path = str(Path(file_data["path"]).resolve())
         func_names = {f["name"] for f in file_data.get("functions", [])}
         class_names = {c["name"] for c in file_data.get("classes", [])}
+        # Pre-sort functions by line range for O(log n) scope lookup via bisect.
+        _file_functions_sorted = sorted(
+            [f for f in file_data.get("functions", []) if f.get("line_number") is not None and f.get("end_line") is not None],
+            key=lambda f: f["line_number"],
+        )
+        _fn_starts = [f["line_number"] for f in _file_functions_sorted]
+        _fn_ends   = [f["end_line"]   for f in _file_functions_sorted]
         local_names = func_names | class_names
         local_class_bases = {
             c["name"]: c.get("bases", []) for c in file_data.get("classes", [])
@@ -1771,15 +1784,17 @@ def build_function_call_groups(
         ) -> Any:
             if not context_name or line_number is None:
                 return context_name
-            for function in file_data.get("functions", []):
-                if function.get("name") != context_name:
+            # Use bisect on pre-sorted intervals instead of linear scan.
+            import bisect
+            idx_r = bisect.bisect_right(_fn_starts, line_number)
+            for i in range(idx_r - 1, -1, -1):
+                fn = _file_functions_sorted[i]
+                if fn["line_number"] > line_number:
                     continue
-                start_line = function.get("line_number")
-                end_line = function.get("end_line", start_line)
-                if start_line is None or end_line is None:
-                    continue
-                if start_line <= line_number <= end_line:
-                    return function_scope(function)
+                if fn["end_line"] < line_number:
+                    break
+                if fn.get("name") == context_name:
+                    return function_scope(fn)
             return context_name
 
         def variable_scope(variable: Dict[str, Any]) -> Any:

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -1219,6 +1219,8 @@ def resolve_function_call(
             candidates = imports_map[called_name]
             for path in candidates:
                 for imp_name in local_imports.values():
+                    if not isinstance(imp_name, str):
+                        continue
                     if imp_name.replace(".", "/") in path:
                         resolved_path = path
                         is_unresolved_external = False

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -33,6 +33,15 @@ def _confidence_label(tier: int, is_unresolved_external: bool) -> str:
     return "INFERRED"
 
 
+def _confidence_label(tier: int, is_unresolved_external: bool) -> str:
+    """Map a resolution tier to EXTRACTED / INFERRED / AMBIGUOUS."""
+    if is_unresolved_external or tier >= 8:
+        return "AMBIGUOUS"
+    if tier in (1, 2, 5, 6):
+        return "EXTRACTED"
+    return "INFERRED"
+
+
 def resolve_function_call(
     call: Dict[str, Any],
     caller_file_path: str,

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -1,23 +1,26 @@
 """Heuristic resolution of function calls into CALLS edge payloads (no DB I/O)."""
 
 from pathlib import Path
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from ....cli.config_manager import get_config_value
+from ...type_utils import strip_type_modifiers
 from ....utils.debug_log import info_logger
+
 
 # Confidence score for each resolution tier.
 # Higher = more certain the edge points to the correct target.
 _TIER_CONFIDENCE: Dict[int, float] = {
     1: 1.00,  # explicit this/self/super receiver — definitionally same-class
     2: 0.95,  # local function or class defined in the same file
-    3: 0.88,  # inferred receiver type + FQN import key (Phase 1 adds FQN entries)
-    4: 0.72,  # inferred receiver type + short-name (possible first-match bias)
-    5: 0.90,  # unique short name — only one file in the graph defines it
-    6: 0.85,  # FQN key in imports_map via qualified import declaration
-    7: 0.70,  # FQN matched as path-substring across multiple candidates
-    8: 0.25,  # alphabetical-first of multiple candidates (wrong most of the time)
-    9: 0.08,  # same-file fallback for obj.method() — definitionally wrong
+    3: 0.88,  # inferred receiver type + FQN import key
+    4: 0.72,  # inferred receiver type + short-name/type fallback
+    5: 0.90,  # unique short name or same-package lookup
+    6: 0.85,  # qualified import/wildcard import lookup
+    7: 0.70,  # FQN path-substring match
+    8: 0.25,  # alphabetical-first of multiple candidates
+    9: 0.08,  # same-file fallback for unresolved obj.method()
 }
 
 # Human-readable confidence labels surfaced on graph edges (#885)
@@ -37,6 +40,17 @@ def resolve_function_call(
     local_imports: dict,
     imports_map: dict,
     skip_external: bool,
+    local_class_bases: Optional[Dict[str, List[str]]] = None,
+    member_return_types: Optional[Dict[Tuple[Optional[str], str], str]] = None,
+    member_property_types: Optional[Dict[Tuple[Optional[str], str], str]] = None,
+    type_aliases: Optional[Dict[str, str]] = None,
+    global_class_bases: Optional[Dict[str, List[str]]] = None,
+    class_method_names: Optional[Dict[str, set]] = None,
+    function_index: Optional[Dict[Tuple[str, str], List[Dict[str, Any]]]] = None,
+    class_index: Optional[Dict[Tuple[str, str], List[Dict[str, Any]]]] = None,
+    class_method_index: Optional[Dict[Tuple[str, str], List[Dict[str, Any]]]] = None,
+    extension_method_index: Optional[Dict[Tuple[str, str], List[Dict[str, Any]]]] = None,
+    diagnostics: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Resolve a single function call to its target. Returns call params dict or None if skipped."""
     called_name = call["name"]
@@ -45,9 +59,11 @@ def resolve_function_call(
 
     resolved_called_name = called_name
     resolved_path = None
-    resolution_tier = 9  # default: same-file fallback
+    resolved_called_name = called_name
+    resolution_tier = 9
     full_call = call.get("full_name", called_name)
     base_obj = full_call.split(".")[0] if "." in full_call else None
+    caller_package = call.get("package")
 
     is_chained_call = full_call.count(".") > 1 if "." in full_call else False
 
@@ -56,35 +72,1103 @@ def resolve_function_call(
     else:
         lookup_name = base_obj if base_obj else called_name
 
-    # ── Tier 1: explicit self/this/super — same-class, always correct ──────────
-    if base_obj in ("self", "this", "super", "super()", "cls", "@") and not is_chained_call:
-        resolved_path = caller_file_path
-        resolution_tier = 1
+    extension_receiver_type = call.get("extension_receiver_type")
+    imported_extension_name = local_imports.get(called_name) if extension_receiver_type else None
+    imported_call_name = local_imports.get(called_name)
+    same_package_call_name = f"{caller_package}.{called_name}" if caller_package else None
+    local_class_bases = local_class_bases or {}
+    member_return_types = member_return_types or {}
+    member_property_types = member_property_types or {}
+    type_aliases = type_aliases or {}
+    global_class_bases = global_class_bases or {}
+    class_method_names = class_method_names or {}
+    function_index = function_index or {}
+    class_index = class_index or {}
+    class_method_index = class_method_index or {}
+    extension_method_index = extension_method_index or {}
+    resolved_called_line_number = None
+    resolved_called_context = None
+    receiver_resolution_failed = False
+    unresolved_overloaded_callable_reference = False
+    unresolved_overloaded_method = False
+    ambiguous_class_target = False
+    wildcard_imports = local_imports.get("__wildcards__", [])
+    if isinstance(wildcard_imports, str):
+        wildcard_imports = [wildcard_imports]
 
-    # ── Tier 2: call target defined locally in the same file ───────────────────
-    elif lookup_name in local_names:
-        resolved_path = caller_file_path
-        resolution_tier = 2
+    def record_skip(reason: str, **details: Any) -> None:
+        if diagnostics is None:
+            return
+        caller_context = call.get("context")
+        caller_name = (
+            caller_context[0]
+            if caller_context and len(caller_context) == 3
+            else None
+        )
+        diagnostics.append({
+            "reason": reason,
+            "caller_name": caller_name,
+            "caller_file_path": caller_file_path,
+            "line_number": call.get("line_number"),
+            "full_call_name": call.get("full_name", called_name),
+            "call_kind": call.get("call_kind", "call"),
+            **details,
+        })
 
-    # ── Tier 3/4: receiver type inferred from variable declaration ─────────────
-    elif call.get("inferred_obj_type"):
-        obj_type = call["inferred_obj_type"]
-        # Tier 3: FQN lookup — only when local import gives us the exact package.
-        # Phase 1 adds FQN entries to imports_map so `imports_map[fqn]` has 1 path.
-        if obj_type in local_imports:
-            fqn = local_imports[obj_type]
-            fqn_paths = imports_map.get(fqn, [])
-            if len(fqn_paths) == 1:
-                resolved_path = fqn_paths[0]
-                resolution_tier = 3
-        # Tier 4: short-name lookup (legacy — may be first-match biased)
+    def canonical_type(type_name: Optional[str]) -> Optional[str]:
+        if not type_name:
+            return None
+        normalized = strip_type_modifiers(type_name)
+        if not normalized:
+            return None
+        candidates = [normalized]
+        imported = local_imports.get(normalized)
+        if imported:
+            candidates.insert(0, imported)
+        if caller_package and "." not in normalized:
+            candidates.append(f"{caller_package}.{normalized}")
+
+        for candidate in candidates:
+            target = type_aliases.get(candidate)
+            if target:
+                target = strip_type_modifiers(target)
+                if not target:
+                    return None
+                imported_target = local_imports.get(target)
+                if imported_target and strip_type_modifiers(imported_target) in imports_map:
+                    return strip_type_modifiers(imported_target)
+                if "." in target and target in imports_map:
+                    return target
+                same_package_target = f"{caller_package}.{target}" if caller_package else None
+                if same_package_target and same_package_target in imports_map:
+                    return same_package_target
+                return target.split(".")[-1]
+        if imported and strip_type_modifiers(imported) in imports_map:
+            return strip_type_modifiers(imported)
+        if "." in normalized and normalized in imports_map:
+            return normalized
+        same_package_name = f"{caller_package}.{normalized}" if caller_package else None
+        if same_package_name and same_package_name in imports_map:
+            return same_package_name
+        return normalized.split(".")[-1]
+
+    def simple_type_key(type_name: Optional[str]) -> Optional[str]:
+        if not type_name:
+            return None
+        normalized = strip_type_modifiers(type_name)
+        return normalized.split(".")[-1] if normalized else None
+
+    def unique_lower_camel_receiver_type(
+        receiver_types: set,
+        receiver_name: str,
+    ) -> Optional[str]:
+        matches = [
+            receiver_type
+            for receiver_type in receiver_types
+            if lower_camel_type_name(receiver_type) == receiver_name
+        ]
+        if not matches:
+            return None
+
+        simple_names = {simple_type_key(receiver_type) for receiver_type in matches}
+        simple_names.discard(None)
+        if len(simple_names) != 1:
+            return None
+
+        simple_name = next(iter(simple_names))
+        imported_or_same_package = canonical_type(simple_name)
+        if imported_or_same_package in matches:
+            return imported_or_same_package
+
+        fqn_matches = [
+            receiver_type
+            for receiver_type in matches
+            if "." in strip_type_modifiers(receiver_type)
+        ]
+        if len(fqn_matches) == 1:
+            return fqn_matches[0]
+        if len(fqn_matches) > 1:
+            return None
+        return simple_name
+
+    def member_type_for_owner(
+        member_types: Dict[Tuple[Optional[str], str], str],
+        owner_type: Optional[str],
+        member_name: str,
+    ) -> Optional[str]:
+        for owner_key in (owner_type, simple_type_key(owner_type)):
+            if not owner_key:
+                continue
+            member_type = member_types.get((owner_key, member_name))
+            if member_type:
+                return member_type
+        return None
+
+    def first_import_path(*names: Optional[str]) -> Optional[str]:
+        for name in names:
+            if not name:
+                continue
+            possible_paths = imports_map.get(name, [])
+            if possible_paths:
+                return possible_paths[0]
+        return None
+
+    def call_arg_count() -> Optional[int]:
+        arg_type_hints = call.get("arg_type_hints")
+        if (
+            call.get("call_kind") == "callable_reference"
+            and isinstance(arg_type_hints, list)
+            and arg_type_hints
+        ):
+            return len(arg_type_hints)
+        args = call.get("args")
+        return len(args) if isinstance(args, list) else None
+
+    def function_arg_count(func: Dict[str, Any]) -> Optional[int]:
+        args = func.get("args")
+        if not isinstance(args, list):
+            args = func.get("parameters")
+        return len(args) if isinstance(args, list) else None
+
+    def function_required_arg_count(func: Dict[str, Any]) -> Optional[int]:
+        total = function_arg_count(func)
+        if total is None:
+            return None
+        defaults = func.get("arg_defaults")
+        if not isinstance(defaults, list):
+            return total
+        optional = sum(1 for has_default in defaults[:total] if has_default)
+        return max(0, total - optional)
+
+    def simple_type_name(type_name: Optional[str]) -> Optional[str]:
+        if not type_name:
+            return None
+        if "->" in type_name:
+            return "Function"
+        simple_name = strip_type_modifiers(type_name).split(".")[-1]
+        primitive_names = {
+            "byte": "Byte",
+            "short": "Short",
+            "int": "Int",
+            "long": "Long",
+            "float": "Float",
+            "double": "Double",
+            "boolean": "Boolean",
+            "char": "Char",
+        }
+        return primitive_names.get(simple_name, simple_name)
+
+    def lower_camel_type_name(type_name: Optional[str]) -> Optional[str]:
+        simple_name = simple_type_name(type_name)
+        if not simple_name:
+            return None
+        return simple_name[0].lower() + simple_name[1:]
+
+    def expression_type_hint(arg: str) -> Optional[str]:
+        text = arg.strip()
+        if not text:
+            return None
+        if text.startswith("{") and text.endswith("}"):
+            return "Function"
+        if re.fullmatch(r'"(?:\\.|[^"\\])*"', text):
+            return "String"
+        if re.fullmatch(r"'(?:\\.|[^'\\])'", text):
+            return "Char"
+        if text in {"true", "false"}:
+            return "Boolean"
+        if re.fullmatch(r"-?\d+", text):
+            return "Int"
+        if re.fullmatch(r"-?\d+\.\d+[fF]", text):
+            return "Float"
+        if re.fullmatch(r"-?\d+\.\d+", text):
+            return "Double"
+        constructor_match = re.match(r"\b([A-Z]\w*)\s*\(", text)
+        if constructor_match:
+            return constructor_match.group(1)
+        if re.search(r'\.toSet\s*\(\s*\)$', text) or re.match(r'\b(?:setOf|mutableSetOf|hashSetOf|linkedSetOf)\s*\(', text):
+            return "Set"
+        if re.search(r'\.toList\s*\(\s*\)$', text) or re.match(r'\b(?:listOf|mutableListOf|arrayListOf)\s*\(', text):
+            return "List"
+        if re.search(r'\.asSequence\s*\(\s*\)$', text) or re.match(r'\bsequenceOf\s*\(', text):
+            return "Sequence"
+        if re.search(r'\.keys\b$', text):
+            return "Set"
+        if re.search(r'\.values\b$', text):
+            return "Collection"
+        return None
+
+    def function_arg_types(func: Dict[str, Any]) -> List[Optional[str]]:
+        arg_types = func.get("arg_types")
+        if not isinstance(arg_types, list):
+            return []
+        return [simple_type_name(type_name) for type_name in arg_types]
+
+    def function_arg_names(func: Dict[str, Any]) -> List[Optional[str]]:
+        args = func.get("args")
+        if not isinstance(args, list):
+            args = func.get("parameters")
+        if not isinstance(args, list):
+            return []
+        return [arg if isinstance(arg, str) else None for arg in args]
+
+    def arity_compatible_function_candidates(
+        candidates: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        arg_count = call_arg_count()
+        if arg_count is None:
+            return candidates
+        return [
+            candidate
+            for candidate in candidates
+            if (
+                function_required_arg_count(candidate) is not None
+                and function_arg_count(candidate) is not None
+                and function_required_arg_count(candidate) <= arg_count <= function_arg_count(candidate)
+            )
+        ]
+
+    def type_compatibility_score(
+        arg_type: Optional[str],
+        param_type: Optional[str],
+    ) -> Optional[int]:
+        if not arg_type or not param_type:
+            return None
+
+        arg_type = simple_type_name(arg_type)
+        param_type = simple_type_name(param_type)
+        if not arg_type or not param_type:
+            return None
+
+        if arg_type == param_type:
+            return 4
+
+        mutable_equivalents = {
+            "MutableSet": "Set",
+            "LinkedHashSet": "Set",
+            "HashSet": "Set",
+            "MutableList": "List",
+            "ArrayList": "List",
+            "MutableCollection": "Collection",
+        }
+        if mutable_equivalents.get(arg_type) == param_type:
+            return 3
+
+        collection_supertypes = {
+            "Set": {"Iterable", "Collection"},
+            "MutableSet": {"Iterable", "Collection", "MutableCollection"},
+            "List": {"Iterable", "Collection"},
+            "MutableList": {"Iterable", "Collection", "MutableCollection"},
+            "Collection": {"Iterable"},
+            "Map": {"Any"},
+        }
+        if param_type in collection_supertypes.get(arg_type, set()):
+            return 1
+
+        return -1
+
+    def split_named_argument(arg: str) -> Tuple[Optional[str], str]:
+        text = arg.strip()
+        depth_round = depth_square = depth_curly = depth_angle = 0
+        for idx, char in enumerate(text):
+            if char == "(":
+                depth_round += 1
+            elif char == ")":
+                depth_round = max(0, depth_round - 1)
+            elif char == "[":
+                depth_square += 1
+            elif char == "]":
+                depth_square = max(0, depth_square - 1)
+            elif char == "{":
+                depth_curly += 1
+            elif char == "}":
+                depth_curly = max(0, depth_curly - 1)
+            elif char == "<":
+                depth_angle += 1
+            elif char == ">":
+                depth_angle = max(0, depth_angle - 1)
+            elif (
+                char == "="
+                and depth_round == depth_square == depth_curly == depth_angle == 0
+            ):
+                prev_char = text[idx - 1] if idx > 0 else ""
+                next_char = text[idx + 1] if idx + 1 < len(text) else ""
+                if prev_char in {"=", "!", "<", ">"} or next_char in {"=", ">"}:
+                    continue
+                name = text[:idx].strip()
+                expression = text[idx + 1:].strip()
+                if re.fullmatch(r"[A-Za-z_]\w*", name) and expression:
+                    return name, expression
+        return None, text
+
+    def candidate_param_type_for_arg(
+        candidate: Dict[str, Any],
+        arg_idx: int,
+        arg_name: Optional[str],
+    ) -> Optional[str]:
+        param_names = function_arg_names(candidate)
+        param_types = function_arg_types(candidate)
+        if arg_name:
+            for param_name, param_type in zip(param_names, param_types):
+                if param_name == arg_name:
+                    return param_type
+            return None
+        return param_types[arg_idx] if arg_idx < len(param_types) else None
+
+    def score_by_argument_types(
+        candidates: List[Dict[str, Any]]
+    ) -> Optional[List[Tuple[int, Dict[str, Any]]]]:
+        args = call.get("args")
+        explicit_arg_hints = call.get("arg_type_hints")
+        if not isinstance(explicit_arg_hints, list):
+            explicit_arg_hints = []
+        if not isinstance(args, list):
+            args = []
+        if call.get("call_kind") == "callable_reference" and not args and explicit_arg_hints:
+            args = [""] * len(explicit_arg_hints)
+        if not args:
+            return None
+        parsed_args = [split_named_argument(arg) for arg in args]
+        arg_hints = [
+            simple_type_name(explicit_arg_hints[idx])
+            if idx < len(explicit_arg_hints) and explicit_arg_hints[idx]
+            else expression_type_hint(expression)
+            for idx, (_, expression) in enumerate(parsed_args)
+        ]
+        for idx, (arg_name, expression) in enumerate(parsed_args):
+            if arg_hints[idx] and not arg_name:
+                continue
+
+            if arg_name:
+                inferred_from_named_param = {
+                    param_type
+                    for candidate in candidates
+                    for param_name, param_type in zip(
+                        function_arg_names(candidate),
+                        function_arg_types(candidate),
+                    )
+                    if param_name == arg_name
+                }
+                if len(inferred_from_named_param) == 1:
+                    arg_hints[idx] = arg_hints[idx] or inferred_from_named_param.pop()
+                continue
+
+            if arg_hints[idx] or not re.fullmatch(r"[A-Za-z_]\w*", expression.strip()):
+                continue
+
+            inferred_from_name = {
+                param_type
+                for candidate in candidates
+                for param_type in function_arg_types(candidate)[idx:idx + 1]
+                if lower_camel_type_name(param_type) == expression.strip()
+            }
+            if len(inferred_from_name) == 1:
+                arg_hints[idx] = inferred_from_name.pop()
+                continue
+
+            inferred_from_param_name = {
+                param_type
+                for candidate in candidates
+                for param_name, param_type in zip(
+                    function_arg_names(candidate)[idx:idx + 1],
+                    function_arg_types(candidate)[idx:idx + 1],
+                )
+                if param_name == expression.strip()
+            }
+            if len(inferred_from_param_name) == 1:
+                arg_hints[idx] = inferred_from_param_name.pop()
+        if not any(arg_hints):
+            return None
+
+        scored_candidates = []
+        for candidate in candidates:
+            param_types = function_arg_types(candidate)
+            if len(param_types) < len(arg_hints):
+                continue
+
+            score = 0
+            comparable = False
+            compatible = True
+            for idx, (arg_hint, (arg_name, _)) in enumerate(zip(arg_hints, parsed_args)):
+                param_type = candidate_param_type_for_arg(candidate, idx, arg_name)
+                if arg_name and param_type is None:
+                    compatible = False
+                    break
+                compatibility = type_compatibility_score(arg_hint, param_type)
+                if compatibility is None:
+                    continue
+                comparable = True
+                if compatibility < 0:
+                    compatible = False
+                    break
+                score += compatibility
+
+            if comparable and compatible:
+                scored_candidates.append((score, candidate))
+
+        return scored_candidates
+
+    def select_by_argument_types(
+        candidates: List[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        scored_candidates = score_by_argument_types(candidates)
+        if not scored_candidates:
+            return None
+
+        best_score = max(score for score, _ in scored_candidates)
+        best_candidates = [
+            candidate
+            for score, candidate in scored_candidates
+            if score == best_score
+        ]
+        return best_candidates[0] if len(best_candidates) == 1 else None
+
+    def call_has_argument_type_hints() -> bool:
+        args = call.get("args")
+        explicit_arg_hints = call.get("arg_type_hints")
+        if (
+            call.get("call_kind") == "callable_reference"
+            and isinstance(explicit_arg_hints, list)
+            and explicit_arg_hints
+        ):
+            return True
+        if not isinstance(args, list):
+            return False
+        if isinstance(explicit_arg_hints, list) and any(explicit_arg_hints):
+            return True
+        return any(
+            expression_type_hint(split_named_argument(arg)[1])
+            for arg in args
+        )
+
+    def call_has_strict_argument_type_hints() -> bool:
+        explicit_arg_hints = call.get("arg_type_hints")
+        if (
+            call.get("call_kind") == "callable_reference"
+            and isinstance(explicit_arg_hints, list)
+            and any(explicit_arg_hints)
+        ):
+            return True
+        args = call.get("args")
+        if not isinstance(args, list):
+            return False
+        return any(
+            expression_type_hint(split_named_argument(arg)[1])
+            for arg in args
+        )
+
+    def select_function_candidate(candidates: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        if not candidates:
+            return None
+
+        arg_count = call_arg_count()
+        if arg_count is not None:
+            arity_compatible = arity_compatible_function_candidates(candidates)
+            selected_by_type = select_by_argument_types(arity_compatible)
+            if selected_by_type:
+                return selected_by_type
+
+            exact_arity = [
+                candidate
+                for candidate in candidates
+                if function_arg_count(candidate) == arg_count
+            ]
+            if (
+                len(exact_arity) == 1
+                and len(arity_compatible) <= 1
+                and not call_has_strict_argument_type_hints()
+            ):
+                return exact_arity[0]
+            if call_has_argument_type_hints() and any(
+                function_arg_types(candidate)
+                for candidate in arity_compatible
+            ):
+                return None
+            if len(exact_arity) == 1:
+                return exact_arity[0]
+            if len(arity_compatible) == 1:
+                return arity_compatible[0]
+
+        if len(candidates) == 1:
+            return candidates[0]
+        return None
+
+    def target_hint_for_function(
+        path: Optional[str],
+        method_name: str,
+        context_hint: Optional[str],
+        line_hint: Optional[int],
+    ) -> Tuple[Optional[int], Optional[str], bool]:
+        if not path:
+            return line_hint, context_hint, False
+
+        candidates = function_index.get((str(Path(path).resolve()), method_name), [])
+        if not candidates:
+            return line_hint, context_hint, False
+
+        if context_hint:
+            context_candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.get("context") == context_hint
+            ]
+            if context_candidates:
+                candidates = context_candidates
+
+        owner_line = call_enclosing_class_line()
+        if owner_line is not None:
+            owner_candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.get("class_context_line") == owner_line
+            ]
+            if owner_candidates:
+                candidates = owner_candidates
+
+        if line_hint is not None:
+            return line_hint, context_hint, False
+
+        if context_hint is None:
+            top_level_candidates = [
+                candidate for candidate in candidates
+                if candidate.get("context") is None
+            ]
+            if len(top_level_candidates) == 1:
+                candidates = top_level_candidates
+
+        selected = select_function_candidate(candidates)
+        if selected:
+            return selected.get("line_number"), selected.get("context") or context_hint, False
+        return None, context_hint, len(candidates) > 1
+
+    def target_hint_for_class(
+        path: Optional[str],
+        class_name: str,
+        line_hint: Optional[int],
+    ) -> Tuple[Optional[int], bool]:
+        if not path:
+            return line_hint, False
+        if line_hint is not None:
+            return line_hint, False
+
+        class_key = simple_type_key(class_name) or class_name
+        candidates = class_index.get((str(Path(path).resolve()), class_key), [])
+        if not candidates:
+            return None, False
+
+        call_class_context = call.get("class_context")
+        enclosing_class_line = (
+            call_class_context[1]
+            if isinstance(call_class_context, tuple) and len(call_class_context) >= 2
+            else None
+        )
+        if enclosing_class_line is not None:
+            owner_candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.get("class_context_line") == enclosing_class_line
+            ]
+            if len(owner_candidates) == 1:
+                return owner_candidates[0].get("line_number"), False
+            if owner_candidates:
+                candidates = owner_candidates
+
+        enclosing_class = call.get("enclosing_class")
+        if enclosing_class:
+            owner_candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.get("class_context") == enclosing_class
+            ]
+            if len(owner_candidates) == 1:
+                return owner_candidates[0].get("line_number"), False
+            if owner_candidates:
+                candidates = owner_candidates
+
+        if len(candidates) == 1:
+            return candidates[0].get("line_number"), False
+
+        top_level_candidates = [
+            candidate
+            for candidate in candidates
+            if not candidate.get("class_context")
+        ]
+        if len(top_level_candidates) == 1:
+            return top_level_candidates[0].get("line_number"), False
+
+        return None, True
+
+    def call_enclosing_class_line() -> Optional[int]:
+        class_context = call.get("class_context")
+        if isinstance(class_context, tuple) and len(class_context) >= 2:
+            line_number = class_context[1]
+            return line_number if isinstance(line_number, int) else None
+        return None
+
+    def filter_method_candidates_by_call_owner(
+        candidates: List[Dict[str, Any]],
+        current_type: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        owner_line = call_enclosing_class_line()
+        if owner_line is None:
+            return candidates
+        if simple_type_key(current_type) != call.get("enclosing_class"):
+            return candidates
+        owner_candidates = [
+            candidate
+            for candidate in candidates
+            if candidate.get("class_context_line") == owner_line
+        ]
+        return owner_candidates or candidates
+
+    def method_target_for_type(
+        type_name: Optional[str],
+        method_name: str,
+    ) -> Tuple[Optional[str], Optional[int], Optional[str]]:
+        nonlocal unresolved_overloaded_callable_reference, unresolved_overloaded_method
+        if not type_name:
+            return None, None, None
+
+        visited = set()
+        queue = [type_name]
+        method_candidates_by_hierarchy: List[Dict[str, Any]] = []
+        extension_candidates_by_hierarchy: List[Dict[str, Any]] = []
+        fallback_method_owner_path: Optional[str] = None
+        fallback_method_context: Optional[str] = None
+        while queue:
+            current = canonical_type(queue.pop(0))
+            if not current or current in visited:
+                continue
+            visited.add(current)
+
+            method_candidates = class_method_index.get((current, method_name), [])
+            if method_candidates:
+                method_candidates_by_hierarchy.extend(
+                    filter_method_candidates_by_call_owner(
+                        method_candidates,
+                        current,
+                    )
+                )
+
+            if not fallback_method_owner_path and method_name in class_method_names.get(current, set()):
+                method_owner_path = first_import_path(current)
+                if method_owner_path:
+                    fallback_method_owner_path = method_owner_path
+                    fallback_method_context = simple_type_key(current)
+
+            extension_candidates = extension_method_index.get((current, method_name), [])
+            if extension_candidates:
+                extension_candidates_by_hierarchy.extend(extension_candidates)
+
+            for base_name in global_class_bases.get(current, []):
+                base_type = canonical_type(base_name)
+                if base_type and base_type not in visited:
+                    queue.append(base_type)
+
+        if method_candidates_by_hierarchy:
+            selected = select_function_candidate(method_candidates_by_hierarchy)
+            if selected:
+                return (
+                    selected.get("path"),
+                    selected.get("line_number"),
+                    selected.get("context") or simple_type_key(type_name),
+                )
+
+            arity_compatible_members = arity_compatible_function_candidates(
+                method_candidates_by_hierarchy
+            )
+            member_type_scores = (
+                score_by_argument_types(arity_compatible_members)
+                if any(function_arg_types(candidate) for candidate in arity_compatible_members)
+                else None
+            )
+            members_are_inapplicable = (
+                not arity_compatible_members
+                or member_type_scores == []
+            )
+            if not (extension_candidates_by_hierarchy and members_are_inapplicable):
+                if call.get("call_kind") == "callable_reference":
+                    unresolved_overloaded_callable_reference = True
+                else:
+                    unresolved_overloaded_method = True
+                return None, None, None
+
+        if fallback_method_owner_path:
+            return fallback_method_owner_path, None, fallback_method_context
+
+        if extension_candidates_by_hierarchy:
+            selected = select_function_candidate(extension_candidates_by_hierarchy)
+            if selected:
+                return selected.get("path"), selected.get("line_number"), selected.get("context")
+            if call.get("call_kind") == "callable_reference":
+                unresolved_overloaded_callable_reference = True
+            else:
+                unresolved_overloaded_method = True
+            return None, None, None
+
+        return None, None, None
+
+    extension_receiver_type = canonical_type(extension_receiver_type)
+    if (
+        not extension_receiver_type
+        and base_obj
+        and re.fullmatch(r"[A-Za-z_]\w*", base_obj)
+    ):
+        receiver_type_candidates = {
+            receiver_type
+            for receiver_type, method_name in extension_method_index
+            if method_name == called_name
+        }
+        matching_receiver_type = unique_lower_camel_receiver_type(
+            receiver_type_candidates,
+            base_obj,
+        )
+        if matching_receiver_type:
+            extension_receiver_type = canonical_type(matching_receiver_type)
+    extension_receiver_simple = simple_type_key(extension_receiver_type)
+    extension_receiver_lookup_types = [
+        receiver_type
+        for receiver_type in (extension_receiver_type, extension_receiver_simple)
+        if receiver_type
+    ]
+    extension_receiver_lookup_types = list(dict.fromkeys(extension_receiver_lookup_types))
+    same_package_extension_names = [
+        f"{caller_package}.{receiver_type}.{called_name}"
+        for receiver_type in extension_receiver_lookup_types
+        if caller_package and "." not in strip_type_modifiers(receiver_type)
+    ]
+    extension_lookup_names = [
+        f"{receiver_type}.{called_name}"
+        for receiver_type in extension_receiver_lookup_types
+    ]
+    wildcard_extension_path = (
+        first_import_path(
+            *(
+                f"{package_name}.{receiver_type}.{called_name}"
+                for package_name in wildcard_imports
+                for receiver_type in extension_receiver_lookup_types
+                if "." not in strip_type_modifiers(receiver_type)
+            )
+        )
+        if extension_receiver_lookup_types and wildcard_imports
+        else None
+    )
+    wildcard_call_path = (
+        first_import_path(
+            *(f"{package_name}.{called_name}" for package_name in wildcard_imports)
+        )
+        if wildcard_imports
+        else None
+    )
+
+    member_receiver_type = None
+    receiver_base_type = call.get("receiver_base_type")
+    receiver_member_name = call.get("receiver_member_name")
+    receiver_member_kind = call.get("receiver_member_kind")
+    if receiver_base_type and receiver_member_name:
+        receiver_base_type = canonical_type(receiver_base_type)
+        if receiver_member_kind == "function":
+            member_receiver_type = member_type_for_owner(
+                member_return_types,
+                receiver_base_type,
+                receiver_member_name,
+            )
+        elif receiver_member_kind == "property":
+            member_receiver_type = member_type_for_owner(
+                member_property_types,
+                receiver_base_type,
+                receiver_member_name,
+            )
+        if member_receiver_type:
+            member_receiver_type = canonical_type(member_receiver_type)
+        elif receiver_member_kind == "property":
+            receiver_type_candidates = {
+                receiver_type
+                for receiver_type, method_name in extension_method_index
+                if method_name == called_name
+            }
+            matching_receiver_type = unique_lower_camel_receiver_type(
+                receiver_type_candidates,
+                receiver_member_name,
+            )
+            if matching_receiver_type:
+                member_receiver_type = canonical_type(matching_receiver_type)
+
+    if extension_receiver_type:
+        (
+            resolved_path,
+            resolved_called_line_number,
+            resolved_called_context,
+        ) = method_target_for_type(extension_receiver_type, called_name)
+        if resolved_path:
+            resolution_tier = 4
+        else:
+            receiver_resolution_failed = True
+
+    if not resolved_path and imported_extension_name and imported_extension_name in imports_map:
+        possible_paths = imports_map[imported_extension_name]
+        if possible_paths:
+            resolved_path = possible_paths[0]
+            resolved_called_name = imported_extension_name.split(".")[-1]
+            resolution_tier = 6
+    elif not resolved_path and any(name in imports_map for name in same_package_extension_names):
+        possible_paths = first_import_path(*same_package_extension_names)
+        if possible_paths:
+            resolved_path = possible_paths
+            resolution_tier = 5
+    elif not resolved_path and wildcard_extension_path:
+        resolved_path = wildcard_extension_path
+        resolution_tier = 6
+    elif not resolved_path and any(name in imports_map for name in extension_lookup_names):
+        possible_path = first_import_path(*extension_lookup_names)
+        if possible_path:
+            resolved_path = possible_path
+            resolution_tier = 4
+
+    if not resolved_path and call.get("implicit_receiver_type"):
+        implicit_type = canonical_type(call["implicit_receiver_type"])
+        (
+            resolved_path,
+            resolved_called_line_number,
+            resolved_called_context,
+        ) = method_target_for_type(implicit_type, called_name)
+        if resolved_path:
+            resolution_tier = 4
+        elif unresolved_overloaded_callable_reference or unresolved_overloaded_method:
+            record_skip(
+                "unresolved_overloaded_callable_reference"
+                if unresolved_overloaded_callable_reference
+                else "unresolved_overloaded_call",
+                receiver_type=implicit_type,
+                arg_type_hints=call.get("arg_type_hints", []),
+            )
+            return None
+        else:
+            receiver_resolution_failed = True
+
+    if not resolved_path and not base_obj and call.get("enclosing_class"):
+        (
+            resolved_path,
+            resolved_called_line_number,
+            resolved_called_context,
+        ) = method_target_for_type(call.get("enclosing_class"), called_name)
+        if resolved_path:
+            resolution_tier = 2
+        elif unresolved_overloaded_callable_reference or unresolved_overloaded_method:
+            record_skip(
+                "unresolved_overloaded_callable_reference"
+                if unresolved_overloaded_callable_reference
+                else "unresolved_overloaded_call",
+                receiver_type=call.get("enclosing_class"),
+                arg_type_hints=call.get("arg_type_hints", []),
+            )
+            return None
+
+    if not resolved_path and (unresolved_overloaded_callable_reference or unresolved_overloaded_method):
+        record_skip(
+            "unresolved_overloaded_callable_reference"
+            if unresolved_overloaded_callable_reference
+            else "unresolved_overloaded_call",
+            receiver_type=(
+                extension_receiver_type
+                or canonical_type(call.get("inferred_obj_type"))
+                or canonical_type(call.get("implicit_receiver_type"))
+                or member_receiver_type
+            ),
+            arg_type_hints=call.get("arg_type_hints", []),
+        )
+        return None
+
+    if not resolved_path and receiver_resolution_failed:
+        if unresolved_overloaded_callable_reference or unresolved_overloaded_method:
+            record_skip(
+                "unresolved_overloaded_callable_reference"
+                if unresolved_overloaded_callable_reference
+                else "unresolved_overloaded_call",
+                receiver_type=(
+                    extension_receiver_type
+                    or canonical_type(call.get("inferred_obj_type"))
+                    or canonical_type(call.get("implicit_receiver_type"))
+                    or member_receiver_type
+                ),
+                arg_type_hints=call.get("arg_type_hints", []),
+            )
+            return None
+        receiver_type_for_path = (
+            extension_receiver_type
+            or canonical_type(call.get("inferred_obj_type"))
+            or canonical_type(call.get("implicit_receiver_type"))
+            or member_receiver_type
+        )
+        possible_paths = imports_map.get(receiver_type_for_path, []) if receiver_type_for_path else []
+        if possible_paths:
+            resolved_path = possible_paths[0]
+            resolution_tier = 4
+            receiver_resolution_failed = False
+
+    if not resolved_path and receiver_resolution_failed:
+        if call.get("call_kind") == "callable_reference":
+            record_skip(
+                "receiver_resolution_failed",
+                receiver_type=(
+                    extension_receiver_type
+                    or canonical_type(call.get("inferred_obj_type"))
+                    or canonical_type(call.get("implicit_receiver_type"))
+                    or member_receiver_type
+                ),
+            )
+        return None
+
+    if not resolved_path and member_receiver_type:
+        (
+            resolved_path,
+            resolved_called_line_number,
+            resolved_called_context,
+        ) = method_target_for_type(member_receiver_type, called_name)
+        if resolved_path:
+            resolution_tier = 4
+        elif unresolved_overloaded_callable_reference or unresolved_overloaded_method:
+            record_skip(
+                "unresolved_overloaded_callable_reference"
+                if unresolved_overloaded_callable_reference
+                else "unresolved_overloaded_call",
+                receiver_type=member_receiver_type,
+                arg_type_hints=call.get("arg_type_hints", []),
+            )
+            return None
         if not resolved_path:
-            possible_paths = imports_map.get(obj_type, [])
+            possible_paths = imports_map.get(member_receiver_type, [])
             if possible_paths:
                 resolved_path = possible_paths[0]
                 resolution_tier = 4
+        if not resolved_path:
+            receiver_resolution_failed = True
 
-    # ── Tier 5/6/7: lookup by call-site name (no inferred type) ───────────────
+    if not resolved_path and (unresolved_overloaded_callable_reference or unresolved_overloaded_method):
+        record_skip(
+            "unresolved_overloaded_callable_reference"
+            if unresolved_overloaded_callable_reference
+            else "unresolved_overloaded_call",
+            receiver_type=(
+                extension_receiver_type
+                or canonical_type(call.get("inferred_obj_type"))
+                or canonical_type(call.get("implicit_receiver_type"))
+                or member_receiver_type
+            ),
+            arg_type_hints=call.get("arg_type_hints", []),
+        )
+        return None
+
+    if not resolved_path and imported_call_name and imported_call_name in imports_map:
+        possible_paths = imports_map[imported_call_name]
+        if possible_paths:
+            resolved_path = possible_paths[0]
+            resolved_called_name = imported_call_name.split(".")[-1]
+            resolution_tier = 6
+    elif not resolved_path and same_package_call_name and same_package_call_name in imports_map:
+        possible_paths = imports_map[same_package_call_name]
+        if possible_paths:
+            resolved_path = possible_paths[0]
+            resolution_tier = 5
+    elif not resolved_path and wildcard_call_path:
+        resolved_path = wildcard_call_path
+        resolution_tier = 6
+    elif not resolved_path and base_obj and base_obj in local_imports:
+        full_import_name = local_imports[base_obj]
+        possible_paths = imports_map.get(full_import_name, [])
+        if possible_paths:
+            resolved_path = possible_paths[0]
+            resolution_tier = 6
+    elif not resolved_path and base_obj == "super":
+        enclosing_class = call.get("enclosing_class")
+        for base_name in local_class_bases.get(enclosing_class, []):
+            base_name = strip_type_modifiers(base_name)
+            (
+                resolved_path,
+                resolved_called_line_number,
+                resolved_called_context,
+            ) = method_target_for_type(base_name, called_name)
+            if resolved_path:
+                resolution_tier = 4
+                break
+
+            possible_paths = imports_map.get(base_name, [])
+            if not possible_paths and caller_package:
+                possible_paths = imports_map.get(f"{caller_package}.{base_name}", [])
+            if possible_paths:
+                resolved_path = possible_paths[0]
+                resolved_called_context = simple_type_key(canonical_type(base_name))
+                resolution_tier = 4
+                break
+        if not resolved_path:
+            resolved_path = caller_file_path
+            resolution_tier = 1
+    elif not resolved_path and base_obj in ("self", "this", "super()", "cls", "@") and not is_chained_call:
+        resolved_path = caller_file_path
+        resolved_called_context = call.get("enclosing_class")
+        resolution_tier = 1
+    elif not resolved_path and lookup_name in local_names:
+        resolved_path = caller_file_path
+        resolution_tier = 2
+    elif not resolved_path and call.get("inferred_obj_type"):
+        raw_obj_type = call["inferred_obj_type"]
+        obj_type = canonical_type(raw_obj_type)
+        (
+            resolved_path,
+            resolved_called_line_number,
+            resolved_called_context,
+        ) = method_target_for_type(obj_type, called_name)
+        if resolved_path:
+            resolution_tier = 4
+        elif unresolved_overloaded_callable_reference or unresolved_overloaded_method:
+            record_skip(
+                "unresolved_overloaded_callable_reference"
+                if unresolved_overloaded_callable_reference
+                else "unresolved_overloaded_call",
+                receiver_type=obj_type,
+                arg_type_hints=call.get("arg_type_hints", []),
+            )
+            return None
+        if not resolved_path and raw_obj_type in local_imports:
+            fqn_paths = imports_map.get(local_imports[raw_obj_type], [])
+            if len(fqn_paths) == 1:
+                resolved_path = fqn_paths[0]
+                resolution_tier = 3
+        if not resolved_path:
+            possible_paths = imports_map.get(obj_type, [])
+            if len(possible_paths) > 0:
+                resolved_path = possible_paths[0]
+                resolution_tier = 4
+        if not resolved_path:
+            receiver_resolution_failed = True
+
+    if not resolved_path and (unresolved_overloaded_callable_reference or unresolved_overloaded_method):
+        record_skip(
+            "unresolved_overloaded_callable_reference"
+            if unresolved_overloaded_callable_reference
+            else "unresolved_overloaded_call",
+            receiver_type=(
+                extension_receiver_type
+                or canonical_type(call.get("inferred_obj_type"))
+                or canonical_type(call.get("implicit_receiver_type"))
+                or member_receiver_type
+            ),
+            arg_type_hints=call.get("arg_type_hints", []),
+        )
+        return None
+
+    if not resolved_path and receiver_resolution_failed:
+        if call.get("call_kind") == "callable_reference":
+            record_skip(
+                "receiver_resolution_failed",
+                receiver_type=(
+                    extension_receiver_type
+                    or canonical_type(call.get("inferred_obj_type"))
+                    or canonical_type(call.get("implicit_receiver_type"))
+                    or member_receiver_type
+                ),
+            )
+        return None
+
     if not resolved_path:
         if lookup_name in local_imports:
             resolved_called_name = local_imports[lookup_name]
@@ -97,61 +1181,102 @@ def resolve_function_call(
                 lookup_name = imported_name
                 resolved_called_name = imported_name
         if len(possible_paths) == 1:
-            # Tier 5: globally unique short name — high confidence
             resolved_path = possible_paths[0]
             resolution_tier = 5
-        elif len(possible_paths) > 1 and lookup_name in local_imports:
-            full_import_name = local_imports[lookup_name]
-            # Tier 6: FQN key in imports_map (added by Phase 1 pre_scan changes)
-            fqn_paths = imports_map.get(full_import_name, [])
-            if fqn_paths and len(fqn_paths) == 1:
-                resolved_path = fqn_paths[0]
-                resolution_tier = 6
-            # Tier 7: FQN as path-substring across candidates
-            if not resolved_path:
-                fqn_as_path = full_import_name.replace(".", "/")
-                for p in possible_paths:
-                    if fqn_as_path in p:
-                        resolved_path = p
-                        resolution_tier = 7
-                        break
+        elif len(possible_paths) > 1:
+            if lookup_name in local_imports:
+                full_import_name = local_imports[lookup_name]
+                if full_import_name in imports_map:
+                    direct_paths = imports_map[full_import_name]
+                    if direct_paths and len(direct_paths) == 1:
+                        resolved_path = direct_paths[0]
+                        resolution_tier = 6
+                if not resolved_path:
+                    for path in possible_paths:
+                        if full_import_name.replace(".", "/") in path:
+                            resolved_path = path
+                            resolution_tier = 7
+                            break
 
-    # ── Tier 8/9: last-resort fallbacks ────────────────────────────────────────
+    if not resolved_path:
+        is_unresolved_external = True
+    else:
+        is_unresolved_external = False
+
+    if not resolved_path:
+        possible_paths = imports_map.get(lookup_name, [])
+        if len(possible_paths) > 0:
+            if lookup_name in local_imports:
+                pass
+            else:
+                pass
     if not resolved_path:
         if called_name in local_names:
-            # Re-check with the bare called_name (covers chained-call edge cases)
             resolved_path = caller_file_path
+            is_unresolved_external = False
             resolution_tier = 2
-        elif resolved_called_name in imports_map and imports_map[resolved_called_name]:
-            candidates = imports_map[resolved_called_name]
-            # Try to match any candidate via a local import path hint
-            for p in candidates:
-                for imp_fqn in local_imports.values():
-                    if imp_fqn.replace(".", "/") in p:
-                        resolved_path = p
+        elif called_name in imports_map and imports_map[called_name]:
+            candidates = imports_map[called_name]
+            for path in candidates:
+                for imp_name in local_imports.values():
+                    if imp_name.replace(".", "/") in path:
+                        resolved_path = path
+                        is_unresolved_external = False
                         resolution_tier = 7
                         break
                 if resolved_path:
                     break
-            # Tier 8: alphabetical first of multiple candidates
             if not resolved_path:
                 resolved_path = candidates[0]
                 resolution_tier = 8
         else:
-            # Tier 9: same-file fallback — wrong for any obj.method() call
             resolved_path = caller_file_path
             resolution_tier = 9
 
-    # Determine whether this resolution is "external" (unresolvable target).
-    # Tier 9 for non-self/super calls means we gave up — treat as external.
-    is_unresolved_external = (
-        resolution_tier == 9
-        and base_obj not in ("self", "this", "super", "super()", "cls", "@")
-    )
-
     if skip_external and is_unresolved_external:
+        record_skip("skip_external_unresolved")
         return None
 
+    class_target_key = simple_type_key(resolved_called_name) or resolved_called_name
+    target_is_class = bool(
+        resolved_path
+        and class_index.get((str(Path(resolved_path).resolve()), class_target_key), [])
+    )
+    if target_is_class:
+        (
+            resolved_called_line_number,
+            ambiguous_class_target,
+        ) = target_hint_for_class(
+            resolved_path,
+            resolved_called_name,
+            resolved_called_line_number,
+        )
+        if ambiguous_class_target:
+            record_skip(
+                "ambiguous_class_target",
+                called_name=resolved_called_name,
+                called_file_path=resolved_path,
+            )
+            return None
+        resolved_called_name = class_target_key
+    else:
+        (
+            resolved_called_line_number,
+            resolved_called_context,
+            ambiguous_function_target,
+        ) = target_hint_for_function(
+            resolved_path,
+            resolved_called_name,
+            resolved_called_context,
+            resolved_called_line_number,
+        )
+        if ambiguous_function_target:
+            record_skip(
+                "ambiguous_function_target",
+                called_name=resolved_called_name,
+                called_file_path=resolved_path,
+            )
+            return None
     confidence = _TIER_CONFIDENCE.get(resolution_tier, 0.1)
     conf_label = _confidence_label(resolution_tier, is_unresolved_external)
 
@@ -165,6 +1290,8 @@ def resolve_function_call(
             "caller_line_number": caller_line_number,
             "called_name": resolved_called_name,
             "called_file_path": resolved_path,
+            "called_line_number": resolved_called_line_number,
+            "called_context": resolved_called_context,
             "line_number": call["line_number"],
             "args": call.get("args", []),
             "full_call_name": call.get("full_name", called_name),
@@ -177,6 +1304,8 @@ def resolve_function_call(
         "caller_file_path": caller_file_path,
         "called_name": resolved_called_name,
         "called_file_path": resolved_path,
+        "called_line_number": resolved_called_line_number,
+        "called_context": resolved_called_context,
         "line_number": call["line_number"],
         "args": call.get("args", []),
         "full_call_name": call.get("full_name", called_name),
@@ -190,6 +1319,7 @@ def build_function_call_groups(
     all_file_data: List[Dict[str, Any]],
     imports_map: dict,
     file_class_lookup: Optional[Dict[str, set]] = None,
+    diagnostics: Optional[List[Dict[str, Any]]] = None,
 ) -> Tuple[
     List[Dict],
     List[Dict],
@@ -206,6 +1336,339 @@ def build_function_call_groups(
     for fd in all_file_data:
         fp = str(Path(fd["path"]).resolve())
         file_class_lookup[fp] = {c["name"] for c in fd.get("classes", [])}
+
+    type_aliases: Dict[str, str] = {}
+    for fd in all_file_data:
+        for typealias in fd.get("typealiases", []):
+            alias_name = typealias.get("name")
+            target = typealias.get("target")
+            if not alias_name or not target:
+                continue
+            target = strip_type_modifiers(target)
+            type_aliases[alias_name] = target
+            package_name = typealias.get("package")
+            if package_name:
+                type_aliases[f"{package_name}.{alias_name}"] = target
+
+    def canonical_type_for_maps(
+        type_name: Optional[str],
+        local_imports: Optional[dict] = None,
+        package_name: Optional[str] = None,
+    ) -> Optional[str]:
+        if not type_name:
+            return None
+        normalized = strip_type_modifiers(type_name)
+        if not normalized:
+            return None
+        candidates = [normalized]
+        if local_imports:
+            imported = local_imports.get(normalized)
+            if imported:
+                candidates.insert(0, imported)
+        if package_name and "." not in normalized:
+            candidates.append(f"{package_name}.{normalized}")
+
+        for candidate in candidates:
+            target = type_aliases.get(candidate)
+            if target:
+                target = strip_type_modifiers(target)
+                if not target:
+                    return None
+                imported_target = local_imports.get(target) if local_imports else None
+                if imported_target and strip_type_modifiers(imported_target) in imports_map:
+                    return strip_type_modifiers(imported_target)
+                if "." in target and target in imports_map:
+                    return target
+                same_package_target = f"{package_name}.{target}" if package_name else None
+                if same_package_target and same_package_target in imports_map:
+                    return same_package_target
+                return target.split(".")[-1]
+        if local_imports:
+            imported = local_imports.get(normalized)
+            if imported and strip_type_modifiers(imported) in imports_map:
+                return strip_type_modifiers(imported)
+        if "." in normalized and normalized in imports_map:
+            return normalized
+        same_package_name = f"{package_name}.{normalized}" if package_name else None
+        if same_package_name and same_package_name in imports_map:
+            return same_package_name
+        return normalized.split(".")[-1]
+
+    def simple_type_key(type_name: Optional[str]) -> Optional[str]:
+        if not type_name:
+            return None
+        normalized = strip_type_modifiers(type_name)
+        return normalized.split(".")[-1] if normalized else None
+
+    def type_keys_for_maps(
+        type_name: Optional[str],
+        local_imports: Optional[dict] = None,
+        package_name: Optional[str] = None,
+    ) -> List[str]:
+        canonical = canonical_type_for_maps(type_name, local_imports, package_name)
+        simple = simple_type_key(type_name) or simple_type_key(canonical)
+        keys: List[str] = []
+        for key in (canonical, simple):
+            if key and key not in keys:
+                keys.append(key)
+        return keys
+
+    def file_local_imports(fd: Dict[str, Any]) -> Dict[str, str]:
+        return {
+            imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
+            for imp in fd.get("imports", [])
+            if not imp["name"].endswith(".*")
+        }
+
+    def file_package(fd: Dict[str, Any]) -> Optional[str]:
+        return fd.get("package") or fd.get("package_name")
+
+    def normalize_full_type(type_name: Optional[str]) -> Optional[str]:
+        if not type_name or type_name == "Unknown":
+            return None
+        text = str(type_name).strip()
+        while text.endswith("?"):
+            text = text[:-1].strip()
+        return text or None
+
+    def split_generic_args(type_name: str) -> List[str]:
+        start = type_name.find("<")
+        end = type_name.rfind(">")
+        if start == -1 or end == -1 or end <= start:
+            return []
+        inner = type_name[start + 1:end]
+        args: List[str] = []
+        current = []
+        depth = 0
+        for char in inner:
+            if char == "<":
+                depth += 1
+            elif char == ">":
+                depth = max(0, depth - 1)
+            if char == "," and depth == 0:
+                arg = "".join(current).strip()
+                if arg:
+                    args.append(arg)
+                current = []
+            else:
+                current.append(char)
+        arg = "".join(current).strip()
+        if arg:
+            args.append(arg)
+        return args
+
+    def collection_element_type(
+        type_name: Optional[str],
+        local_imports: Optional[dict] = None,
+        package_name: Optional[str] = None,
+    ) -> Optional[str]:
+        full_type = normalize_full_type(type_name)
+        if not full_type:
+            return None
+        base_type = canonical_type_for_maps(full_type, local_imports, package_name)
+        args = split_generic_args(full_type)
+        if not args:
+            return None
+        if simple_type_key(base_type) in {
+            "Array",
+            "Collection",
+            "Flow",
+            "Iterable",
+            "List",
+            "MutableCollection",
+            "MutableIterable",
+            "MutableList",
+            "MutableSet",
+            "Sequence",
+            "Set",
+        }:
+            return canonical_type_for_maps(args[0], local_imports, package_name)
+        return None
+
+    def collection_type_from_operator(
+        source_type: Optional[str],
+        operator: Optional[str],
+    ) -> Optional[str]:
+        element_type = collection_element_type(source_type)
+        if not element_type:
+            return None
+        if operator == "toSet":
+            return f"Set<{element_type}>"
+        if operator == "asSequence":
+            return f"Sequence<{element_type}>"
+        return f"List<{element_type}>"
+
+    member_return_types: Dict[Tuple[Optional[str], str], str] = {}
+    member_return_types_full: Dict[Tuple[Optional[str], str], str] = {}
+    member_property_types: Dict[Tuple[Optional[str], str], str] = {}
+    global_class_bases: Dict[str, List[str]] = {}
+    class_method_names: Dict[str, set] = {}
+    function_index: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    class_index: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    class_method_index: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    extension_method_index: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    global_variable_types: Dict[str, str] = {}
+
+    def companion_owner_context_names(
+        fd: Dict[str, Any],
+        func: Dict[str, Any],
+        package_name: Optional[str],
+    ) -> List[str]:
+        if func.get("line_number") is None:
+            return []
+
+        line_number = func["line_number"]
+        companion_objects = [
+            class_data
+            for class_data in fd.get("classes", [])
+            if (
+                class_data.get("node_type") == "companion_object"
+                or (
+                    class_data.get("node_type") is None
+                    and class_data.get("name") == "Companion"
+                )
+            )
+            and class_data.get("line_number") is not None
+            and class_data.get("end_line") is not None
+            and class_data["line_number"] <= line_number <= class_data["end_line"]
+        ]
+        if not companion_objects or func.get("context") not in {
+            companion.get("name") for companion in companion_objects
+        }:
+            return []
+
+        owners = [
+            class_data
+            for class_data in fd.get("classes", [])
+            if class_data not in companion_objects
+            and class_data.get("line_number") is not None
+            and class_data.get("end_line") is not None
+            and class_data["line_number"] <= line_number <= class_data["end_line"]
+        ]
+        if not owners:
+            return []
+
+        owner = min(
+            owners,
+            key=lambda class_data: class_data["end_line"] - class_data["line_number"],
+        )
+        return type_keys_for_maps(owner.get("name"), package_name=package_name)
+
+    def function_context_names_for_maps(
+        fd: Dict[str, Any],
+        func: Dict[str, Any],
+        package_name: Optional[str],
+    ) -> List[str]:
+        context_names = list(type_keys_for_maps(func.get("context"), package_name=package_name))
+        context_names.extend(companion_owner_context_names(fd, func, package_name))
+        return list(dict.fromkeys(context_names))
+
+    for fd in all_file_data:
+        file_path = str(Path(fd["path"]).resolve())
+        package_name = file_package(fd)
+        fd_local_imports = file_local_imports(fd)
+        for class_data in fd.get("classes", []):
+            indexed_class = {**class_data, "path": fd["path"], "package": package_name}
+            for class_name in type_keys_for_maps(
+                class_data.get("name"),
+                package_name=package_name,
+            ):
+                class_index.setdefault((file_path, class_name), []).append(indexed_class)
+            class_keys = type_keys_for_maps(class_data.get("name"), package_name=package_name)
+            if not class_keys:
+                continue
+            base_types = [
+                canonical_type_for_maps(base_name, fd_local_imports, package_name)
+                for base_name in class_data.get("bases", [])
+                if canonical_type_for_maps(base_name, fd_local_imports, package_name)
+            ]
+            for class_name in class_keys:
+                global_class_bases[class_name] = base_types
+        for func in fd.get("functions", []):
+            indexed_func = {**func, "path": fd["path"], "package": package_name}
+            function_index.setdefault((file_path, func["name"]), []).append(indexed_func)
+            context_names = function_context_names_for_maps(fd, func, package_name)
+            for context_name in context_names:
+                class_method_names.setdefault(context_name, set()).add(func["name"])
+                class_method_index.setdefault((context_name, func["name"]), []).append(
+                    indexed_func
+                )
+            receiver_types = type_keys_for_maps(
+                func.get("receiver_type"),
+                fd_local_imports,
+                package_name,
+            )
+            for receiver_type in receiver_types:
+                extension_method_index.setdefault((receiver_type, func["name"]), []).append(
+                    indexed_func
+                )
+        for variable in fd.get("variables", []):
+            if variable.get("context"):
+                continue
+            variable_name = variable.get("name")
+            variable_type = canonical_type_for_maps(
+                variable.get("type") or variable.get("initializer_inferred_type"),
+                fd_local_imports,
+                package_name,
+            )
+            if not variable_name or not variable_type:
+                continue
+            global_variable_types[variable_name] = variable_type
+            if package_name:
+                global_variable_types[f"{package_name}.{variable_name}"] = variable_type
+
+    needs_member_receiver_types = any(
+        call.get("receiver_base_type") and call.get("receiver_member_name")
+        for fd in all_file_data
+        for call in fd.get("function_calls", [])
+    ) or any(
+        fd.get("lang") == "kotlin" and call.get("base_obj")
+        for fd in all_file_data
+        for call in fd.get("function_calls", [])
+    ) or any(
+        variable.get("initializer_receiver_name")
+        and variable.get("initializer_member_name")
+        for fd in all_file_data
+        for variable in fd.get("variables", [])
+    ) or any(
+        variable.get("initializer_collection_receiver_name")
+        and variable.get("initializer_collection_member_name")
+        for fd in all_file_data
+        for variable in fd.get("variables", [])
+    )
+    if needs_member_receiver_types:
+        for fd in all_file_data:
+            package_name = file_package(fd)
+            fd_local_imports = file_local_imports(fd)
+            for func in fd.get("functions", []):
+                return_type = func.get("return_type")
+                if return_type:
+                    return_type_key = canonical_type_for_maps(
+                        return_type,
+                        fd_local_imports,
+                        package_name,
+                    )
+                    full_return_type = normalize_full_type(
+                        func.get("return_type_full") or return_type
+                    )
+                    for context_name in function_context_names_for_maps(fd, func, package_name):
+                        key = (context_name, func["name"])
+                        member_return_types[key] = return_type_key
+                        if full_return_type:
+                            member_return_types_full[key] = full_return_type
+            for variable in fd.get("variables", []):
+                variable_type = variable.get("type")
+                if variable_type:
+                    property_type_key = canonical_type_for_maps(
+                        variable_type,
+                        fd_local_imports,
+                        package_name,
+                    )
+                    for context_name in type_keys_for_maps(
+                        variable.get("context"),
+                        package_name=package_name,
+                    ):
+                        member_property_types[(context_name, variable["name"])] = property_type_key
 
     info_logger(f"[CALLS] Resolving function calls across {len(all_file_data)} files...")
     fn_to_fn: List[Dict] = []
@@ -234,7 +1697,9 @@ def build_function_call_groups(
                 "cpp":        {".cpp", ".h", ".hpp", ".hh"},
                 "c":          {".c"},
                 "c_sharp":    {".cs"},
-                "kotlin":     {".kt"},
+                # Kotlin/JVM projects routinely call Java classes directly; keep
+                # Java targets so explicit Java imports can disambiguate receivers.
+                "kotlin":     {".kt", ".java"},
                 "scala":      {".scala", ".sc"},
                 "ruby":       {".rb"},
                 "swift":      {".swift"},
@@ -267,24 +1732,645 @@ def build_function_call_groups(
         func_names = {f["name"] for f in file_data.get("functions", [])}
         class_names = {c["name"] for c in file_data.get("classes", [])}
         local_names = func_names | class_names
+        local_class_bases = {
+            c["name"]: c.get("bases", []) for c in file_data.get("classes", [])
+        }
         local_imports = {
             imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
             for imp in file_data.get("imports", [])
+            if not imp["name"].endswith(".*")
         }
+        wildcard_imports = [
+            imp["name"][:-2]
+            for imp in file_data.get("imports", [])
+            if imp["name"].endswith(".*")
+        ]
+        if wildcard_imports:
+            local_imports["__wildcards__"] = wildcard_imports
 
         caller_lang = file_data.get("lang", "")
         effective_imports_map = _get_lang_imports(caller_lang) if caller_lang else imports_map
+        caller_package = file_package(file_data)
+
+        local_variable_types: Dict[Tuple[str, Any], str] = {}
+        local_variable_full_types: Dict[Tuple[str, Any], str] = {}
+        local_variable_declarations: Dict[Tuple[str, Any], List[Dict[str, Any]]] = {}
+
+        def function_scope(function: Dict[str, Any]) -> Tuple[Optional[str], Optional[int], Optional[str]]:
+            return (
+                function.get("name"),
+                function.get("line_number"),
+                function.get("context") or function.get("class_context"),
+            )
+
+        def function_scope_for_line(
+            context_name: Optional[str],
+            line_number: Optional[int],
+        ) -> Any:
+            if not context_name or line_number is None:
+                return context_name
+            for function in file_data.get("functions", []):
+                if function.get("name") != context_name:
+                    continue
+                start_line = function.get("line_number")
+                end_line = function.get("end_line", start_line)
+                if start_line is None or end_line is None:
+                    continue
+                if start_line <= line_number <= end_line:
+                    return function_scope(function)
+            return context_name
+
+        def variable_scope(variable: Dict[str, Any]) -> Any:
+            return function_scope_for_line(
+                variable.get("context"),
+                variable.get("line_number"),
+            )
+
+        def call_scope(call: Dict[str, Any]) -> Any:
+            context = call.get("context")
+            if not context or len(context) != 3:
+                return None
+            return function_scope_for_line(context[0], context[2])
+
+        def local_type_values(type_name: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+            if not type_name or type_name == "Unknown":
+                return None, None
+            canonical = canonical_type_for_maps(type_name, local_imports, caller_package)
+            if not canonical:
+                return None, None
+            return canonical, normalize_full_type(type_name)
+
+        def record_local_variable_declaration(
+            name: Optional[str],
+            context: Any,
+            line_number: Optional[int],
+            type_name: Optional[str],
+        ) -> None:
+            if not name:
+                return
+
+            canonical, full_type = local_type_values(type_name)
+            key = (name, context)
+            records = local_variable_declarations.setdefault(key, [])
+            for record in records:
+                if record.get("line_number") == line_number:
+                    if canonical:
+                        record["type"] = canonical
+                    existing_full_type = record.get("full_type")
+                    if full_type and (
+                        not existing_full_type
+                        or ("<" in full_type and "<" not in existing_full_type)
+                    ):
+                        record["full_type"] = full_type
+                    return
+            records.append({
+                "line_number": line_number,
+                "type": canonical,
+                "full_type": full_type,
+            })
+
+        def add_local_variable_type(
+            name: Optional[str],
+            context: Any,
+            type_name: Optional[str],
+            line_number: Optional[int] = None,
+        ) -> bool:
+            if not name or not type_name or type_name == "Unknown":
+                return False
+            canonical, full_type = local_type_values(type_name)
+            if not canonical:
+                return False
+            key = (name, context)
+            if local_variable_types.get(key) == canonical:
+                return False
+            local_variable_types[key] = canonical
+            if full_type:
+                local_variable_full_types[key] = full_type
+            if line_number is not None:
+                record_local_variable_declaration(name, context, line_number, type_name)
+            return True
+
+        pending_variable_member_hints = []
+        pending_variable_candidate_hints = []
+        pending_variable_collection_hints = []
+        for import_alias, import_name in local_imports.items():
+            if import_alias == "__wildcards__":
+                continue
+            imported_variable_type = global_variable_types.get(import_name)
+            if imported_variable_type:
+                add_local_variable_type(import_alias, None, imported_variable_type)
+
+        for variable in file_data.get("variables", []):
+            scope = variable_scope(variable)
+            variable_line = variable.get("line_number")
+            record_local_variable_declaration(
+                variable.get("name"),
+                scope,
+                variable_line,
+                variable.get("type"),
+            )
+            add_local_variable_type(
+                variable.get("name"),
+                scope,
+                variable.get("type"),
+                variable_line,
+            )
+            add_local_variable_type(
+                variable.get("name"),
+                scope,
+                variable.get("initializer_inferred_type"),
+                variable_line,
+            )
+            if variable.get("initializer_receiver_name") and variable.get("initializer_member_name"):
+                pending_variable_member_hints.append(variable)
+            if variable.get("initializer_candidate_names"):
+                pending_variable_candidate_hints.append(variable)
+            if variable.get("initializer_collection_receiver_name") and variable.get("initializer_collection_member_name"):
+                pending_variable_collection_hints.append(variable)
+
+        for function in file_data.get("functions", []):
+            scope = function_scope(function)
+            for arg_name, arg_type in zip(
+                function.get("args", []),
+                function.get("arg_types", []),
+            ):
+                record_local_variable_declaration(
+                    arg_name,
+                    scope,
+                    function.get("line_number"),
+                    arg_type,
+                )
+                add_local_variable_type(arg_name, scope, arg_type, function.get("line_number"))
+
+        def lookup_scoped_declaration_value(
+            name: Optional[str],
+            context: Any,
+            line_number: Optional[int],
+            *,
+            full: bool = False,
+        ) -> Tuple[bool, Optional[str]]:
+            if not name or not isinstance(context, tuple) or line_number is None:
+                return False, None
+
+            candidates = [
+                record
+                for record in local_variable_declarations.get((name, context), [])
+                if record.get("line_number") is not None
+                and record["line_number"] <= line_number
+            ]
+            if not candidates:
+                return False, None
+
+            record = max(candidates, key=lambda item: item.get("line_number") or 0)
+            if full:
+                return True, record.get("full_type") or record.get("type")
+            return True, record.get("type")
+
+        def lookup_declared_variable_type(
+            name: Optional[str],
+            context: Any,
+            line_number: Optional[int],
+        ) -> Optional[str]:
+            found, value = lookup_scoped_declaration_value(name, context, line_number)
+            if found:
+                return value
+            return local_variable_types.get((name, context))
+
+        def unique_local_value(
+            mapping: Dict[Tuple[str, Any], str],
+            name: str,
+            context: Any = None,
+            line_number: Optional[int] = None,
+            *,
+            full: bool = False,
+        ) -> Optional[str]:
+            values = set()
+            for (variable_name, scope), value in mapping.items():
+                if variable_name != name or not value:
+                    continue
+                if isinstance(context, tuple) and scope == context and line_number is not None:
+                    found, scoped_value = lookup_scoped_declaration_value(
+                        name,
+                        context,
+                        line_number,
+                        full=full,
+                    )
+                    if found and scoped_value:
+                        values.add(scoped_value)
+                    continue
+                values.add(value)
+            return next(iter(values)) if len(values) == 1 else None
+
+        def inherited_member_property_type(
+            class_context: Optional[str],
+            property_name: str,
+        ) -> Optional[str]:
+            if not class_context:
+                return None
+
+            queue = [
+                canonical_type_for_maps(class_context, local_imports, caller_package),
+                simple_type_key(class_context),
+            ]
+            visited = set()
+            while queue:
+                current = queue.pop(0)
+                if not current or current in visited:
+                    continue
+                visited.add(current)
+
+                property_type = member_property_types.get((current, property_name))
+                if property_type:
+                    return property_type
+
+                simple_current = simple_type_key(current)
+                if simple_current and simple_current != current:
+                    property_type = member_property_types.get((simple_current, property_name))
+                    if property_type:
+                        return property_type
+
+                bases = []
+                bases.extend(local_class_bases.get(simple_current or current, []))
+                bases.extend(global_class_bases.get(current, []))
+                if simple_current:
+                    bases.extend(global_class_bases.get(simple_current, []))
+                for base_name in bases:
+                    canonical_base = canonical_type_for_maps(
+                        base_name,
+                        local_imports,
+                        caller_package,
+                    ) or base_name
+                    if canonical_base and canonical_base not in visited:
+                        queue.append(canonical_base)
+                    simple_base = simple_type_key(base_name)
+                    if simple_base and simple_base not in visited:
+                        queue.append(simple_base)
+            return None
+
+        def lookup_local_variable_type(
+            name: Optional[str],
+            context: Any,
+            line_number: Optional[int] = None,
+        ) -> Optional[str]:
+            if not name:
+                return None
+            found, scoped_type = lookup_scoped_declaration_value(
+                name,
+                context,
+                line_number,
+            )
+            if found:
+                return scoped_type
+            if not (isinstance(context, tuple) and line_number is not None):
+                inferred_type = local_variable_types.get((name, context))
+                if inferred_type:
+                    return inferred_type
+            class_context = context[2] if isinstance(context, tuple) and len(context) >= 3 else None
+            inferred_type = local_variable_types.get((name, class_context))
+            if inferred_type:
+                return inferred_type
+            inferred_type = inherited_member_property_type(class_context, name)
+            if inferred_type:
+                return inferred_type
+            inferred_type = local_variable_types.get((name, None))
+            if inferred_type:
+                return inferred_type
+            return unique_local_value(local_variable_types, name, context, line_number)
+
+        def lookup_local_variable_full_type(
+            name: Optional[str],
+            context: Any,
+            line_number: Optional[int] = None,
+        ) -> Optional[str]:
+            if not name:
+                return None
+            found, scoped_type = lookup_scoped_declaration_value(
+                name,
+                context,
+                line_number,
+                full=True,
+            )
+            if found:
+                return scoped_type
+            if not (isinstance(context, tuple) and line_number is not None):
+                inferred_type = local_variable_full_types.get((name, context))
+                if inferred_type:
+                    return inferred_type
+            class_context = context[2] if isinstance(context, tuple) and len(context) >= 3 else None
+            inferred_type = local_variable_full_types.get((name, class_context))
+            if inferred_type:
+                return inferred_type
+            inferred_type = local_variable_full_types.get((name, None))
+            if inferred_type:
+                return inferred_type
+            inferred_type = unique_local_value(
+                local_variable_full_types,
+                name,
+                context,
+                line_number,
+                full=True,
+            )
+            if inferred_type:
+                return inferred_type
+            inferred_type = lookup_local_variable_type(name, context, line_number)
+            return inferred_type
+
+        def lookup_local_expression_type(
+            expr: str,
+            context: Any,
+            line_number: Optional[int] = None,
+        ) -> Optional[str]:
+            text = expr.strip()
+            if re.fullmatch(r"[A-Za-z_]\w*", text):
+                return lookup_local_variable_type(text, context, line_number)
+            if re.search(r'\.keys\.asSequence\s*\(\s*\)$', text):
+                return "Sequence"
+            if re.search(r'\.keys\b$', text):
+                return "Set"
+            if re.search(r'\.values\b$', text):
+                return "Collection"
+
+            receiver_match = re.match(r"([A-Za-z_]\w*)\.(map|filter|flatMap|take|drop)\b", text)
+            if receiver_match:
+                receiver_type = lookup_local_variable_type(
+                    receiver_match.group(1),
+                    context,
+                    line_number,
+                )
+                receiver_type = canonical_type_for_maps(
+                    receiver_type,
+                    local_imports,
+                    caller_package,
+                )
+                if receiver_type == "Sequence":
+                    return "Sequence"
+                if receiver_type:
+                    return "List"
+            return None
+
+        def class_like_initializer_receiver_type(receiver_name: Optional[str]) -> Optional[str]:
+            if not receiver_name:
+                return None
+            text = receiver_name.strip()
+            simple_name = text.rsplit(".", 1)[-1]
+            if not re.match(r"[A-Z_]", simple_name):
+                return None
+            return canonical_type_for_maps(text, local_imports, caller_package)
+
+        max_inference_iterations = (
+            len(pending_variable_member_hints)
+            + len(pending_variable_candidate_hints)
+            + len(pending_variable_collection_hints)
+        )
+        for _ in range(max_inference_iterations):
+            changed = False
+            for variable in pending_variable_collection_hints:
+                scope = variable_scope(variable)
+                variable_line = variable.get("line_number")
+                initializer_lookup_line = variable_line - 1 if isinstance(variable_line, int) else None
+                if lookup_declared_variable_type(variable.get("name"), scope, variable_line):
+                    continue
+
+                receiver_type = lookup_local_variable_type(
+                    variable.get("initializer_collection_receiver_name"),
+                    scope,
+                    initializer_lookup_line,
+                )
+                if not receiver_type:
+                    receiver_type = class_like_initializer_receiver_type(
+                        variable.get("initializer_collection_receiver_name")
+                    )
+                receiver_type = canonical_type_for_maps(
+                    receiver_type,
+                    local_imports,
+                    caller_package,
+                )
+                if not receiver_type:
+                    continue
+
+                member_name = variable.get("initializer_collection_member_name")
+                operator = variable.get("initializer_collection_operator")
+                full_return_type = member_return_types_full.get((receiver_type, member_name))
+                inferred_collection_type = collection_type_from_operator(
+                    full_return_type,
+                    operator,
+                )
+                changed = add_local_variable_type(
+                    variable.get("name"),
+                    scope,
+                    inferred_collection_type,
+                    variable_line,
+                ) or changed
+
+            for variable in pending_variable_member_hints:
+                scope = variable_scope(variable)
+                variable_line = variable.get("line_number")
+                initializer_lookup_line = variable_line - 1 if isinstance(variable_line, int) else None
+                if lookup_declared_variable_type(variable.get("name"), scope, variable_line):
+                    continue
+
+                receiver_type = lookup_local_variable_type(
+                    variable.get("initializer_receiver_name"),
+                    scope,
+                    initializer_lookup_line,
+                )
+                if not receiver_type:
+                    receiver_type = class_like_initializer_receiver_type(
+                        variable.get("initializer_receiver_name")
+                    )
+                receiver_type = canonical_type_for_maps(
+                    receiver_type,
+                    local_imports,
+                    caller_package,
+                )
+                if not receiver_type:
+                    continue
+
+                member_name = variable.get("initializer_member_name")
+                member_kind = variable.get("initializer_member_kind")
+                inferred_full_type = None
+                if member_kind == "function":
+                    inferred_type = member_return_types.get((receiver_type, member_name))
+                    inferred_full_type = member_return_types_full.get((receiver_type, member_name))
+                elif member_kind == "property":
+                    inferred_type = member_property_types.get((receiver_type, member_name))
+                else:
+                    inferred_type = None
+
+                changed = add_local_variable_type(
+                    variable.get("name"),
+                    scope,
+                    inferred_full_type or inferred_type,
+                    variable_line,
+                ) or changed
+
+            for variable in pending_variable_candidate_hints:
+                scope = variable_scope(variable)
+                variable_line = variable.get("line_number")
+                initializer_lookup_line = variable_line - 1 if isinstance(variable_line, int) else None
+                if lookup_declared_variable_type(variable.get("name"), scope, variable_line):
+                    continue
+
+                candidate_types = []
+                for candidate_name in variable.get("initializer_candidate_names", []):
+                    candidate_type = lookup_local_variable_type(
+                        candidate_name,
+                        scope,
+                        initializer_lookup_line,
+                    )
+                    candidate_type = canonical_type_for_maps(
+                        candidate_type,
+                        local_imports,
+                        caller_package,
+                    )
+                    if not candidate_type:
+                        candidate_types = []
+                        break
+                    candidate_types.append(candidate_type)
+
+                if candidate_types and len(set(candidate_types)) == 1:
+                    changed = add_local_variable_type(
+                        variable.get("name"),
+                        scope,
+                        candidate_types[0],
+                        variable_line,
+                    ) or changed
+            if not changed:
+                break
 
         for call in file_data.get("function_calls", []):
+            call_to_resolve = (
+                {**call, "package": caller_package}
+                if caller_package and not call.get("package")
+                else call
+            )
+            context = call.get("context")
+            context_name = context[0] if context and len(context) == 3 else None
+            current_call_scope = call_scope(call)
+            call_line = call.get("line_number")
+            if caller_lang == "kotlin":
+                base_obj = call.get("base_obj")
+                if not base_obj:
+                    full_name = call.get("full_name", "")
+                    base_obj = full_name.split(".", 1)[0] if "." in full_name else None
+
+                if base_obj and re.fullmatch(r"[A-Za-z_]\w*", base_obj):
+                    inferred_type = lookup_local_variable_type(
+                        base_obj,
+                        current_call_scope,
+                        call_line,
+                    )
+                    if not inferred_type and call.get("implicit_receiver_type"):
+                        implicit_receiver_type = canonical_type_for_maps(
+                            call.get("implicit_receiver_type"),
+                            local_imports,
+                            caller_package,
+                        )
+                        inferred_type = member_property_types.get(
+                            (implicit_receiver_type, base_obj)
+                        )
+                    if inferred_type:
+                        existing_extension_receiver = call.get("extension_receiver_type")
+                        call_to_resolve = {
+                            **call,
+                            "inferred_obj_type": inferred_type,
+                            "extension_receiver_type": (
+                                inferred_type
+                                if not existing_extension_receiver
+                                or existing_extension_receiver == base_obj
+                                else existing_extension_receiver
+                            ),
+                        }
+
+            call_args = call_to_resolve.get("args", [])
+            if caller_lang == "kotlin" and isinstance(call_args, list):
+                arg_type_hints = [
+                    (
+                        canonical_type_for_maps(
+                            call_to_resolve.get("scope_receiver_type"),
+                            local_imports,
+                            caller_package,
+                        )
+                        if arg.strip() == "this" and call_to_resolve.get("scope_receiver_type")
+                        else lookup_local_expression_type(arg.strip(), current_call_scope, call_line)
+                    )
+                    for arg in call_args
+                ]
+                if any(arg_type_hints):
+                    call_to_resolve = {
+                        **call_to_resolve,
+                        "arg_type_hints": arg_type_hints,
+                    }
+
+            if (
+                caller_lang == "kotlin"
+                and call_to_resolve.get("call_kind") == "callable_reference"
+                and not call_to_resolve.get("arg_type_hints")
+                and call_to_resolve.get("callable_reference_collection_receiver")
+            ):
+                collection_receiver = call_to_resolve.get("callable_reference_collection_receiver")
+                collection_type = None
+                if isinstance(collection_receiver, str):
+                    if re.fullmatch(r"[A-Za-z_]\w*", collection_receiver.strip()):
+                        collection_type = lookup_local_variable_full_type(
+                            collection_receiver.strip(),
+                            current_call_scope,
+                            call_line,
+                        )
+                    else:
+                        simple_collection_type = lookup_local_expression_type(
+                            collection_receiver.strip(),
+                            current_call_scope,
+                            call_line,
+                        )
+                        collection_type = simple_collection_type
+                element_type = collection_element_type(
+                    collection_type,
+                    local_imports,
+                    caller_package,
+                )
+                if element_type:
+                    call_to_resolve = {
+                        **call_to_resolve,
+                        "arg_type_hints": [element_type],
+                    }
+
             resolved = resolve_function_call(
-                call, caller_file_path, local_names, local_imports, effective_imports_map, skip_external
+                call_to_resolve,
+                caller_file_path,
+                local_names,
+                local_imports,
+                effective_imports_map,
+                skip_external,
+                local_class_bases=local_class_bases,
+                member_return_types=member_return_types,
+                member_property_types=member_property_types,
+                type_aliases=type_aliases,
+                global_class_bases=global_class_bases,
+                class_method_names=class_method_names,
+                function_index=function_index,
+                class_index=class_index,
+                class_method_index=class_method_index,
+                extension_method_index=extension_method_index,
+                diagnostics=diagnostics,
             )
             if not resolved:
                 continue
 
             called_path = resolved.get("called_file_path", "")
             called_name = resolved["called_name"]
-            called_is_class = called_name in file_class_lookup.get(called_path, set())
+            class_names_for_path = file_class_lookup.get(called_path, set())
+            simple_called_name = simple_type_key(called_name)
+            called_is_class = (
+                called_name in class_names_for_path
+                or (
+                    simple_called_name is not None
+                    and simple_called_name in class_names_for_path
+                )
+            )
+            if called_is_class and called_name not in class_names_for_path and simple_called_name:
+                resolved = {**resolved, "called_name": simple_called_name}
+                called_name = simple_called_name
 
             if resolved["type"] == "file":
                 if called_is_class:

--- a/src/codegraphcontext/tools/indexing/schema.py
+++ b/src/codegraphcontext/tools/indexing/schema.py
@@ -76,6 +76,9 @@ def create_graph_schema(driver: Any, db_manager: Any) -> None:
             session.run("CREATE INDEX function_lang IF NOT EXISTS FOR (f:Function) ON (f.lang)")
             session.run("CREATE INDEX class_lang IF NOT EXISTS FOR (c:Class) ON (c.lang)")
             session.run("CREATE INDEX annotation_lang IF NOT EXISTS FOR (a:Annotation) ON (a.lang)")
+            session.run(
+                "CREATE INDEX parameter_unique IF NOT EXISTS FOR (p:Parameter) ON (p.name, p.path, p.function_line_number)"
+            )
 
             backend_type = getattr(db_manager, "get_backend_type", lambda: "neo4j")()
             if backend_type == "falkordb":

--- a/src/codegraphcontext/tools/languages/java.py
+++ b/src/codegraphcontext/tools/languages/java.py
@@ -359,12 +359,12 @@ class JavaTreeSitterParser:
                             "path": str(path),
                             "lang": self.language_name,
                             "context": context_name,
-                            "class_context": context_name if context_type and "class" in context_type else None
+                            "class_context": context_name if context_type in ("class_declaration", "interface_declaration", "enum_declaration", "annotation_type_declaration") else None
                         }
 
                         if package_name:
                             func_data["package_name"] = package_name
-                            class_ctx = context_name if (context_type and "class" in context_type) else None
+                            class_ctx = context_name if context_type in ("class_declaration", "interface_declaration", "enum_declaration", "annotation_type_declaration") else None
                             if class_ctx:
                                 func_data["qualified_name"] = f"{package_name}.{class_ctx}.{func_name}"
                             else:
@@ -545,7 +545,7 @@ class JavaTreeSitterParser:
                         "path": str(path),
                         "lang": self.language_name,
                         "context": ctx_name,
-                        "class_context": ctx_name if ctx_type and "class" in ctx_type else None
+                        "class_context": ctx_name if ctx_type in ("class_declaration", "interface_declaration", "enum_declaration", "annotation_type_declaration") else None
                      })
 
         return variables
@@ -620,9 +620,12 @@ class JavaTreeSitterParser:
                         })
 
                 elif "Table" in ann_map and "Entity" not in ann_map:
-                    # Could be Spring Data Cassandra @Table(value="...")
+                    # Could be Spring Data Cassandra @Table(keyspace="...", name="...") or @Table(value="...")
                     t_args = ann_map["Table"] or ""
-                    m = re.search(r'value\s*=\s*"([^"]+)"', t_args)
+                    # Prefer explicit name= attribute (Cassandra uses keyspace+name; name= is the table)
+                    m = re.search(r'\bname\s*=\s*"([^"]+)"', t_args)
+                    if not m:
+                        m = re.search(r'value\s*=\s*"([^"]+)"', t_args)
                     if not m:
                         m = re.search(r'"([^"]+)"', t_args)
                     table_name = m.group(1) if m else (class_name.lower() if class_name else None)
@@ -923,7 +926,7 @@ class JavaTreeSitterParser:
                         "args": args,
                         "inferred_obj_type": inferred_obj_type,
                         "context": (ctx_name, ctx_type, ctx_line),
-                        "class_context": (ctx_name, ctx_line) if ctx_type and "class" in ctx_type else (None, None),
+                        "class_context": (ctx_name, ctx_line) if ctx_type in ("class_declaration", "interface_declaration", "enum_declaration", "annotation_type_declaration") else (None, None),
                         "lang": self.language_name,
                         "is_dependency": False,
                     }

--- a/src/codegraphcontext/tools/languages/java.py
+++ b/src/codegraphcontext/tools/languages/java.py
@@ -338,9 +338,11 @@ class JavaTreeSitterParser:
                         
                         params_node = node.child_by_field_name("parameters")
                         parameters = []
+                        parameter_types = []
                         if params_node:
                             params_text = self._get_node_text(params_node)
                             parameters = self._extract_parameter_names(params_text)
+                            parameter_types = self._extract_parameter_types(params_text)
 
                         source_text = self._get_node_text(node)
                         
@@ -350,6 +352,8 @@ class JavaTreeSitterParser:
                         func_data = {
                             "name": func_name,
                             "parameters": parameters,
+                            "args": parameters,
+                            "arg_types": parameter_types,
                             "line_number": start_line,
                             "end_line": end_line,
                             "path": str(path),
@@ -940,8 +944,8 @@ class JavaTreeSitterParser:
         if not params_content:
             return params
             
-        for param in params_content.split(","):
-            param = param.strip()
+        for param in self._split_parameters(params_text):
+            param = self._strip_parameter_annotations_and_modifiers(param)
             if param:
                 parts = param.split()
                 if len(parts) >= 2:
@@ -949,6 +953,134 @@ class JavaTreeSitterParser:
                     params.append(param_name)
                     
         return params
+
+    def _split_parameters(self, params_text: str) -> list[str]:
+        if not params_text or params_text.strip() == "()":
+            return []
+
+        params_content = params_text.strip().strip("()")
+        if not params_content:
+            return []
+
+        params = []
+        current = []
+        depth_angle = depth_round = depth_square = depth_curly = 0
+        in_string: Optional[str] = None
+        escaped = False
+        for char in params_content:
+            if in_string:
+                current.append(char)
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == in_string:
+                    in_string = None
+                continue
+
+            if char in {"'", '"'}:
+                in_string = char
+            elif char == "<":
+                depth_angle += 1
+            elif char == ">":
+                depth_angle = max(0, depth_angle - 1)
+            elif char == "(":
+                depth_round += 1
+            elif char == ")":
+                depth_round = max(0, depth_round - 1)
+            elif char == "[":
+                depth_square += 1
+            elif char == "]":
+                depth_square = max(0, depth_square - 1)
+            elif char == "{":
+                depth_curly += 1
+            elif char == "}":
+                depth_curly = max(0, depth_curly - 1)
+            elif char == "," and depth_angle == depth_round == depth_square == depth_curly == 0:
+                param = "".join(current).strip()
+                if param:
+                    params.append(param)
+                current = []
+                continue
+            current.append(char)
+
+        param = "".join(current).strip()
+        if param:
+            params.append(param)
+        return params
+
+    def _matching_paren_index(self, text: str, open_index: int) -> Optional[int]:
+        depth = 0
+        in_string: Optional[str] = None
+        escaped = False
+        for idx in range(open_index, len(text)):
+            char = text[idx]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == in_string:
+                    in_string = None
+                continue
+
+            if char in {"'", '"'}:
+                in_string = char
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    return idx
+        return None
+
+    def _strip_parameter_annotations_and_modifiers(self, param: str) -> str:
+        text = param.strip()
+        while text:
+            final_match = re.match(r"final\b\s*", text)
+            if final_match:
+                text = text[final_match.end() :].lstrip()
+                continue
+            if not text.startswith("@"):
+                break
+
+            match = re.match(r"@[\w.]+", text)
+            if not match:
+                break
+            idx = match.end()
+            while idx < len(text) and text[idx].isspace():
+                idx += 1
+            if idx < len(text) and text[idx] == "(":
+                close_idx = self._matching_paren_index(text, idx)
+                if close_idx is None:
+                    break
+                idx = close_idx + 1
+            text = text[idx:].lstrip()
+        return text
+
+    def _extract_parameter_types(self, params_text: str) -> list[str]:
+        primitive_types = {
+            "byte": "Byte",
+            "short": "Short",
+            "int": "Int",
+            "long": "Long",
+            "float": "Float",
+            "double": "Double",
+            "boolean": "Boolean",
+            "char": "Char",
+        }
+        types = []
+        for param in self._split_parameters(params_text):
+            cleaned = self._strip_parameter_annotations_and_modifiers(param)
+            parts = cleaned.split()
+            if len(parts) < 2:
+                continue
+            type_name = " ".join(parts[:-1]).replace("...", "[]").strip()
+            while type_name.endswith("[]"):
+                type_name = type_name[:-2].strip()
+            type_name = self._strip_generic(type_name)
+            types.append(primitive_types.get(type_name, type_name))
+        return types
 
 
 def pre_scan_java(files: list[Path], parser_wrapper) -> dict:

--- a/src/codegraphcontext/tools/languages/kotlin.py
+++ b/src/codegraphcontext/tools/languages/kotlin.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 import re
+from codegraphcontext.tools.type_utils import strip_type_modifiers
 from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logger, warning_logger
 from codegraphcontext.utils.tree_sitter_manager import execute_query
 
@@ -23,12 +24,22 @@ KOTLIN_QUERIES = {
     """,
     "calls": """
         (call_expression) @call_node
+        (constructor_invocation) @call_node
+        (constructor_delegation_call) @call_node
+        (callable_reference) @call_node
     """,
     "variables": """
         (property_declaration
             (variable_declaration
                 (simple_identifier) @name
             )
+        ) @variable
+        (class_parameter
+            (binding_pattern_kind)
+            (simple_identifier) @name
+        ) @variable
+        (parameter
+            (simple_identifier) @name
         ) @variable
     """,
 }
@@ -39,6 +50,16 @@ class KotlinTreeSitterParser:
         self.language_name = "kotlin"
         self.language = generic_parser_wrapper.language
         self.parser = generic_parser_wrapper.parser
+
+    @staticmethod
+    def _strip_type_modifiers(type_str: str) -> str:
+        """Return the receiver type CGC can resolve, e.g. 'List<T>?' -> 'List'."""
+        return strip_type_modifiers(type_str)
+
+    @staticmethod
+    def _extract_package_name(source_code: str) -> str:
+        match = re.search(r'^\s*package\s+([\w\.]+)', source_code, re.MULTILINE)
+        return match.group(1) if match else ""
 
     def parse(self, path: Path, is_dependency: bool = False, index_source: bool = False) -> Dict[str, Any]:
         try:
@@ -53,10 +74,12 @@ class KotlinTreeSitterParser:
                     "functions": [],
                     "classes": [],
                     "variables": [],
+                    "typealiases": [],
                     "imports": [],
                     "function_calls": [],
                     "is_dependency": is_dependency,
                     "lang": self.language_name,
+                    "package": "",
                 }
 
             tree = self.parser.parse(bytes(source_code, "utf8"))
@@ -66,34 +89,40 @@ class KotlinTreeSitterParser:
             parsed_variables = []
             parsed_imports = []
             parsed_calls = []
+            package_name = self._extract_package_name(source_code)
+            parsed_typealiases = self._parse_typealiases(source_code, path, package_name)
 
-            # Parse Variables first to populate for inference
+            if 'functions' in KOTLIN_QUERIES:
+                results = execute_query(self.language, KOTLIN_QUERIES['functions'], tree.root_node)
+                parsed_functions.extend(self._parse_functions(results, source_code, path))
+
+            # Parse Variables after functions so fallback destructuring can keep function scope.
             if 'variables' in KOTLIN_QUERIES:
-                 results = execute_query(self.language, KOTLIN_QUERIES['variables'], tree.root_node)
-                 parsed_variables = self._parse_variables(results, source_code, path)
+                results = execute_query(self.language, KOTLIN_QUERIES['variables'], tree.root_node)
+                parsed_variables = self._parse_variables(results, source_code, path, parsed_functions)
 
             for capture_name, query in KOTLIN_QUERIES.items():
-                if capture_name == 'variables': continue # Already done
+                if capture_name in {'functions', 'variables'}: continue # Already done
                 results = execute_query(self.language, query, tree.root_node)
 
-                if capture_name == "functions":
-                    parsed_functions.extend(self._parse_functions(results, source_code, path))
-                elif capture_name == "classes":
+                if capture_name == "classes":
                     parsed_classes.extend(self._parse_classes(results, source_code, path))
                 elif capture_name == "imports":
                     parsed_imports.extend(self._parse_imports(results, source_code))
                 elif capture_name == "calls":
-                    parsed_calls.extend(self._parse_calls(results, source_code, path, parsed_variables))
+                    parsed_calls.extend(self._parse_calls(results, source_code, path, parsed_variables, parsed_functions))
 
             return {
                 "path": str(path),
                 "functions": parsed_functions,
                 "classes": parsed_classes,
                 "variables": parsed_variables,
+                "typealiases": parsed_typealiases,
                 "imports": parsed_imports,
                 "function_calls": parsed_calls,
                 "is_dependency": is_dependency,
                 "lang": self.language_name,
+                "package": package_name,
             }
 
         except Exception as e:
@@ -103,10 +132,12 @@ class KotlinTreeSitterParser:
                 "functions": [],
                 "classes": [],
                 "variables": [],
+                "typealiases": [],
                 "imports": [],
                 "function_calls": [],
                 "is_dependency": is_dependency,
                 "lang": self.language_name,
+                "package": "",
             }
 
     def _get_parent_context(self, node: Any) -> Tuple[Optional[str], Optional[str], Optional[int]]:
@@ -123,7 +154,7 @@ class KotlinTreeSitterParser:
                     curr.type,
                     curr.start_point[0] + 1,
                 )
-            if curr.type in ("class_declaration", "object_declaration"):
+            if curr.type in ("class_declaration", "interface_declaration", "object_declaration"):
                 for child in curr.children:
                     if child.type in ("simple_identifier", "type_identifier"):
                          return (
@@ -171,6 +202,1006 @@ class KotlinTreeSitterParser:
         if not node: return ""
         return node.text.decode("utf-8")
 
+    def _get_enclosing_class_context(self, node: Any) -> Tuple[Optional[str], Optional[int]]:
+        curr = node.parent
+        while curr:
+            if curr.type in ("class_declaration", "interface_declaration", "object_declaration"):
+                for child in curr.children:
+                    if child.type in ("simple_identifier", "type_identifier"):
+                        return self._get_node_text(child), curr.start_point[0] + 1
+            curr = curr.parent
+        return None, None
+
+    def _lookup_scoped_declaration_type(
+        self,
+        declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]],
+        name: str,
+        context: Any,
+        line_number: Optional[int],
+    ) -> Tuple[bool, Optional[str]]:
+        if not declarations or not isinstance(context, tuple) or line_number is None:
+            return False, None
+
+        candidates = [
+            (decl_line, decl_type)
+            for decl_line, decl_type in declarations.get((name, context), [])
+            if decl_line is not None and decl_line <= line_number
+        ]
+        if not candidates:
+            return False, None
+
+        _, decl_type = max(candidates, key=lambda item: item[0] or 0)
+        return True, decl_type
+
+    def _unique_variable_type(
+        self,
+        var_map: Dict[Tuple[str, Any], str],
+        name: str,
+        context: Any = None,
+        line_number: Optional[int] = None,
+        declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]] = None,
+    ) -> Optional[str]:
+        values = set()
+        for (vname, scope), vtype in var_map.items():
+            if vname != name or not vtype or vtype == "Unknown":
+                continue
+            if isinstance(context, tuple) and scope == context and line_number is not None:
+                found, scoped_type = self._lookup_scoped_declaration_type(
+                    declarations,
+                    name,
+                    context,
+                    line_number,
+                )
+                if found and scoped_type:
+                    values.add(scoped_type)
+                continue
+            values.add(vtype)
+        return next(iter(values)) if len(values) == 1 else None
+
+    def _lookup_variable_type(
+        self,
+        var_map: Dict[Tuple[str, Any], str],
+        name: str,
+        context: Any,
+        declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]] = None,
+        line_number: Optional[int] = None,
+    ) -> Optional[str]:
+        found, scoped_type = self._lookup_scoped_declaration_type(
+            declarations,
+            name,
+            context,
+            line_number,
+        )
+        if found:
+            return scoped_type
+
+        if not (isinstance(context, tuple) and line_number is not None):
+            inferred_type = var_map.get((name, context))
+            if inferred_type:
+                return inferred_type
+        class_context = context[2] if isinstance(context, tuple) and len(context) >= 3 else None
+        inferred_type = var_map.get((name, class_context))
+        if inferred_type:
+            return inferred_type
+        inferred_type = var_map.get((name, None))
+        if inferred_type:
+            return inferred_type
+        return self._unique_variable_type(
+            var_map,
+            name,
+            context,
+            line_number,
+            declarations,
+        )
+
+    def _lookup_raw_variable_type(
+        self,
+        var_map: Dict[Tuple[str, Any], str],
+        name: str,
+        context: Any,
+        enclosing_class: Optional[str] = None,
+        declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]] = None,
+        line_number: Optional[int] = None,
+    ) -> Optional[str]:
+        found, scoped_type = self._lookup_scoped_declaration_type(
+            declarations,
+            name,
+            context,
+            line_number,
+        )
+        if found:
+            return scoped_type
+
+        keys = [(name, enclosing_class), (name, None)]
+        if not (isinstance(context, tuple) and line_number is not None):
+            keys.insert(0, (name, context))
+
+        for key in keys:
+            inferred_type = var_map.get(key)
+            if inferred_type and inferred_type != "Unknown":
+                return inferred_type
+        return self._unique_variable_type(
+            var_map,
+            name,
+            context,
+            line_number,
+            declarations,
+        )
+
+    def _generic_type_args(self, type_name: Optional[str]) -> list[str]:
+        if not type_name or "<" not in type_name or ">" not in type_name:
+            return []
+        inner = type_name[type_name.find("<") + 1:type_name.rfind(">")]
+        return [arg.strip() for arg in self._split_parameters(inner) if arg.strip()]
+
+    def _map_value_type(self, type_name: Optional[str]) -> Optional[str]:
+        args = self._generic_type_args(type_name)
+        if len(args) < 2:
+            return None
+        return self._strip_type_modifiers(args[1])
+
+    def _collection_element_type(self, type_name: Optional[str]) -> Optional[str]:
+        args = self._generic_type_args(type_name)
+        if not args:
+            return None
+        return self._strip_type_modifiers(args[0])
+
+    def _indexed_access_value_type(
+        self,
+        expr: str,
+        context: Any,
+        enclosing_class: Optional[str],
+        raw_var_map: Dict[Tuple[str, Any], str],
+        raw_declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]] = None,
+        line_number: Optional[int] = None,
+    ) -> Optional[str]:
+        match = re.match(r"([A-Za-z_]\w*)\s*\[", expr.strip())
+        if not match:
+            return None
+        receiver_type = self._lookup_raw_variable_type(
+            raw_var_map,
+            match.group(1),
+            context,
+            enclosing_class,
+            raw_declarations,
+            line_number,
+        )
+        return self._map_value_type(receiver_type)
+
+    def _collection_lambda_hint(
+        self,
+        node: Any,
+        context: Any,
+        enclosing_class: Optional[str],
+        raw_var_map: Dict[Tuple[str, Any], str],
+        raw_declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]] = None,
+        line_number: Optional[int] = None,
+    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        curr = node.parent
+        while curr:
+            text = self._get_node_text(curr)
+            if "{" not in text:
+                curr = curr.parent
+                continue
+            receiver_match = re.search(
+                r"([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*\.\s*(forEach|any|map|mapValues)\s*\{",
+                text,
+                re.S,
+            )
+            if not receiver_match:
+                curr = curr.parent
+                continue
+
+            receiver_expr = receiver_match.group(1)
+            function_name = receiver_match.group(2)
+            param_match = re.search(r"\{\s*([A-Za-z_]\w*)\s*->", text)
+            param_name = param_match.group(1) if param_match else "it"
+
+            if receiver_expr.endswith(".values"):
+                base_name = receiver_expr.rsplit(".", 1)[0]
+                receiver_type = self._lookup_raw_variable_type(
+                    raw_var_map,
+                    base_name,
+                    context,
+                    enclosing_class,
+                    raw_declarations,
+                    line_number,
+                )
+                return param_name, self._map_value_type(receiver_type), None
+
+            receiver_type = self._lookup_raw_variable_type(
+                raw_var_map,
+                receiver_expr,
+                context,
+                enclosing_class,
+                raw_declarations,
+                line_number,
+            )
+            if function_name == "mapValues":
+                return param_name, None, self._map_value_type(receiver_type)
+
+            return param_name, self._collection_element_type(receiver_type), None
+
+        return None, None, None
+
+    def _parse_typealiases(
+        self,
+        source_code: str,
+        path: Path,
+        package_name: str,
+    ) -> list[Dict[str, Any]]:
+        typealiases = []
+        pattern = re.compile(
+            r'^[ \t]*typealias\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_][\w\.]*(?:<[^>\n]+>)?\??)',
+            re.MULTILINE,
+        )
+        for match in pattern.finditer(source_code):
+            typealiases.append(
+                {
+                    "name": match.group(1),
+                    "target": match.group(2).strip(),
+                    "line_number": source_code.count("\n", 0, match.start()) + 1,
+                    "path": str(path),
+                    "package": package_name,
+                    "lang": self.language_name,
+                }
+            )
+        return typealiases
+
+    def _infer_receiver_type(
+        self,
+        expression: str,
+        context: Any,
+        enclosing_class: Optional[str],
+        var_map: Dict[Tuple[str, Any], str],
+        function_return_map: Dict[Tuple[Optional[str], str], str],
+        declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]] = None,
+        line_number: Optional[int] = None,
+    ) -> Optional[str]:
+        context_name = context[0] if isinstance(context, tuple) and context else context
+        expr = self._normalize_receiver_expression(expression)
+        cast_type = self._extract_cast_type(expr)
+        if cast_type:
+            return self._strip_type_modifiers(cast_type)
+
+        generic_factory_type = self._extract_generic_factory_type(expr)
+        if generic_factory_type:
+            return self._strip_type_modifiers(generic_factory_type)
+
+        candidate_type = self._common_type_for_candidate_names(
+            self._initializer_candidate_names(expr),
+            context,
+            var_map,
+            declarations,
+            line_number,
+        )
+        if candidate_type:
+            return candidate_type
+
+        if expr == "this":
+            return enclosing_class
+        if expr == "super":
+            return None
+        if re.fullmatch(r"[A-Za-z_]\w*", expr):
+            variable_type = self._lookup_variable_type(
+                var_map,
+                expr,
+                context,
+                declarations,
+                line_number,
+            )
+            if variable_type:
+                return variable_type
+            if re.fullmatch(r"[A-Z][A-Za-z_]\w*", expr):
+                return expr
+
+        call_target = self._call_target_without_value_args(expr)
+        if call_target:
+            if "." in call_target:
+                base_expr, member_name = call_target.rsplit(".", 1)
+                member_name = member_name.split("<", 1)[0]
+                if member_name == "spanBuilder":
+                    return "SpanBuilder"
+                if member_name in {"startSpan", "current"} and base_expr.endswith("Span"):
+                    return "Span"
+                base_type = self._infer_receiver_type(
+                    base_expr,
+                    context,
+                    enclosing_class,
+                    var_map,
+                    function_return_map,
+                    declarations,
+                    line_number,
+                )
+                if base_type:
+                    return function_return_map.get((base_type, member_name))
+            inner = call_target.split("<", 1)[0]
+            return (
+                function_return_map.get((enclosing_class, inner))
+                or function_return_map.get((context_name, inner))
+                or function_return_map.get((None, inner))
+            )
+
+        if "." in expr:
+            base_expr, member_name = expr.rsplit(".", 1)
+            base_type = self._infer_receiver_type(
+                base_expr,
+                context,
+                enclosing_class,
+                var_map,
+                function_return_map,
+                declarations,
+                line_number,
+            )
+            if base_type:
+                if re.fullmatch(r"[A-Z][A-Z0-9_]*", member_name):
+                    return base_type
+                return (
+                    var_map.get((member_name, base_type))
+                    or function_return_map.get((base_type, member_name))
+                )
+
+        return None
+
+    def _receiver_member_hint(
+        self,
+        expression: str,
+        context: Any,
+        enclosing_class: Optional[str],
+        var_map: Dict[Tuple[str, Any], str],
+        function_return_map: Dict[Tuple[Optional[str], str], str],
+        declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]] = None,
+        line_number: Optional[int] = None,
+    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        expr = self._normalize_receiver_expression(expression)
+        if self._extract_cast_type(expr) or self._extract_generic_factory_type(expr):
+            return None, None, None
+
+        member_kind = None
+        target = expr
+        call_target = self._call_target_without_value_args(expr)
+        if call_target:
+            target = call_target
+            member_kind = "function"
+        elif "." in expr:
+            member_kind = "property"
+
+        if "." not in target or member_kind is None:
+            return None, None, None
+
+        base_expr, member_name = target.rsplit(".", 1)
+        member_name = member_name.split("<", 1)[0]
+        base_type = self._infer_receiver_type(
+            base_expr,
+            context,
+            enclosing_class,
+            var_map,
+            function_return_map,
+            declarations,
+            line_number,
+        )
+        return base_type, member_name, member_kind
+
+    def _strip_outer_parentheses(self, expression: str) -> str:
+        expr = expression.strip()
+        while expr.startswith("(") and expr.endswith(")"):
+            depth = 0
+            wraps_entire_expression = True
+            for idx, char in enumerate(expr):
+                if char == "(":
+                    depth += 1
+                elif char == ")":
+                    depth -= 1
+                    if depth == 0 and idx != len(expr) - 1:
+                        wraps_entire_expression = False
+                        break
+            if not wraps_entire_expression:
+                break
+            expr = expr[1:-1].strip()
+        return expr
+
+    def _normalize_receiver_expression(self, expression: str) -> str:
+        expr = expression.replace("?.", ".").strip()
+        expr = self._strip_outer_parentheses(expr)
+        while expr.endswith("!!"):
+            expr = self._strip_outer_parentheses(expr[:-2].strip())
+        return expr
+
+    def _extract_cast_type(self, expression: str) -> Optional[str]:
+        expr = self._normalize_receiver_expression(expression)
+        match = re.search(
+            r'\b(?:as|as\?)\s+([A-Za-z_][\w\.]*(?:<[^>\n]+>)?\??)\s*$',
+            expr,
+        )
+        return match.group(1) if match else None
+
+    def _extract_generic_factory_type(self, expression: str) -> Optional[str]:
+        expr = self._normalize_receiver_expression(expression)
+        target = self._call_target_without_value_args(expr)
+        if not target:
+            return None
+
+        member_name = target.rsplit(".", 1)[-1]
+        match = re.fullmatch(
+            r'([A-Za-z_]\w*)\s*<\s*([A-Za-z_][\w\.]*(?:<[^>\n]+>)?\??)\s*>',
+            member_name,
+        )
+        if not match:
+            return None
+
+        factory_names = {
+            "get",
+            "getInstance",
+            "inject",
+            "instance",
+            "resolve",
+            "service",
+        }
+        if match.group(1) not in factory_names:
+            return None
+        return match.group(2)
+
+    def _call_target_without_value_args(self, expression: str) -> Optional[str]:
+        expr = self._normalize_receiver_expression(expression)
+        if not expr.endswith(")"):
+            return None
+
+        depth = 0
+        for idx in range(len(expr) - 1, -1, -1):
+            char = expr[idx]
+            if char == ")":
+                depth += 1
+            elif char == "(":
+                depth -= 1
+                if depth == 0:
+                    return expr[:idx].strip() or None
+        return None
+
+    def _initializer_member_hint(
+        self,
+        initializer: str,
+    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        expr = self._normalize_receiver_expression(initializer)
+        if self._extract_cast_type(expr) or self._extract_generic_factory_type(expr):
+            return None, None, None
+
+        call_target = self._call_target_without_value_args(expr)
+        if call_target and "." in call_target:
+            receiver_name, member_name = call_target.rsplit(".", 1)
+            if re.fullmatch(r"[A-Za-z_]\w*", receiver_name):
+                return receiver_name, member_name.split("<", 1)[0], "function"
+        elif "." in expr:
+            receiver_name, member_name = expr.rsplit(".", 1)
+            if re.fullmatch(r"[A-Za-z_]\w*", receiver_name):
+                return receiver_name, member_name, "property"
+
+        return None, None, None
+
+    def _initializer_collection_return_hint(
+        self,
+        initializer: str,
+    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        expr = self._normalize_receiver_expression(initializer)
+        match = re.search(
+            r'\b([A-Za-z_]\w*)\s*\.\s*([A-Za-z_]\w*)\s*\(.*?\)\s*'
+            r'\.\s*(toCollection|toList|toSet|asSequence)\s*\(',
+            expr,
+            re.DOTALL,
+        )
+        if not match:
+            return None, None, None
+        return match.group(1), match.group(2), match.group(3)
+
+    def _callable_reference_collection_hint(
+        self,
+        node: Any,
+    ) -> Tuple[Optional[str], Optional[str]]:
+        if node.type != "callable_reference":
+            return None, None
+
+        current = node.parent
+        reference_text = self._get_node_text(node)
+        while current is not None:
+            if current.type == "call_expression":
+                call_text = self._get_node_text(current)
+                if reference_text not in call_text:
+                    current = current.parent
+                    continue
+
+                call_target = self._call_target_without_value_args(call_text)
+                if call_target and "." in call_target:
+                    receiver_expr, member_name = call_target.rsplit(".", 1)
+                    if member_name in {
+                        "all",
+                        "any",
+                        "count",
+                        "filter",
+                        "filterNot",
+                        "find",
+                        "first",
+                        "firstOrNull",
+                        "flatMap",
+                        "forEach",
+                        "last",
+                        "lastOrNull",
+                        "map",
+                        "none",
+                        "onEach",
+                        "partition",
+                    }:
+                        return receiver_expr.strip(), member_name
+            current = current.parent
+        return None, None
+
+    def _split_top_level_operator(self, expression: str, operator: str) -> list[str]:
+        parts = []
+        current = []
+        depth_round = depth_square = depth_curly = 0
+        idx = 0
+        while idx < len(expression):
+            char = expression[idx]
+            if char == "(":
+                depth_round += 1
+            elif char == ")":
+                depth_round = max(0, depth_round - 1)
+            elif char == "[":
+                depth_square += 1
+            elif char == "]":
+                depth_square = max(0, depth_square - 1)
+            elif char == "{":
+                depth_curly += 1
+            elif char == "}":
+                depth_curly = max(0, depth_curly - 1)
+
+            at_top_level = (
+                depth_round == 0
+                and depth_square == 0
+                and depth_curly == 0
+            )
+            if at_top_level and expression.startswith(operator, idx):
+                parts.append("".join(current).strip())
+                current = []
+                idx += len(operator)
+                continue
+
+            current.append(char)
+            idx += 1
+
+        if current:
+            parts.append("".join(current).strip())
+        return parts
+
+    def _initializer_candidate_names(self, initializer: Optional[str]) -> list[str]:
+        if not initializer:
+            return []
+
+        expr = self._normalize_receiver_expression(initializer)
+        if re.fullmatch(r"[A-Za-z_]\w*", expr):
+            return [expr]
+
+        elvis_parts = self._split_top_level_operator(expr, "?:")
+        if len(elvis_parts) > 1:
+            candidates = []
+            for part in elvis_parts:
+                part_candidates = self._initializer_candidate_names(part)
+                if not part_candidates:
+                    return []
+                candidates.extend(part_candidates)
+            return candidates
+
+        if_candidates = self._if_expression_candidate_names(expr)
+        if if_candidates:
+            return if_candidates
+
+        if expr.startswith("when"):
+            candidates = re.findall(r'->\s*([A-Za-z_]\w*)\b', expr)
+            return candidates if len(candidates) > 1 else []
+
+        return []
+
+    def _if_expression_candidate_names(self, expression: str) -> list[str]:
+        expr = expression.strip()
+        if not expr.startswith("if"):
+            return []
+
+        idx = 2
+        while idx < len(expr) and expr[idx].isspace():
+            idx += 1
+        if idx >= len(expr) or expr[idx] != "(":
+            return []
+
+        depth = 0
+        close_idx = None
+        for pos in range(idx, len(expr)):
+            if expr[pos] == "(":
+                depth += 1
+            elif expr[pos] == ")":
+                depth -= 1
+                if depth == 0:
+                    close_idx = pos
+                    break
+        if close_idx is None:
+            return []
+
+        rest = expr[close_idx + 1:].strip()
+        match = re.fullmatch(
+            r'([A-Za-z_]\w*)\s+else\s+([A-Za-z_]\w*)',
+            rest,
+            re.DOTALL,
+        )
+        return [match.group(1), match.group(2)] if match else []
+
+    def _common_type_for_candidate_names(
+        self,
+        candidate_names: list[str],
+        context: Any,
+        var_map: Dict[Tuple[str, Any], str],
+        declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]] = None,
+        line_number: Optional[int] = None,
+    ) -> Optional[str]:
+        if not candidate_names:
+            return None
+
+        candidate_types = []
+        for candidate_name in candidate_names:
+            candidate_type = self._lookup_variable_type(
+                var_map,
+                candidate_name,
+                context,
+                declarations,
+                line_number,
+            )
+            if not candidate_type:
+                return None
+            candidate_types.append(self._strip_type_modifiers(candidate_type))
+
+        unique_types = set(candidate_types)
+        return candidate_types[0] if len(unique_types) == 1 else None
+
+    def _extract_initializer_type(self, initializer: str) -> Optional[str]:
+        expr = self._normalize_receiver_expression(initializer)
+        cast_type = self._extract_cast_type(expr)
+        if cast_type:
+            return self._strip_type_modifiers(cast_type)
+
+        generic_factory_type = self._extract_generic_factory_type(expr)
+        if generic_factory_type:
+            return self._strip_type_modifiers(generic_factory_type)
+
+        call_target = self._call_target_without_value_args(expr)
+        if call_target:
+            member_name = call_target.rsplit(".", 1)[-1].split("<", 1)[0]
+            if member_name == "spanBuilder":
+                return "SpanBuilder"
+            if member_name == "startSpan" or call_target.endswith("Span.current"):
+                return "Span"
+
+        builder_match = re.match(r'\b([A-Z]\w*)\.newBuilder\s*\(', expr)
+        if builder_match and re.search(r'\.build\s*\(\s*\)', expr):
+            return builder_match.group(1)
+
+        constructor_match = re.match(
+            r'\b([A-Z]\w*(?:<[^>\n]+>)?)\s*\(',
+            expr,
+        )
+        if constructor_match:
+            return constructor_match.group(1)
+
+        if re.search(r'\.partition\s*\{', expr):
+            return "List"
+        if re.match(r'\b(?:buildMap|mapOf|mutableMapOf|hashMapOf|linkedMapOf)\s*(?:<[^>]+>)?\s*[\({]', expr):
+            return "Map"
+        if re.match(r'\b(?:buildList|listOf|mutableListOf|arrayListOf)\s*(?:<[^>]+>)?\s*[\({]', expr):
+            return "List"
+        if re.search(r'\.associateBy\s*\{', expr):
+            return "Map"
+        if re.search(r'\.asSequence\s*\(\s*\).*\.map\s*\{', expr):
+            return "Sequence"
+        if re.search(r'\.map\s*\{', expr):
+            return "List"
+
+        if re.search(r'\.asSequence\s*\(', expr) or re.match(r'\bsequenceOf\s*\(', expr):
+            return "Sequence"
+        if re.search(r'\.toSet\s*\(', expr) or re.match(r'\b(?:setOf|mutableSetOf|hashSetOf|linkedSetOf)\s*\(', expr):
+            return "Set"
+        if re.search(r'\.toList\s*\(', expr) or re.match(r'\b(?:listOf|mutableListOf|arrayListOf)\s*\(', expr):
+            return "List"
+        if re.search(r'\.keys\b', expr):
+            return "Set"
+        if re.search(r'\.values\b', expr):
+            return "Collection"
+
+        constructor_match = re.fullmatch(
+            r'(?:[A-Za-z_][\w\.]*\.)?([A-Z][A-Za-z_]\w*)\s*(?:<[^>\n]+>)?\s*\(.*\)',
+            expr,
+            re.DOTALL,
+        )
+        return constructor_match.group(1) if constructor_match else None
+
+    def _extract_initializer_text(self, declaration_text: str) -> Optional[str]:
+        if "=" not in declaration_text:
+            return None
+        return declaration_text.split("=", 1)[1].strip().rstrip(";")
+
+    def _extract_call_parts(self, node: Any) -> Tuple[str, Optional[str]]:
+        if not node.children:
+            return "unknown", None
+
+        first_child = node.children[0]
+        if node.type == "callable_reference":
+            name_node = next(
+                (
+                    child
+                    for child in reversed(node.children)
+                    if child.type in ("simple_identifier", "type_identifier")
+                ),
+                None,
+            )
+            if name_node is None:
+                return "unknown", None
+            receiver_text = None
+            if len(node.children) >= 3 and first_child is not name_node:
+                receiver_text = self._get_node_text(first_child).strip()
+                if receiver_text == "::":
+                    receiver_text = None
+            return self._get_node_text(name_node), receiver_text
+
+        if node.type == "constructor_invocation":
+            for child in node.children:
+                if child.type == "user_type":
+                    return self._strip_type_modifiers(self._get_node_text(child)), None
+            return "unknown", None
+
+        if first_child.type == "simple_identifier":
+            return self._get_node_text(first_child), None
+
+        if first_child.type == "navigation_expression":
+            nav_children = first_child.children
+            if len(nav_children) < 2:
+                return "unknown", None
+
+            operand = nav_children[0]
+            suffix = nav_children[-1]
+            call_name = "unknown"
+            if suffix.type == "navigation_suffix":
+                for child in suffix.children:
+                    if child.type == "simple_identifier":
+                        call_name = self._get_node_text(child)
+                        break
+            elif suffix.type == "simple_identifier":
+                call_name = self._get_node_text(suffix)
+
+            return call_name, self._get_node_text(operand)
+
+        return "unknown", None
+
+    def _extract_first_argument(self, call_text: str) -> Optional[str]:
+        open_paren = call_text.find("(")
+        if open_paren == -1:
+            return None
+
+        depth = 0
+        arg_chars = []
+        for char in call_text[open_paren + 1:]:
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                if depth == 0:
+                    break
+                depth -= 1
+            elif char == "," and depth == 0:
+                break
+            arg_chars.append(char)
+
+        arg = "".join(arg_chars).strip()
+        return arg or None
+
+    def _extract_call_arguments(self, node: Any) -> list[str]:
+        args = []
+        for child in node.children:
+            if child.type == "call_suffix":
+                for suffix_child in child.children:
+                    if suffix_child.type == "value_arguments":
+                        args.extend(
+                            self._get_node_text(arg)
+                            for arg in suffix_child.children
+                            if arg.type == "value_argument"
+                        )
+                    elif suffix_child.type in ("annotated_lambda", "lambda_literal"):
+                        args.append(self._get_node_text(suffix_child))
+            elif child.type == "value_arguments":
+                args.extend(
+                    self._get_node_text(arg)
+                    for arg in child.children
+                    if arg.type == "value_argument"
+                )
+            elif child.type in ("annotated_lambda", "lambda_literal"):
+                args.append(self._get_node_text(child))
+        return args
+
+    def _extract_lambda_parameter(self, call_text: str) -> Optional[str]:
+        match = re.search(r'\{\s*([A-Za-z_]\w*)\s*->', call_text, re.DOTALL)
+        return match.group(1) if match else None
+
+    def _scope_function_receiver_hint(
+        self,
+        node: Any,
+        context: Any,
+        enclosing_class: Optional[str],
+        var_map: Dict[Tuple[str, Any], str],
+        function_return_map: Dict[Tuple[Optional[str], str], str],
+        declarations: Optional[Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]]] = None,
+        line_number: Optional[int] = None,
+    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        def contains_node(container: Any, target: Any) -> bool:
+            return (
+                container.start_byte <= target.start_byte
+                and target.end_byte <= container.end_byte
+            )
+
+        def is_inside_scope_lambda(scope_call: Any, target: Any) -> bool:
+            stack = list(scope_call.children)
+            while stack:
+                child = stack.pop()
+                if child.type in ("annotated_lambda", "lambda_literal") and contains_node(child, target):
+                    return True
+                stack.extend(child.children)
+            return False
+
+        curr = node.parent
+        while curr:
+            if curr.type == "call_expression" and (
+                curr.start_byte != node.start_byte or curr.end_byte != node.end_byte
+            ):
+                if not is_inside_scope_lambda(curr, node):
+                    curr = curr.parent
+                    continue
+
+                scope_name, scope_base = self._extract_call_parts(curr)
+                receiver_expression = None
+                if scope_name in {"apply", "run", "let", "also"} and scope_base:
+                    receiver_expression = scope_base
+                elif scope_name == "with":
+                    receiver_expression = self._extract_first_argument(self._get_node_text(curr))
+
+                if receiver_expression:
+                    receiver_type = self._infer_receiver_type(
+                        receiver_expression,
+                        context,
+                        enclosing_class,
+                        var_map,
+                        function_return_map,
+                        declarations,
+                        line_number,
+                    )
+                    if receiver_type:
+                        return (
+                            scope_name,
+                            self._strip_type_modifiers(receiver_type),
+                            self._extract_lambda_parameter(self._get_node_text(curr)),
+                        )
+
+            curr = curr.parent
+
+        return None, None, None
+
+    def _smart_cast_receiver_hint(
+        self,
+        node: Any,
+        receiver_name: Optional[str],
+    ) -> Optional[str]:
+        if not receiver_name or not re.fullmatch(r"[A-Za-z_]\w*", receiver_name):
+            return None
+
+        curr = node.parent
+        while curr:
+            if curr.type == "if_expression":
+                cast_type = self._smart_cast_type_from_if(curr, node, receiver_name)
+                if cast_type:
+                    return cast_type
+            elif curr.type == "when_entry":
+                cast_type = self._smart_cast_type_from_when_entry(curr, node, receiver_name)
+                if cast_type:
+                    return cast_type
+
+            curr = curr.parent
+
+        return None
+
+    def _smart_cast_type_from_if(
+        self,
+        if_node: Any,
+        call_node: Any,
+        receiver_name: str,
+    ) -> Optional[str]:
+        check_node = None
+        positive_body = None
+        for child in if_node.children:
+            if child.type == "check_expression":
+                check_node = child
+            elif child.type == "control_structure_body" and positive_body is None:
+                positive_body = child
+
+        if not check_node or not positive_body:
+            return None
+        if not (positive_body.start_byte <= call_node.start_byte <= positive_body.end_byte):
+            return None
+
+        return self._type_from_positive_check(check_node, receiver_name)
+
+    def _smart_cast_type_from_when_entry(
+        self,
+        when_entry: Any,
+        call_node: Any,
+        receiver_name: str,
+    ) -> Optional[str]:
+        body = None
+        type_test = None
+        check_node = None
+        for child in when_entry.children:
+            if child.type == "control_structure_body":
+                body = child
+            elif child.type == "when_condition":
+                for condition_child in child.children:
+                    if condition_child.type == "type_test":
+                        type_test = condition_child
+                    elif condition_child.type == "check_expression":
+                        check_node = condition_child
+
+        if not body or not (body.start_byte <= call_node.start_byte <= body.end_byte):
+            return None
+
+        if check_node:
+            return self._type_from_positive_check(check_node, receiver_name)
+
+        subject_name = self._when_subject_name(when_entry.parent)
+        if subject_name == receiver_name and type_test:
+            return self._type_from_type_test(type_test)
+
+        return None
+
+    def _when_subject_name(self, when_node: Any) -> Optional[str]:
+        if not when_node or when_node.type != "when_expression":
+            return None
+        for child in when_node.children:
+            if child.type == "when_subject":
+                for subject_child in child.children:
+                    if subject_child.type == "simple_identifier":
+                        return self._get_node_text(subject_child)
+        return None
+
+    def _type_from_type_test(self, type_test_node: Any) -> Optional[str]:
+        text = self._get_node_text(type_test_node)
+        if text.lstrip().startswith("!is"):
+            return None
+        for child in type_test_node.children:
+            if child.type in ("user_type", "nullable_type"):
+                return self._strip_type_modifiers(self._get_node_text(child))
+        match = re.search(
+            r'\bis\s+([A-Za-z_][\w\.]*(?:<[^>\n]+>)?\??)',
+            text,
+        )
+        return self._strip_type_modifiers(match.group(1)) if match else None
+
+    def _type_from_positive_check(
+        self,
+        check_node: Any,
+        receiver_name: str,
+    ) -> Optional[str]:
+        text = self._get_node_text(check_node)
+        escaped_name = re.escape(receiver_name)
+        if "||" in text:
+            return None
+        if re.search(rf'!\s*\(\s*{escaped_name}\s+is\b', text):
+            return None
+        if re.search(rf'\b{escaped_name}\s+!is\b', text):
+            return None
+        match = re.search(
+            rf'\b{escaped_name}\s+is\s+([A-Za-z_][\w\.]*(?:<[^>\n]+>)?\??)',
+            text,
+        )
+        return self._strip_type_modifiers(match.group(1)) if match else None
+
     def _parse_functions(self, captures: list, source_code: str, path: Path) -> list[Dict[str, Any]]:
         functions = []
         seen_nodes = set()
@@ -203,24 +1234,52 @@ class KotlinTreeSitterParser:
                                 break
                                 
                         parameters = []
+                        parameter_types = []
+                        parameter_defaults = []
                         if params_node:
                             params_text = self._get_node_text(params_node)
                             parameters = self._extract_parameter_names(params_text)
+                            parameter_types = self._extract_parameter_types(params_text)
+                            parameter_defaults = self._extract_parameter_defaults(params_text)
 
                         source_text = self._get_node_text(node)
                         
                         context_name, context_type, context_line = self._get_parent_context(node)
+                        is_class_context = bool(
+                            context_type
+                            and (
+                                "class" in context_type
+                                or "interface" in context_type
+                                or "object" in context_type
+                            )
+                        )
 
                         func_data = {
                             "name": func_name,
                             "args": parameters,
+                            "arg_types": parameter_types,
+                            "arg_defaults": parameter_defaults,
                             "line_number": start_line,
                             "end_line": end_line,
                             "path": str(path),
                             "lang": self.language_name,
                             "context": context_name,
-                            "class_context": context_name if context_type and ("class" in context_type or "object" in context_type) else None
+                            "class_context": context_name if is_class_context else None,
                         }
+                        if is_class_context and context_line is not None:
+                            func_data["class_context_line"] = context_line
+
+                        for child in node.children:
+                            if child.type == "receiver_type":
+                                func_data["receiver_type"] = self._strip_type_modifiers(self._get_node_text(child))
+                                break
+
+                        for child in node.children:
+                            if child.type in ("user_type", "nullable_type"):
+                                raw_return_type = self._get_node_text(child)
+                                func_data["return_type"] = self._strip_type_modifiers(raw_return_type)
+                                func_data["return_type_full"] = raw_return_type
+                                break
                         
                         if self.index_source:
                             func_data["source"] = source_text
@@ -259,6 +1318,15 @@ class KotlinTreeSitterParser:
                             break
                             
                     source_text = self._get_node_text(node)
+                    context_name, context_type, context_line = self._get_parent_context(node)
+                    is_nested_class = bool(
+                        context_type
+                        and (
+                            "class" in context_type
+                            or "interface" in context_type
+                            or "object" in context_type
+                        )
+                    )
                     
                     bases = []
                     # Check for delegation specifiers
@@ -287,12 +1355,17 @@ class KotlinTreeSitterParser:
 
                     class_data = {
                         "name": class_name,
+                        "node_type": node.type,
                         "line_number": start_line,
                         "end_line": end_line,
                         "bases": bases,
                         "path": str(path),
                         "lang": self.language_name,
                     }
+                    if is_nested_class:
+                        class_data["class_context"] = context_name
+                        if context_line is not None:
+                            class_data["class_context_line"] = context_line
 
                     if self.index_source:
                         class_data["source"] = source_text
@@ -305,7 +1378,13 @@ class KotlinTreeSitterParser:
 
         return classes
 
-    def _parse_variables(self, captures: list, source_code: str, path: Path) -> list[Dict[str, Any]]:
+    def _parse_variables(
+        self,
+        captures: list,
+        source_code: str,
+        path: Path,
+        functions: Optional[list[Dict[str, Any]]] = None,
+    ) -> list[Dict[str, Any]]:
         variables = []
         seen_vars = set()
         
@@ -314,20 +1393,45 @@ class KotlinTreeSitterParser:
                 try:
                     start_line = node.start_point[0] + 1
                     ctx_name, ctx_type, ctx_line = self._get_parent_context(node)
+                    node_text = self._get_node_text(node)
 
                     # Destructuring declaration
-                    if "destructuring" in node.type:
-                        pass
+                    destructuring_match = re.match(
+                        r'\s*(?:val|var)\s*\(([^)]+)\)\s*=\s*(.+)',
+                        node_text,
+                        re.S,
+                    )
+                    if destructuring_match:
+                        initializer_text = destructuring_match.group(2).strip()
+                        initializer_inferred_type = self._extract_initializer_type(initializer_text)
+                        for raw_name in destructuring_match.group(1).split(","):
+                            var_name = raw_name.strip()
+                            if not var_name or var_name == "_":
+                                continue
+                            variable_data = {
+                                "name": var_name,
+                                "type": initializer_inferred_type or "Unknown",
+                                "line_number": start_line,
+                                "path": str(path),
+                                "lang": self.language_name,
+                                "context": ctx_name,
+                                "class_context": ctx_name if ctx_type and ("class" in ctx_type or "interface" in ctx_type or "object" in ctx_type) else None
+                            }
+                            if initializer_inferred_type:
+                                variable_data["initializer_inferred_type"] = initializer_inferred_type
+                            variables.append(variable_data)
+                        continue
 
                     # Regular property/variable
                     var_name = "unknown"
                     var_type = "Unknown"
                     
-                    var_decl = None
-                    for child in node.children:
-                        if child.type == "variable_declaration":
-                            var_decl = child
-                            break
+                    var_decl = node if node.type in ("class_parameter", "parameter") else None
+                    if var_decl is None:
+                        for child in node.children:
+                            if child.type == "variable_declaration":
+                                var_decl = child
+                                break
                     
                     if var_decl:
                         # Check for name and type in variable_declaration
@@ -335,7 +1439,7 @@ class KotlinTreeSitterParser:
                             if child.type == "simple_identifier":
                                 var_name = self._get_node_text(child)
                             
-                            if child.type == "user_type":
+                            if child.type in ("user_type", "nullable_type"):
                                 var_type = self._get_node_text(child)
 
                     # Attempt inference from initializer if type is unknown
@@ -346,22 +1450,120 @@ class KotlinTreeSitterParser:
                                 # call_expression -> simple_identifier (constructor)
                                 for sub in child.children:
                                     if sub.type == "simple_identifier":
-                                        var_type = self._get_node_text(sub)
-                                        break
+                                        candidate_type = self._get_node_text(sub)
+                                        if re.match(r"[A-Z]", candidate_type):
+                                            var_type = candidate_type
+                                            break
                                 if var_type != "Unknown": break
 
                     if var_name != "unknown":
-                        variables.append({
+                        initializer_text = self._extract_initializer_text(self._get_node_text(node))
+                        initializer_inferred_type = (
+                            self._extract_initializer_type(initializer_text)
+                            if initializer_text
+                            else None
+                        )
+                        if var_type == "Unknown" and initializer_inferred_type:
+                            var_type = initializer_inferred_type
+
+                        (
+                            initializer_receiver_name,
+                            initializer_member_name,
+                            initializer_member_kind,
+                        ) = (
+                            self._initializer_member_hint(initializer_text)
+                            if initializer_text
+                            else (None, None, None)
+                        )
+                        (
+                            initializer_collection_receiver_name,
+                            initializer_collection_member_name,
+                            initializer_collection_operator,
+                        ) = (
+                            self._initializer_collection_return_hint(initializer_text)
+                            if initializer_text
+                            else (None, None, None)
+                        )
+
+                        variable_data = {
                             "name": var_name,
                             "type": var_type,
                             "line_number": start_line,
                             "path": str(path),
                             "lang": self.language_name,
                             "context": ctx_name,
-                            "class_context": ctx_name if ctx_type and ("class" in ctx_type or "object" in ctx_type) else None
-                        })
+                            "class_context": ctx_name if ctx_type and ("class" in ctx_type or "interface" in ctx_type or "object" in ctx_type) else None
+                        }
+                        if initializer_inferred_type:
+                            variable_data["initializer_inferred_type"] = initializer_inferred_type
+                        if initializer_receiver_name and initializer_member_name:
+                            variable_data["initializer_receiver_name"] = initializer_receiver_name
+                            variable_data["initializer_member_name"] = initializer_member_name
+                            variable_data["initializer_member_kind"] = initializer_member_kind
+                        if initializer_collection_receiver_name and initializer_collection_member_name:
+                            variable_data["initializer_collection_receiver_name"] = initializer_collection_receiver_name
+                            variable_data["initializer_collection_member_name"] = initializer_collection_member_name
+                            variable_data["initializer_collection_operator"] = initializer_collection_operator
+                        if initializer_text:
+                            variable_data["initializer_text"] = initializer_text
+                        initializer_candidate_names = self._initializer_candidate_names(initializer_text)
+                        if initializer_candidate_names:
+                            variable_data["initializer_candidate_names"] = initializer_candidate_names
+                        variables.append(variable_data)
                 except Exception as e:
                     continue
+
+        function_ranges = [
+            (
+                function.get("line_number"),
+                function.get("end_line", function.get("line_number")),
+                function.get("name"),
+                function.get("class_context"),
+            )
+            for function in (functions or [])
+            if function.get("name") and function.get("line_number")
+        ]
+
+        for line_number, line in enumerate(source_code.splitlines(), start=1):
+            destructuring_match = re.match(
+                r'\s*(?:val|var)\s*\(([^)]+)\)\s*=\s*(.+)',
+                line,
+            )
+            if not destructuring_match:
+                continue
+
+            initializer_text = destructuring_match.group(2).strip()
+            initializer_inferred_type = self._extract_initializer_type(initializer_text)
+            context_name = None
+            class_context = None
+            for start_line, end_line, function_name, function_class_context in function_ranges:
+                if start_line <= line_number <= end_line:
+                    context_name = function_name
+                    class_context = function_class_context
+                    break
+
+            for raw_name in destructuring_match.group(1).split(","):
+                var_name = raw_name.strip()
+                if not var_name or var_name == "_":
+                    continue
+                if any(
+                    existing.get("name") == var_name
+                    and existing.get("line_number") == line_number
+                    for existing in variables
+                ):
+                    continue
+                variable_data = {
+                    "name": var_name,
+                    "type": initializer_inferred_type or "Unknown",
+                    "line_number": line_number,
+                    "path": str(path),
+                    "lang": self.language_name,
+                    "context": context_name,
+                    "class_context": class_context,
+                }
+                if initializer_inferred_type:
+                    variable_data["initializer_inferred_type"] = initializer_inferred_type
+                variables.append(variable_data)
 
         return variables
 
@@ -393,17 +1595,94 @@ class KotlinTreeSitterParser:
 
         return imports
 
-    def _parse_calls(self, captures: list, source_code: str, path: Path, variables: list[Dict[str, Any]] = []) -> list[Dict[str, Any]]:
+    def _parse_calls(
+        self,
+        captures: list,
+        source_code: str,
+        path: Path,
+        variables: list[Dict[str, Any]] = [],
+        functions: list[Dict[str, Any]] = [],
+    ) -> list[Dict[str, Any]]:
         calls = []
         seen_calls = set()
+        package_name = self._extract_package_name(source_code)
+
+        def function_scope(function: Dict[str, Any]) -> Tuple[Optional[str], Optional[int], Optional[str]]:
+            return (
+                function.get("name"),
+                function.get("line_number"),
+                function.get("context") or function.get("class_context"),
+            )
+
+        def function_scope_for_line(
+            context_name: Optional[str],
+            line_number: Optional[int],
+        ) -> Any:
+            if not context_name or line_number is None:
+                return context_name
+            for function in functions:
+                if function.get("name") != context_name:
+                    continue
+                start_line = function.get("line_number")
+                end_line = function.get("end_line", start_line)
+                if start_line is None or end_line is None:
+                    continue
+                if start_line <= line_number <= end_line:
+                    return function_scope(function)
+            return context_name
+
+        def variable_scope(variable: Dict[str, Any]) -> Any:
+            return function_scope_for_line(
+                variable.get("context"),
+                variable.get("line_number"),
+            )
         
         # Index variables for fast lookup: (name, context) -> type
         var_map = {}
+        raw_var_map = {}
+        var_declarations = {}
+        raw_var_declarations = {}
+
+        def record_declaration(
+            declarations: Dict[Tuple[str, Any], list[Tuple[Optional[int], Optional[str]]]],
+            key: Tuple[str, Any],
+            line_number: Optional[int],
+            type_name: Optional[str],
+        ) -> None:
+            declarations.setdefault(key, []).append((line_number, type_name))
+
         for v in variables:
-            key = (v['name'], v['context'])
-            var_map[key] = v['type']
+            key = (v['name'], variable_scope(v))
+            raw_type = v.get('type', '')
+            record_declaration(
+                raw_var_declarations,
+                key,
+                v.get("line_number"),
+                raw_type if raw_type and raw_type != "Unknown" else None,
+            )
+            if raw_type and raw_type != "Unknown":
+                raw_var_map[key] = raw_type
+            normalized_type = self._strip_type_modifiers(v.get('type', ''))
+            record_declaration(
+                var_declarations,
+                key,
+                v.get("line_number"),
+                normalized_type if normalized_type and normalized_type != "Unknown" else None,
+            )
+            if normalized_type and normalized_type != "Unknown":
+                var_map[key] = normalized_type
             # Fallback for null context or partial match could be added
             # For class props: (name, class_context) might work if local lookup fails?
+
+        function_return_map = {}
+        function_receiver_map = {}
+        for f in functions:
+            return_type = f.get("return_type")
+            if return_type:
+                function_return_map[(f.get("context"), f["name"])] = self._strip_type_modifiers(return_type)
+            receiver_type = f.get("receiver_type")
+            if receiver_type:
+                function_receiver_map[(f["name"], f.get("line_number"))] = self._strip_type_modifiers(receiver_type)
 
         for node, capture_name in captures:
             if capture_name == "call_node":
@@ -440,135 +1719,330 @@ class KotlinTreeSitterParser:
                     # Let's verify children
                     children = node.children
                     first_child = children[0]
+                    enclosing_class, enclosing_class_line = self._get_enclosing_class_context(node)
                     
-                    if first_child.type == "simple_identifier":
-                        call_name = self._get_node_text(first_child)
-                        # No explicit base object
-                    elif first_child.type == "navigation_expression":
-                        # x.foo
-                        # children: operand (x), operator (.), suffix (foo)
-                        # Usually 3 children?
-                        # Let's inspect nav expression children
-                        nav_children = first_child.children
-                        if len(nav_children) >= 2:
-                             # operand is 0
-                             operand = nav_children[0]
-                             # last one is suffix?
-                             suffix = nav_children[-1]
-                             
-                             # Suffix usually contains the method name in a navigation_suffix node or directly?
-                             # Suffix is (navigation_suffix (simple_identifier)) usually.
-                             
-                             if suffix.type == "navigation_suffix":
-                                 # (navigation_suffix (simple_identifier))
-                                 for c in suffix.children:
-                                     if c.type == "simple_identifier":
-                                         call_name = self._get_node_text(c)
-                                         break
-                             elif suffix.type == "simple_identifier":
-                                 call_name = self._get_node_text(suffix)
-                                 
-                             # Base object
-                             base_obj = self._get_node_text(operand)
-                    
+                    if node.type == "constructor_invocation":
+                        for child in node.children:
+                            if child.type == "user_type":
+                                call_name = self._strip_type_modifiers(self._get_node_text(child))
+                                break
+                    elif node.type == "constructor_delegation_call":
+                        delegation_target = self._get_node_text(first_child)
+                        if delegation_target == "this" and enclosing_class:
+                            call_name = enclosing_class
+                        elif delegation_target == "super":
+                            call_name = "super"
+                            base_obj = "super"
+                    elif node.type == "callable_reference":
+                        call_name, base_obj = self._extract_call_parts(node)
+                    else:
+                        call_name, base_obj = self._extract_call_parts(node)
+
                     if call_name == "unknown":
                         continue
-                        
+
                     full_name = f"{base_obj}.{call_name}" if base_obj else call_name
-                    
+
                     ctx_name, ctx_type, ctx_line = self._get_parent_context(node)
+                    current_scope = function_scope_for_line(ctx_name, ctx_line)
+                    implicit_receiver_type = (
+                        function_receiver_map.get((ctx_name, ctx_line))
+                        if ctx_type == "function_declaration"
+                        else None
+                    )
                     
                     # Inference
                     inferred_type = None
+                    extension_receiver_type = None
+                    receiver_base_type = None
+                    receiver_member_name = None
+                    receiver_member_kind = None
                     if base_obj:
-                        # Lookup base_obj in variables
-                        # Try exact context
-                        inferred_type = var_map.get((base_obj, ctx_name))
-                        if not inferred_type:
-                            # Try class context if we are in a method
-                             # This logic is approximate.
-                             # If we are in method 'foo' of 'ClassA', and 'base_obj' refers to a property of 'ClassA',
-                             # var_map entry would have context 'ClassA'.
-                             # But our 'variables' parsing puts context as 'ClassA' for props.
-                             # But 'ctx_name' here is 'foo'.
-                             # We need to know 'foo' is in 'ClassA'.
-                             # 'get_parent_context' returns immediate parent.
-                             pass
-                             # Fallback: check global/file scope (context=None)
-                             if not inferred_type:
-                                 inferred_type = var_map.get((base_obj, None))
-                             
-                             # Fallback: check if any variable named base_obj exists (loose match)
-                             if not inferred_type:
-                                 for (vname, vctx), vtype in var_map.items():
-                                     if vname == base_obj:
-                                         inferred_type = vtype
-                                         break
+                        inferred_type = self._infer_receiver_type(
+                            base_obj,
+                            current_scope,
+                            enclosing_class,
+                            var_map,
+                            function_return_map,
+                            var_declarations,
+                            start_line,
+                        )
+                        (
+                            receiver_base_type,
+                            receiver_member_name,
+                            receiver_member_kind,
+                        ) = self._receiver_member_hint(
+                            base_obj,
+                            current_scope,
+                            enclosing_class,
+                            var_map,
+                            function_return_map,
+                            var_declarations,
+                            start_line,
+                        )
+                        extension_receiver_type = inferred_type
 
+                        indexed_access_type = self._indexed_access_value_type(
+                            base_obj,
+                            current_scope,
+                            enclosing_class,
+                            raw_var_map,
+                            raw_var_declarations,
+                            start_line,
+                        )
+                        if indexed_access_type:
+                            inferred_type = indexed_access_type
+                            extension_receiver_type = indexed_access_type
 
-                    calls.append({
+                        smart_cast_type = self._smart_cast_receiver_hint(node, base_obj)
+                        if smart_cast_type:
+                            inferred_type = smart_cast_type
+                            extension_receiver_type = smart_cast_type
+
+                    scope_name, scope_receiver_type, scope_lambda_parameter = self._scope_function_receiver_hint(
+                        node,
+                        current_scope,
+                        enclosing_class,
+                        var_map,
+                        function_return_map,
+                        var_declarations,
+                        start_line,
+                    )
+                    if scope_receiver_type:
+                        is_implicit_receiver_call = (
+                            not base_obj
+                            and scope_name in {"apply", "run", "with"}
+                        )
+                        is_this_receiver_call = (
+                            base_obj == "this"
+                            and scope_name in {"apply", "run", "with"}
+                        )
+                        is_it_receiver_call = (
+                            base_obj == "it"
+                            and scope_name in {"let", "also"}
+                        )
+                        is_named_lambda_receiver_call = (
+                            scope_lambda_parameter is not None
+                            and base_obj == scope_lambda_parameter
+                        )
+                        if (
+                            is_implicit_receiver_call
+                            or is_this_receiver_call
+                            or is_it_receiver_call
+                            or is_named_lambda_receiver_call
+                        ):
+                            inferred_type = scope_receiver_type
+                            extension_receiver_type = scope_receiver_type
+
+                    (
+                        lambda_parameter_name,
+                        lambda_parameter_type,
+                        lambda_value_type,
+                    ) = self._collection_lambda_hint(
+                        node,
+                        current_scope,
+                        enclosing_class,
+                        raw_var_map,
+                        raw_var_declarations,
+                        start_line,
+                    )
+                    if base_obj and lambda_parameter_name:
+                        if base_obj == lambda_parameter_name and lambda_parameter_type:
+                            inferred_type = lambda_parameter_type
+                            extension_receiver_type = lambda_parameter_type
+                        elif base_obj == f"{lambda_parameter_name}.value" and lambda_value_type:
+                            inferred_type = lambda_value_type
+                            extension_receiver_type = lambda_value_type
+
+                    (
+                        callable_collection_receiver,
+                        callable_collection_operator,
+                    ) = self._callable_reference_collection_hint(node)
+
+                    call_data = {
                         "name": call_name,
                         "full_name": full_name,
+                        "base_obj": base_obj,
+                        "call_kind": "callable_reference" if node.type == "callable_reference" else "call",
                         "line_number": start_line,
-                        "args": [], # Simplified
+                        "args": self._extract_call_arguments(node),
                         "inferred_obj_type": inferred_type,
-                        "context": [None, ctx_type, ctx_line], # Keeping format compatible
-                        "class_context": [None, None],
+                        "extension_receiver_type": extension_receiver_type,
+                        "implicit_receiver_type": implicit_receiver_type,
+                        "scope_receiver_type": scope_receiver_type,
+                        "receiver_base_type": receiver_base_type,
+                        "receiver_member_name": receiver_member_name,
+                        "receiver_member_kind": receiver_member_kind,
+                        "enclosing_class": enclosing_class,
+                        "package": package_name,
+                        "context": (ctx_name, ctx_type, ctx_line),
+                        "class_context": (enclosing_class, enclosing_class_line),
                         "lang": self.language_name,
                         "is_dependency": False
-                    })
+                    }
+                    if callable_collection_receiver:
+                        call_data["callable_reference_collection_receiver"] = callable_collection_receiver
+                        call_data["callable_reference_collection_operator"] = callable_collection_operator
+                    calls.append(call_data)
                 except Exception as e:
                     continue
         return calls
+
+    def _split_parameters(self, params_text: str) -> list[str]:
+        if not params_text:
+            return []
+
+        clean = params_text.strip()
+        if clean.startswith('(') and clean.endswith(')'):
+            clean = clean[1:-1]
+
+        if not clean.strip():
+            return []
+
+        current_param = []
+        depth_angle = 0
+        depth_round = 0
+        depth_square = 0
+        depth_curly = 0
+
+        raw_params = []
+
+        for char in clean:
+            if char == '<':
+                depth_angle += 1
+            elif char == '>':
+                depth_angle = max(0, depth_angle - 1)
+            elif char == '(':
+                depth_round += 1
+            elif char == ')':
+                depth_round -= 1
+            elif char == '[':
+                depth_square += 1
+            elif char == ']':
+                depth_square -= 1
+            elif char == '{':
+                depth_curly += 1
+            elif char == '}':
+                depth_curly -= 1
+
+            if (
+                char == ','
+                and depth_angle == 0
+                and depth_round == 0
+                and depth_square == 0
+                and depth_curly == 0
+            ):
+                raw_params.append("".join(current_param).strip())
+                current_param = []
+            else:
+                current_param.append(char)
+
+        if current_param:
+            raw_params.append("".join(current_param).strip())
+
+        return raw_params
+
+    def _strip_parameter_default(self, type_text: str) -> str:
+        current = []
+        depth_angle = 0
+        depth_round = 0
+        depth_square = 0
+        depth_curly = 0
+
+        for char in type_text:
+            if char == '<':
+                depth_angle += 1
+            elif char == '>':
+                depth_angle = max(0, depth_angle - 1)
+            elif char == '(':
+                depth_round += 1
+            elif char == ')':
+                depth_round -= 1
+            elif char == '[':
+                depth_square += 1
+            elif char == ']':
+                depth_square -= 1
+            elif char == '{':
+                depth_curly += 1
+            elif char == '}':
+                depth_curly -= 1
+
+            if (
+                char == '='
+                and depth_angle == 0
+                and depth_round == 0
+                and depth_square == 0
+                and depth_curly == 0
+            ):
+                break
+            current.append(char)
+
+        return "".join(current).strip()
+
+    def _parameter_has_default(self, param_text: str) -> bool:
+        depth_angle = 0
+        depth_round = 0
+        depth_square = 0
+        depth_curly = 0
+
+        for char in param_text:
+            if char == '<':
+                depth_angle += 1
+            elif char == '>':
+                depth_angle = max(0, depth_angle - 1)
+            elif char == '(':
+                depth_round += 1
+            elif char == ')':
+                depth_round = max(0, depth_round - 1)
+            elif char == '[':
+                depth_square += 1
+            elif char == ']':
+                depth_square = max(0, depth_square - 1)
+            elif char == '{':
+                depth_curly += 1
+            elif char == '}':
+                depth_curly = max(0, depth_curly - 1)
+
+            if (
+                char == '='
+                and depth_angle == 0
+                and depth_round == 0
+                and depth_square == 0
+                and depth_curly == 0
+            ):
+                return True
+        return False
+
+    def _extract_parameter_defaults(self, params_text: str) -> list[bool]:
+        return [
+            self._parameter_has_default(param)
+            for param in self._split_parameters(params_text)
+        ]
+
+    def _extract_parameter_types(self, params_text: str) -> list[str]:
+        types = []
+        for param in self._split_parameters(params_text):
+            colon_index = param.find(':')
+            if colon_index == -1:
+                types.append("")
+                continue
+            type_text = self._strip_parameter_default(param[colon_index + 1:])
+            types.append(self._strip_type_modifiers(type_text))
+        return types
 
     def _extract_parameter_names(self, params_text: str) -> list[str]:
         """
         Extracts parameter names from a Kotlin parameter list string.
         Handles nested generics like Map<String, Int>.
-        
+
         Args:
             params_text (str): The text content of function_value_parameters node, e.g. "(a: Int, b: Map<String, Int>)"
-            
+
         Returns:
             list[str]: List of parameter names.
         """
         params = []
-        if not params_text: return params
-        
-        # Remove outer parentheses
-        clean = params_text.strip()
-        if clean.startswith('(') and clean.endswith(')'):
-            clean = clean[1:-1]
-        
-        if not clean.strip(): return params
-        
-        # Robust splitting by comma, respecting brackets <>, (), [], {}
-        current_param = []
-        depth_angle = 0 # < >
-        depth_round = 0 # ( )
-        depth_square = 0 # [ ]
-        depth_curly = 0 # { }
-        
-        raw_params = []
-        
-        for char in clean:
-            if char == '<': depth_angle += 1
-            elif char == '>': depth_angle -= 1
-            elif char == '(': depth_round += 1
-            elif char == ')': depth_round -= 1
-            elif char == '[': depth_square += 1
-            elif char == ']': depth_square -= 1
-            elif char == '{': depth_curly += 1
-            elif char == '}': depth_curly -= 1
-            
-            if char == ',' and depth_angle == 0 and depth_round == 0 and depth_square == 0 and depth_curly == 0:
-                raw_params.append("".join(current_param).strip())
-                current_param = []
-            else:
-                current_param.append(char)
-                
-        if current_param:
-            raw_params.append("".join(current_param).strip())
+        raw_params = self._split_parameters(params_text)
             
         # Process each raw parameter string to extract name
         # Format: "val x: Int", "override var y: String", "@Ann z: Int", "a: Int = 5"
@@ -606,6 +2080,39 @@ class KotlinTreeSitterParser:
 
 def pre_scan_kotlin(files: list[Path], parser_wrapper) -> dict:
     name_to_files = {}
+    parser = KotlinTreeSitterParser(parser_wrapper)
+
+    def add_symbol(name: str, path: Path):
+        if name not in name_to_files:
+            name_to_files[name] = []
+        name_to_files[name].append(str(path))
+
+    def find_child_text(node, child_type: str) -> Optional[str]:
+        for child in node.children:
+            if child.type == child_type:
+                return parser._get_node_text(child)
+        return None
+
+    def is_top_level_function(node) -> bool:
+        curr = node.parent
+        while curr:
+            if curr.type in (
+                "class_declaration",
+                "object_declaration",
+                "companion_object",
+                "function_declaration",
+            ):
+                return False
+            curr = curr.parent
+        return True
+
+    def walk_top_level_functions(node):
+        if node.type == "function_declaration" and is_top_level_function(node):
+            yield node
+            return
+        for child in node.children:
+            yield from walk_top_level_functions(child)
+
     for path in files:
         try:
             with open(path, 'r', encoding='utf-8', errors='ignore') as f:
@@ -614,9 +2121,7 @@ def pre_scan_kotlin(files: list[Path], parser_wrapper) -> dict:
             # 1. Extract package
             # package com.example.project
             package_name = ""
-            pkg_match = re.search(r'^\s*package\s+([\w\.]+)', content, re.MULTILINE)
-            if pkg_match:
-                package_name = pkg_match.group(1)
+            package_name = parser._extract_package_name(content)
             
             # 2. Extract classes/objects/interfaces/typealiases
             matches = re.finditer(r'\b(class|interface|object|typealias)\s+(\w+)', content)
@@ -624,17 +2129,30 @@ def pre_scan_kotlin(files: list[Path], parser_wrapper) -> dict:
             for match in matches:
                 name = match.group(2)
                 # Map simple name
-                if name not in name_to_files:
-                    name_to_files[name] = []
-                name_to_files[name].append(str(path))
+                add_symbol(name, path)
                 
                 # If package exists, map FQN
                 if package_name:
                     fqn = f"{package_name}.{name}"
-                    if fqn not in name_to_files:
-                        name_to_files[fqn] = []
-                    name_to_files[fqn].append(str(path))
-                    
+                    add_symbol(fqn, path)
+
+            tree = parser_wrapper.parser.parse(bytes(content, "utf8"))
+            for func_node in walk_top_level_functions(tree.root_node):
+                func_name = find_child_text(func_node, "simple_identifier")
+                if not func_name:
+                    continue
+
+                add_symbol(func_name, path)
+                if package_name:
+                    add_symbol(f"{package_name}.{func_name}", path)
+
+                receiver_type = find_child_text(func_node, "receiver_type")
+                if receiver_type:
+                    receiver_type = parser._strip_type_modifiers(receiver_type)
+                    add_symbol(f"{receiver_type}.{func_name}", path)
+                    if package_name:
+                        add_symbol(f"{package_name}.{receiver_type}.{func_name}", path)
+
         except Exception:
             pass
     return name_to_files

--- a/src/codegraphcontext/tools/type_utils.py
+++ b/src/codegraphcontext/tools/type_utils.py
@@ -1,0 +1,12 @@
+"""Shared type-name normalization helpers for parser and resolver heuristics."""
+
+
+def strip_type_modifiers(type_str: str) -> str:
+    """Return the resolvable base type, e.g. 'List<T>?' -> 'List'."""
+    stripped = type_str.strip()
+    while stripped.endswith("?"):
+        stripped = stripped[:-1].strip()
+    bracket = stripped.find("<")
+    if bracket != -1:
+        stripped = stripped[:bracket].strip()
+    return stripped

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -252,7 +252,7 @@ def cli_test_stubs(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_main, "list_watching_helper", lambda *_args, **_kwargs: None)
 
     fake_db = _FakeDBManager()
-    monkeypatch.setattr(cli_main, "_initialize_services", lambda *_args, **_kwargs: (fake_db, _FakeGraphBuilder(), _FakeCodeFinder()))
+    monkeypatch.setattr(cli_main, "_initialize_services", lambda *_args, **_kwargs: (fake_db, _FakeGraphBuilder(), _FakeCodeFinder(), MagicMock()))
     monkeypatch.setattr(cli_main.DatabaseManager, "test_connection", staticmethod(lambda *_args, **_kwargs: (True, None)))
     monkeypatch.setattr(cli_main.typer, "confirm", lambda *_args, **_kwargs: True)
 

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -205,6 +205,15 @@ class _FakeCodeFinder:
             }]
         }
 
+    def audit_kotlin_call_ambiguity(self, *_args, **_kwargs):
+        return {
+            "kotlin_fn_to_fn_edges": 0,
+            "ambiguous_groups": 0,
+            "ambiguous_edges": 0,
+            "top_names": [],
+            "examples": [],
+        }
+
     def list_indexed_repositories(self):
         return [{"name": "repo", "path": "repo"}]
 
@@ -342,7 +351,18 @@ def test_cli_inventory_grouped_from_source():
     assert inventory["bundle"] == {"export", "import", "load"}
     assert inventory["registry"] == {"list", "search", "download", "request"}
     assert inventory["find"] == {"name", "pattern", "type", "variable", "content", "decorator", "argument"}
-    assert inventory["analyze"] == {"calls", "callers", "chain", "deps", "tree", "complexity", "dead-code", "overrides", "variable"}
+    assert inventory["analyze"] == {
+        "calls",
+        "callers",
+        "chain",
+        "deps",
+        "tree",
+        "complexity",
+        "dead-code",
+        "overrides",
+        "variable",
+        "kotlin-call-audit",
+    }
     if "datasource" in inventory:
         assert inventory["datasource"] == {"mysql", "cassandra", "redis"}
     if "context" in inventory:
@@ -397,6 +417,7 @@ def test_all_canonical_cli_commands_run_with_kuzudb(kuzudb_env, cli_test_stubs):
         ["analyze", "dead-code"],
         ["analyze", "overrides", "run"],
         ["analyze", "variable", "value"],
+        ["analyze", "kotlin-call-audit"],
         ["query", "MATCH (n) RETURN n LIMIT 1"],
         ["cypher", "MATCH (n) RETURN n LIMIT 1"],
         ["i", "."],
@@ -662,7 +683,4 @@ def test_load_credentials_displays_kuzudb_backend(monkeypatch, tmp_path):
         with patch("codegraphcontext.cli.main.console", Console(file=output, force_terminal=False)):
             _load_credentials()
 
-        lowered = output.getvalue().lower()
-        assert "using database: kuzudb" in lowered
-        assert "source:" in lowered
-
+        assert "Using database: KùzuDB" in output.getvalue()

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -683,4 +683,6 @@ def test_load_credentials_displays_kuzudb_backend(monkeypatch, tmp_path):
         with patch("codegraphcontext.cli.main.console", Console(file=output, force_terminal=False)):
             _load_credentials()
 
-        assert "Using database: KùzuDB" in output.getvalue()
+        lowered = output.getvalue().lower()
+        assert "using database: kuzudb" in lowered
+        assert "source:" in lowered

--- a/tests/unit/cli/test_index_exit_codes.py
+++ b/tests/unit/cli/test_index_exit_codes.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from codegraphcontext.cli import cli_helpers
+
+
+async def _failing_index(*_args, **_kwargs):
+    raise RuntimeError("boom")
+
+
+def _services(tmp_path):
+    db_manager = MagicMock()
+    code_finder = MagicMock()
+    code_finder.list_indexed_repositories.return_value = []
+    ctx = SimpleNamespace(cgcignore_path=None, mode="global")
+    return db_manager, MagicMock(), code_finder, ctx
+
+
+def test_index_helper_exits_nonzero_on_indexing_failure(tmp_path):
+    services = _services(tmp_path)
+    with (
+        patch.object(cli_helpers, "_initialize_services", return_value=services),
+        patch.object(cli_helpers, "_run_index_with_progress", side_effect=_failing_index),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        cli_helpers.index_helper(str(tmp_path))
+
+    assert exc_info.value.exit_code == 1
+    services[0].close_driver.assert_called_once()
+
+
+def test_reindex_helper_exits_nonzero_on_indexing_failure(tmp_path):
+    services = _services(tmp_path)
+    with (
+        patch.object(cli_helpers, "_initialize_services", return_value=services),
+        patch.object(cli_helpers, "_run_index_with_progress", side_effect=_failing_index),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        cli_helpers.reindex_helper(str(tmp_path))
+
+    assert exc_info.value.exit_code == 1
+    services[0].close_driver.assert_called_once()

--- a/tests/unit/core/test_cgcignore_patterns.py
+++ b/tests/unit/core/test_cgcignore_patterns.py
@@ -2,6 +2,8 @@ import subprocess
 import shutil
 import os
 import json
+import shlex
+import sys
 import pytest
 import uuid
 import time
@@ -15,6 +17,18 @@ from codegraphcontext.tools.graph_builder import DEFAULT_IGNORE_PATTERNS
 
 # Use unique directory for EACH test run to avoid conflicts
 BASE_TEST_DIR = Path("/tmp/cgc_test")
+TEST_HOME = BASE_TEST_DIR / "_home"
+CGC_CMD = f"{shlex.quote(sys.executable)} -m codegraphcontext.cli.main"
+
+
+def _test_env():
+    """Run shell-based CGC tests against the current interpreter in an isolated HOME."""
+    TEST_HOME.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["HOME"] = str(TEST_HOME)
+    env["DEFAULT_DATABASE"] = "falkordb"
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    return env
 
 def get_unique_test_dir():
     """Generate unique test directory"""
@@ -23,7 +37,7 @@ def get_unique_test_dir():
 
 def run(cmd):
     """Run command and return output"""
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, env=_test_env())
     return result.stdout + result.stderr
 
 
@@ -45,7 +59,7 @@ def setup_test_dir(test_dir: Path):
 def clean_db_completely():
     """Completely clean the database"""
     # Delete ALL nodes
-    run('cgc query "MATCH (n) DETACH DELETE n"')
+    run(f'{CGC_CMD} query "MATCH (n) DETACH DELETE n"')
     time.sleep(1)  # Wait for DB to sync
 
 def delete_repo_from_db(repo_path: Path):
@@ -53,25 +67,25 @@ def delete_repo_from_db(repo_path: Path):
     path_str = str(repo_path.resolve())
     # Escape quotes properly for shell
     escaped_path = path_str.replace('"', '\\"')
-    run(f'cgc query "MATCH (r:Repository {{path: \\"{escaped_path}\\"}})-[:CONTAINS*]->(n) DETACH DELETE r, n"')
-    run(f'cgc query "MATCH (r:Repository {{path: \\"{escaped_path}\\"}}) DETACH DELETE r"')
+    run(f'{CGC_CMD} query "MATCH (r:Repository {{path: \\"{escaped_path}\\"}})-[:CONTAINS*]->(n) DETACH DELETE r, n"')
+    run(f'{CGC_CMD} query "MATCH (r:Repository {{path: \\"{escaped_path}\\"}}) DETACH DELETE r"')
 
 def index_repo(test_dir: Path):
     """Index the test repository"""
-    output = run(f"cgc index {test_dir}")
+    output = run(f"{CGC_CMD} index {shlex.quote(str(test_dir))}")
     print(f"INDEX OUTPUT: {output[:500]}")  # Debug
     time.sleep(0.5)  # Wait for indexing to complete
     return output
 
 def query_all_files():
     """Query ALL files in database for debugging"""
-    output = run('cgc query "MATCH (f:File) RETURN f.name, f.path LIMIT 20"')
+    output = run(f'{CGC_CMD} query "MATCH (f:File) RETURN f.name, f.path LIMIT 20"')
     print(f"ALL FILES IN DB: {output}")
     return output
 
 def query_all_repos():
     """Query ALL repositories in database for debugging"""
-    output = run('cgc query "MATCH (r:Repository) RETURN r.name, r.path"')
+    output = run(f'{CGC_CMD} query "MATCH (r:Repository) RETURN r.name, r.path"')
     print(f"ALL REPOS IN DB: {output}")
     return output
 
@@ -84,7 +98,7 @@ def query_files_for_repo(test_dir: Path):
     
     # Use simpler query - match by repository name (folder name)
     repo_name = test_dir.name
-    output = run(f'cgc query "MATCH (r:Repository)-[:CONTAINS*]->(f:File) WHERE r.path CONTAINS \\"{repo_name}\\" RETURN f.name"')
+    output = run(f'{CGC_CMD} query "MATCH (r:Repository)-[:CONTAINS*]->(f:File) WHERE r.path CONTAINS \\"{repo_name}\\" RETURN f.name"')
     
     print(f"QUERY OUTPUT for {repo_name}: {output}")
     

--- a/tests/unit/core/test_database_kuzu_kotlin_metadata.py
+++ b/tests/unit/core/test_database_kuzu_kotlin_metadata.py
@@ -1,0 +1,290 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("kuzu")
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+
+def _fresh_kuzu_manager(db_path: Path) -> KuzuDBManager:
+    if KuzuDBManager._instance is not None:
+        KuzuDBManager._instance.close_driver()
+    KuzuDBManager._instance = None
+    KuzuDBManager._db = None
+    KuzuDBManager._conn = None
+    return KuzuDBManager(db_path=str(db_path))
+
+
+def test_kuzu_schema_metadata_migration_failures_are_fatal(tmp_path):
+    manager = _fresh_kuzu_manager(tmp_path / "migration-failure-db")
+    try:
+        manager._conn = MagicMock()
+
+        def execute(statement):
+            if "class_context_line" in statement:
+                raise Exception("permission denied")
+            return None
+
+        manager._conn.execute.side_effect = execute
+
+        with pytest.raises(RuntimeError, match="Kuzu Schema Migration Failed"):
+            manager._initialize_schema()
+    finally:
+        manager.close_driver()
+
+
+def test_class_node_type_persists_in_kuzu(tmp_path):
+    manager = _fresh_kuzu_manager(tmp_path / "node-type-db")
+    try:
+        driver = manager.get_driver()
+        with driver.session() as session:
+            session.run(
+                """
+                MERGE (c:Class {uid: $uid})
+                SET c.name = $name,
+                    c.path = $path,
+                    c.line_number = $line_number,
+                    c.node_type = $node_type
+                """,
+                uid="class-1",
+                name="Factory",
+                path="/repo/Sample.kt",
+                line_number=4,
+                node_type="companion_object",
+            )
+            row = session.run(
+                "MATCH (c:Class {uid: $uid}) RETURN c.node_type AS node_type",
+                uid="class-1",
+            ).single()
+
+        assert row is not None
+        assert row["node_type"] == "companion_object"
+    finally:
+        manager.close_driver()
+
+
+def test_calls_metadata_updates_do_not_duplicate_kuzu_relationships(tmp_path):
+    manager = _fresh_kuzu_manager(tmp_path / "calls-db")
+    try:
+        driver = manager.get_driver()
+        with driver.session() as session:
+            session.run(
+                """
+                MERGE (f:Function {uid: $uid})
+                SET f.name = $name, f.path = $path, f.line_number = $line_number
+                """,
+                uid="caller",
+                name="caller",
+                path="/repo/Sample.kt",
+                line_number=1,
+            )
+            session.run(
+                """
+                MERGE (f:Function {uid: $uid})
+                SET f.name = $name, f.path = $path, f.line_number = $line_number
+                """,
+                uid="target",
+                name="target",
+                path="/repo/Sample.kt",
+                line_number=5,
+            )
+
+        writer = GraphWriter(driver)
+        call = {
+            "caller_name": "caller",
+            "caller_file_path": "/repo/Sample.kt",
+            "caller_line_number": 1,
+            "called_name": "target",
+            "called_file_path": "/repo/Sample.kt",
+            "called_line_number": 5,
+            "line_number": 2,
+            "args": [],
+            "full_call_name": "target",
+        }
+        writer.write_function_call_groups(
+            [{**call, "confidence": 0.25, "resolution_tier": 5}],
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
+        writer.write_function_call_groups(
+            [{**call, "confidence": 0.95, "resolution_tier": 1}],
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
+
+        with driver.session() as session:
+            rows = session.run(
+                """
+                MATCH (:Function {name: $caller, path: $path, line_number: $caller_line})
+                      -[r:CALLS]->
+                      (:Function {name: $called, path: $path, line_number: $called_line})
+                RETURN r.confidence AS confidence, r.resolution_tier AS resolution_tier
+                """,
+                caller="caller",
+                called="target",
+                path="/repo/Sample.kt",
+                caller_line=1,
+                called_line=5,
+            ).data()
+
+        assert rows == [{"confidence": pytest.approx(0.95), "resolution_tier": 1}]
+    finally:
+        manager.close_driver()
+
+
+def test_class_calls_use_target_line_in_kuzu(tmp_path):
+    manager = _fresh_kuzu_manager(tmp_path / "class-calls-db")
+    try:
+        driver = manager.get_driver()
+        with driver.session() as session:
+            session.run(
+                """
+                MERGE (f:Function {uid: $uid})
+                SET f.name = $name, f.path = $path, f.line_number = $line_number
+                """,
+                uid="make",
+                name="make",
+                path="/repo/Sample.kt",
+                line_number=3,
+            )
+            for line_number in (2, 7):
+                session.run(
+                    """
+                    MERGE (c:Class {uid: $uid})
+                    SET c.name = $name, c.path = $path, c.line_number = $line_number
+                    """,
+                    uid=f"inner-{line_number}",
+                    name="Inner",
+                    path="/repo/Sample.kt",
+                    line_number=line_number,
+                )
+
+        writer = GraphWriter(driver)
+        writer.write_function_call_groups(
+            [],
+            [
+                {
+                    "caller_name": "make",
+                    "caller_file_path": "/repo/Sample.kt",
+                    "caller_line_number": 3,
+                    "called_name": "Inner",
+                    "called_file_path": "/repo/Sample.kt",
+                    "called_line_number": 2,
+                    "line_number": 3,
+                    "args": [],
+                    "full_call_name": "Inner",
+                }
+            ],
+            [],
+            [],
+            [],
+            [],
+        )
+
+        with driver.session() as session:
+            rows = session.run(
+                """
+                MATCH (:Function {name: $caller, path: $path, line_number: $caller_line})
+                      -[:CALLS]->
+                      (called:Class {name: $called, path: $path})
+                RETURN called.line_number AS line_number
+                ORDER BY line_number
+                """,
+                caller="make",
+                called="Inner",
+                path="/repo/Sample.kt",
+                caller_line=3,
+            ).data()
+
+        assert rows == [{"line_number": 2}]
+    finally:
+        manager.close_driver()
+
+
+def test_class_function_containment_uses_owner_line_in_kuzu(tmp_path):
+    manager = _fresh_kuzu_manager(tmp_path / "contains-db")
+    try:
+        driver = manager.get_driver()
+        writer = GraphWriter(driver)
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        file_path = repo_path / "Sample.kt"
+        file_path.write_text("", encoding="utf-8")
+
+        writer.add_repository_to_graph(repo_path)
+        writer.add_file_to_graph(
+            {
+                "path": str(file_path),
+                "repo_path": str(repo_path),
+                "lang": "kotlin",
+                "is_dependency": False,
+                "functions": [
+                    {
+                        "name": "run",
+                        "line_number": 3,
+                        "args": [],
+                        "class_context": "Worker",
+                        "class_context_line": 2,
+                    },
+                    {
+                        "name": "run",
+                        "line_number": 8,
+                        "args": [],
+                        "class_context": "Worker",
+                        "class_context_line": 7,
+                    },
+                ],
+                "classes": [
+                    {"name": "Worker", "line_number": 2, "node_type": "class_declaration"},
+                    {"name": "Worker", "line_number": 7, "node_type": "class_declaration"},
+                ],
+                "variables": [],
+                "imports": [],
+                "function_calls": [],
+            },
+            repo_path.name,
+            {},
+            repo_path_str=str(repo_path),
+        )
+
+        with driver.session() as session:
+            first_owner = session.run(
+                """
+                MATCH (:Class {name: $class_name, path: $path, line_number: $class_line})
+                      -[:CONTAINS]->
+                      (fn:Function {name: $function_name, path: $path})
+                RETURN fn.line_number AS line_number
+                ORDER BY line_number
+                """,
+                class_name="Worker",
+                function_name="run",
+                path=str(file_path.resolve()),
+                class_line=2,
+            ).data()
+            second_owner = session.run(
+                """
+                MATCH (:Class {name: $class_name, path: $path, line_number: $class_line})
+                      -[:CONTAINS]->
+                      (fn:Function {name: $function_name, path: $path})
+                RETURN fn.line_number AS line_number
+                ORDER BY line_number
+                """,
+                class_name="Worker",
+                function_name="run",
+                path=str(file_path.resolve()),
+                class_line=7,
+            ).data()
+
+        assert first_owner == [{"line_number": 3}]
+        assert second_owner == [{"line_number": 8}]
+    finally:
+        manager.close_driver()

--- a/tests/unit/parsers/test_java_parser.py
+++ b/tests/unit/parsers/test_java_parser.py
@@ -159,6 +159,73 @@ class TestJavaDiCrossFileCalls:
         assert JavaTreeSitterParser._strip_generic("  RoidFraudCheckService  ") == "RoidFraudCheckService"
 
 
+class TestJavaParameterParsing:
+    def test_annotation_string_commas_do_not_split_parameters(self, parser):
+        src = """
+        package com.example.app;
+
+        public class AnnotatedController {
+            public void handle(
+                @Named(value = "text, with (parentheses)", escaped = "quote: \\"") String name,
+                java.util.List<java.util.Map<String, Integer>> values
+            ) {}
+        }
+
+        @interface Named {
+            String value();
+            String escaped() default "";
+        }
+        """
+
+        data = _write_and_parse(parser, src)
+        handle = next(f for f in data["functions"] if f["name"] == "handle")
+
+        assert handle["args"] == ["name", "values"]
+        assert handle["arg_types"] == ["String", "java.util.List"]
+
+    def test_annotation_array_values_do_not_split_parameters(self, parser):
+        src = """
+        package com.example.app;
+
+        public class AnnotatedController {
+            public void handle(@Flags({"a,b", "(x,y)"}) String name, int count) {}
+        }
+
+        @interface Flags {
+            String[] value();
+        }
+        """
+
+        data = _write_and_parse(parser, src)
+        handle = next(f for f in data["functions"] if f["name"] == "handle")
+
+        assert handle["args"] == ["name", "count"]
+        assert handle["arg_types"] == ["String", "Int"]
+
+    def test_final_with_non_space_whitespace_is_stripped(self, parser):
+        src = """
+        package com.example.app;
+
+        public class AnnotatedController {
+            public void handle(
+                @Named("a,b") final
+                String name,
+                final\tint count
+            ) {}
+        }
+
+        @interface Named {
+            String value();
+        }
+        """
+
+        data = _write_and_parse(parser, src)
+        handle = next(f for f in data["functions"] if f["name"] == "handle")
+
+        assert handle["args"] == ["name", "count"]
+        assert handle["arg_types"] == ["String", "Int"]
+
+
 # ---------------------------------------------------------------------------
 # End-to-end: full cross-file CALLS resolution via resolve_function_call
 # ---------------------------------------------------------------------------
@@ -225,6 +292,30 @@ class TestJavaCrossFileResolution:
                 assert resolved["called_file_path"] == service_path, (
                     f"WorkService has no DI fields; expected self-resolution for '{call['name']}'"
                 )
+
+
+    def test_super_call_without_base_context_stays_in_caller_file(self):
+        """Non-Kotlin super.method() calls must not resolve to unrelated same-name symbols."""
+        caller_path = "/tmp/Controller.java"
+        external_path = "/tmp/Audit.java"
+
+        resolved = resolve_function_call(
+            {
+                "name": "audit",
+                "full_name": "super.audit",
+                "line_number": 12,
+                "args": [],
+                "context": ("handle", "function", 10),
+            },
+            caller_file_path=caller_path,
+            local_names={"Controller", "handle"},
+            local_imports={},
+            imports_map={"audit": [external_path]},
+            skip_external=False,
+        )
+
+        assert resolved is not None
+        assert resolved["called_file_path"] == caller_path
 
 
 # ---------------------------------------------------------------------------
@@ -434,4 +525,3 @@ class TestSpringDataRepoDetection:
             assert r.get("method_name"), f"method_name missing on {r}"
             assert r.get("method_path"), f"method_path missing on {r}"
             assert r.get("entity_class"), f"entity_class missing on {r}"
-

--- a/tests/unit/parsers/test_kotlin_parser.py
+++ b/tests/unit/parsers/test_kotlin_parser.py
@@ -1,0 +1,4084 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.tools.indexing.resolution.calls import build_function_call_groups, resolve_function_call
+from codegraphcontext.tools.languages.java import JavaTreeSitterParser, pre_scan_java
+from codegraphcontext.tools.languages.kotlin import KotlinTreeSitterParser, pre_scan_kotlin
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+@pytest.fixture(scope="module")
+def parser():
+    manager = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "kotlin"
+    wrapper.language = manager.get_language_safe("kotlin")
+    wrapper.parser = manager.create_parser("kotlin")
+    return KotlinTreeSitterParser(wrapper)
+
+
+def _write_and_parse(parser, src: str, suffix: str = ".kt") -> dict:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=suffix, delete=False, encoding="utf-8"
+    ) as f:
+        f.write(src)
+        tmp = f.name
+    try:
+        return parser.parse(Path(tmp))
+    finally:
+        os.unlink(tmp)
+
+
+def _write_source(root: Path, relative_path: str, src: str) -> Path:
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+EVENT_PROCESSOR_SRC = """
+package com.example
+
+data class Request(val id: String)
+
+class EventProcessorGrpcService(
+    private val progressService: ProgressService
+) {
+    fun submitEvents(request: Request): String {
+        val events = getEventsFromRequest(request)
+        progressService.applyEvent(events)
+        directHelper(events)
+        return events
+    }
+
+    private fun getEventsFromRequest(request: Request): String {
+        return request.id
+    }
+
+    private fun directHelper(events: String): String {
+        return events
+    }
+}
+"""
+
+
+PROGRESS_SERVICE_SRC = """
+package com.example
+
+class ProgressService {
+    fun applyEvent(event: String): String {
+        return event
+    }
+}
+"""
+
+
+RECEIVER_PATTERNS_SRC = """
+package com.example
+
+class ReceiverPatterns(
+    private val ctorService: ProgressService,
+    private val optionalService: ProgressService?,
+    private val genericServices: List<ProgressService>
+) {
+    private val bodyService: ProgressService = ProgressService()
+    private val optionalBodyService: ProgressService? = ProgressService()
+
+    fun run(): String {
+        val localService: ProgressService = ProgressService()
+        val inferredLocal = ProgressService()
+
+        ctorService.applyEvent("ctor")
+        bodyService.applyEvent("body")
+        localService.applyEvent("local")
+        inferredLocal.applyEvent("inferred")
+        optionalService?.applyEvent("safeCtor")
+        optionalBodyService?.applyEvent("safeBody")
+        genericServices.first()
+
+        return "done"
+    }
+}
+"""
+
+OVERLOADED_SERVICE_SRC = """
+package com.example
+
+class OverloadedService {
+    fun target(value: String): String {
+        return value
+    }
+
+    fun target(value: String, flag: Boolean): String {
+        return value
+    }
+}
+
+class AmbiguousCache {
+    fun get(values: Sequence<String>): List<String> {
+        return emptyList()
+    }
+
+    fun get(values: Iterable<String>): List<String> {
+        return emptyList()
+    }
+}
+
+class LambdaOverloadService {
+    fun target(predicate: (String) -> Boolean): String {
+        return "lambda"
+    }
+
+    fun target(value: String): String {
+        return value
+    }
+}
+"""
+
+OVERLOAD_CALLER_SRC = """
+package com.example
+
+class OverloadCaller(
+    private val service: OverloadedService,
+    private val cache: AmbiguousCache
+) {
+    fun run() {
+        service.target("value", true)
+        cache.get(listOf("value"))
+    }
+}
+"""
+
+AMBIGUOUS_OVERLOAD_CALLER_SRC = """
+package com.example
+
+class AmbiguousOverloadCaller(
+    private val cache: AmbiguousCache
+) {
+    fun run(values: Any) {
+        cache.get(values)
+    }
+}
+"""
+
+COLLECTION_INITIALIZER_CALLER_SRC = """
+package com.example
+
+class CollectionInitializerCaller(
+    private val cache: AmbiguousCache
+) {
+    fun run(raw: List<String>) {
+        val ids = raw.asSequence().map { it }
+        cache.get(ids)
+    }
+}
+"""
+
+SEQUENCE_MAP_CALLER_SRC = """
+package com.example
+
+class SequenceMapCaller(
+    private val cache: AmbiguousCache
+) {
+    fun run(ids: Sequence<String>) {
+        cache.get(ids.map { it })
+    }
+}
+"""
+
+PARTITION_OVERLOAD_SERVICE_SRC = """
+package com.example
+
+class InstanceFilter
+
+class InstanceStateService {
+    fun asStates(ids: Set<String>, filter: InstanceFilter) {
+    }
+
+    fun asStates(ids: Iterable<String>, filter: InstanceFilter) {
+    }
+}
+"""
+
+PARTITION_OVERLOAD_CALLER_SRC = """
+package com.example
+
+class PartitionOverloadCaller(
+    private val service: InstanceStateService
+) {
+    fun run(ids: Sequence<String>, instanceFilter: InstanceFilter) {
+        val (valid, notFound) = ids.partition { it.isNotEmpty() }
+        val items = valid.map { it }
+        service.asStates(items, instanceFilter)
+    }
+}
+"""
+
+IMPLICIT_RECEIVER_PROPERTY_SRC = """
+package com.example
+
+interface EnrolmentState {
+    fun isEnrolled(): Boolean
+}
+
+class EnrolmentStateImpl : EnrolmentState {
+    override fun isEnrolled(): Boolean {
+        return true
+    }
+}
+
+class MatchState(
+    val enrolmentState: EnrolmentState
+)
+
+fun MatchState.matches(): Boolean {
+    return enrolmentState.isEnrolled()
+}
+"""
+
+MAP_VALUE_RECEIVER_SRC = """
+package com.example
+
+class Context
+
+interface EventsGroup {
+    fun appendEvent(factory: () -> String)
+    fun sendToExporter()
+}
+
+interface EventsExporter {
+    fun buildEventsGroup(context: Context): EventsGroup
+}
+
+class CompositeEventsExporter(private val exporters: List<EventsExporter>) {
+    private val exporterPerType = EnumMap<EventType, EventsExporter>(EventType::class.java).apply {
+    }
+
+    fun buildEventsGroup(context: Context): CompositeEventsGroup {
+        val eventTypeToGroup = exporterPerType.mapValues { it.value.buildEventsGroup(context) }
+        return CompositeEventsGroup(eventTypeToGroup)
+    }
+}
+
+class CompositeEventsGroup(private val eventTypeToGroup: Map<EventType, EventsGroup>) {
+    fun appendEvent(eventType: EventType, factory: () -> String) {
+        eventTypeToGroup[eventType]?.appendEvent(factory)
+    }
+
+    fun sendToExporter() {
+        eventTypeToGroup.values.forEach { it.sendToExporter() }
+    }
+}
+
+enum class EventType {
+    A
+}
+"""
+
+PRETTY_STRING_RECEIVER_SRC = """
+package com.example
+
+class CategoryId
+class ViewId
+class RecordDefinitionId {
+    companion object {
+        fun newBuilder(): RecordDefinitionIdBuilder {
+            return RecordDefinitionIdBuilder()
+        }
+    }
+}
+class RecordDefinitionIdBuilder {
+    fun setRecordId(id: String): RecordDefinitionIdBuilder {
+        return this
+    }
+    fun build(): RecordDefinitionId {
+        return RecordDefinitionId()
+    }
+}
+
+fun CategoryId.asPrettyString(): String {
+    return "category"
+}
+
+fun ViewId.asPrettyString(): String {
+    return "view"
+}
+
+fun RecordDefinitionId.asPrettyString(): String {
+    return "record"
+}
+
+class PrettyStringCaller {
+    fun fromNameOnly(): String {
+        return categoryId.asPrettyString()
+    }
+
+    fun fromBuilder(): String {
+        val fullRecordId = RecordDefinitionId.newBuilder()
+            .setRecordId("record")
+            .build()
+        return fullRecordId.asPrettyString()
+    }
+}
+"""
+
+AMBIGUOUS_CALLABLE_REFERENCE_SRC = """
+package com.example
+
+class A
+class B
+
+class Accumulator {
+    fun accumulate(value: A) {
+    }
+
+    fun accumulate(value: B) {
+    }
+}
+
+class CallableReferenceCaller {
+    fun run(accumulator: Accumulator, values: List<Any>) {
+        accumulator.accumulate(A())
+        values.forEach(accumulator::accumulate)
+    }
+}
+"""
+
+CALLABLE_REFERENCE_EXPECTED_TYPE_SRC = """
+package com.example
+
+class A
+class B
+
+class Accumulator {
+    fun accumulate(value: A) {
+    }
+
+    fun accumulate(value: B) {
+    }
+}
+
+class CallableReferenceCaller {
+    fun run(accumulator: Accumulator, values: List<A>) {
+        values.forEach(accumulator::accumulate)
+    }
+}
+"""
+
+CALLABLE_REFERENCE_COLLECTION_RETURN_SRC = """
+package com.example
+
+class A
+class B
+class Flow<T>
+
+fun <T> mutableListOf(): MutableList<T> {
+    TODO()
+}
+
+class Repository {
+    fun load(): Flow<A> {
+        TODO()
+    }
+}
+
+class Accumulator {
+    fun accumulate(value: A) {
+    }
+
+    fun accumulate(value: B) {
+    }
+}
+
+class CallableReferenceCaller(
+    private val repository: Repository
+) {
+    fun run(accumulator: Accumulator) {
+        val values = repository.load().toCollection(mutableListOf())
+        values.forEach(accumulator::accumulate)
+    }
+}
+"""
+
+TRAILING_LAMBDA_CALLER_SRC = """
+package com.example
+
+class TrailingLambdaCaller(
+    private val service: LambdaOverloadService
+) {
+    fun run() {
+        service.target { it.isNotEmpty() }
+    }
+}
+"""
+
+EXTERNAL_RECEIVER_SRC = """
+package com.example
+
+fun StringBuilder.escape() {
+    append("external")
+}
+
+class ProjectWriter {
+    fun append(value: String) {
+    }
+}
+
+class ExternalReceiverCaller {
+    fun run() {
+        val buffer = StringBuilder()
+        buffer.append("external")
+        buffer.escape()
+    }
+}
+"""
+
+EXTENSION_OVERLOADS_SRC = """
+package com.example
+
+enum class FailureA {
+    BAD
+}
+
+enum class FailureB {
+    BAD
+}
+
+fun FailureA.asDetails(): String {
+    return "a"
+}
+
+fun FailureB.asDetails(): String {
+    return "b"
+}
+
+class ExtensionOverloadCaller {
+    fun run() {
+        FailureA.BAD.asDetails()
+        FailureB.BAD.asDetails()
+    }
+}
+"""
+
+TAG_SPAN_SUPPORT_SRC = """
+package com.example.trace
+
+open class InternalEntity
+class CommunityEntity : InternalEntity()
+class Entity
+class Span {
+    companion object {
+        fun current(): Span {
+            return Span()
+        }
+    }
+}
+class SpanBuilder
+
+fun Entity.tagSpan(span: Span) {
+}
+
+fun InternalEntity.tagSpan(span: SpanBuilder) {
+}
+
+fun InternalEntity.tagSpan(span: Span) {
+}
+"""
+
+TAG_SPAN_CONSTANT_SRC = """
+package com.example.community
+
+import com.example.trace.CommunityEntity
+
+val COMMUNITY_ENTITY = CommunityEntity()
+"""
+
+TAG_SPAN_CALLER_SRC = """
+package com.example
+
+import com.example.community.COMMUNITY_ENTITY
+import com.example.trace.InternalEntity
+import com.example.trace.Span
+import com.example.trace.SpanBuilder
+import com.example.trace.tagSpan
+
+data class EventContext(val entity: InternalEntity)
+
+class Caller {
+    fun generated(request: SubmitRequest) {
+        val span = Span.current()
+        request.entity.tagSpan(span)
+    }
+
+    fun constant() {
+        val span = Span.current()
+        COMMUNITY_ENTITY.tagSpan(span)
+    }
+
+    fun member(eventContext: EventContext, span: Span) {
+        eventContext.entity.tagSpan(span)
+    }
+
+    fun scoped(entity: InternalEntity) {
+        val builder = SpanBuilder()
+        builder.apply {
+            entity.tagSpan(this)
+        }
+    }
+}
+"""
+
+IMPLICIT_CLASS_RECEIVER_SRC = """
+package com.example
+
+class LocalWriter {
+    fun append(value: String) {
+    }
+
+    fun append(value: Int) {
+    }
+
+    fun accept(value: String) {
+        append(value)
+    }
+}
+
+class OtherWriter {
+    fun append(value: String) {
+    }
+}
+"""
+
+
+def _local_names(parsed: dict) -> set[str]:
+    return {f["name"] for f in parsed["functions"]} | {c["name"] for c in parsed["classes"]}
+
+
+def _local_imports(parsed: dict) -> dict:
+    imports = {
+        imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
+        for imp in parsed.get("imports", [])
+        if not imp["name"].endswith(".*")
+    }
+    wildcard_imports = [
+        imp["name"][:-2]
+        for imp in parsed.get("imports", [])
+        if imp["name"].endswith(".*")
+    ]
+    if wildcard_imports:
+        imports["__wildcards__"] = wildcard_imports
+    return imports
+
+
+def _resolve_with_progress_service(call: dict, caller_data: dict, progress_data: dict) -> dict:
+    resolved = resolve_function_call(
+        call,
+        caller_file_path=caller_data["path"],
+        local_names=_local_names(caller_data),
+        local_imports={},
+        imports_map={"ProgressService": [progress_data["path"]]},
+        skip_external=False,
+    )
+    assert resolved is not None
+    return resolved
+
+
+class TestKotlinFunctionCallResolution:
+    def test_function_type_parameters_are_split_at_top_level_commas(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            class FunctionTypeConsumer {
+                fun register(cb: (Int) -> String, x: Int, handlers: Map<String, (String) -> Unit> = emptyMap()) {
+                    cb(x)
+                }
+            }
+            """,
+        )
+
+        register = next(f for f in data["functions"] if f["name"] == "register")
+
+        assert register["args"] == ["cb", "x", "handlers"]
+        assert register["arg_types"] == ["(Int) -> String", "Int", "Map"]
+
+    def test_top_level_callable_reference_is_parsed_and_resolved(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            fun top(value: String): String {
+                return value
+            }
+
+            class Caller {
+                fun run(items: List<String>): List<String> {
+                    return items.map(::top)
+                }
+            }
+            """,
+        )
+
+        callable_ref = next(
+            c for c in data["function_calls"]
+            if c["call_kind"] == "callable_reference"
+        )
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={"top": [data["path"]]},
+        )
+
+        assert callable_ref["name"] == "top"
+        assert callable_ref["full_name"] == "top"
+        assert callable_ref["base_obj"] is None
+        assert any(
+            edge["caller_name"] == "run"
+            and edge["called_name"] == "top"
+            and edge["called_file_path"] == str(Path(data["path"]).resolve())
+            for edge in fn_to_fn
+        )
+
+    def test_function_class_context_includes_owner_line(self, parser):
+        data = _write_and_parse(
+            parser,
+            """package p
+fun top() {}
+class A {
+    class Worker {
+        fun run() {}
+    }
+}
+class B {
+    class Worker {
+        fun run() {}
+    }
+}
+""",
+        )
+
+        workers = sorted(
+            (cls["name"], cls["line_number"])
+            for cls in data["classes"]
+            if cls["name"] == "Worker"
+        )
+        runs = sorted(
+            (fn["line_number"], fn["class_context"], fn["class_context_line"])
+            for fn in data["functions"]
+            if fn["name"] == "run"
+        )
+        top = next(fn for fn in data["functions"] if fn["name"] == "top")
+
+        assert workers == [("Worker", 4), ("Worker", 9)]
+        assert runs == [(5, "Worker", 4), (10, "Worker", 9)]
+        assert "class_context_line" not in top
+
+    def test_nested_constructor_call_resolves_nearest_same_named_class(self, parser):
+        data = _write_and_parse(
+            parser,
+            """package p
+class A {
+    class Inner
+    fun make() = Inner()
+}
+class B {
+    class Inner
+}
+""",
+        )
+
+        a_inner = next(
+            cls
+            for cls in data["classes"]
+            if cls["name"] == "Inner" and cls.get("class_context") == "A"
+        )
+        fn_to_fn, fn_to_cls, *_ = build_function_call_groups([data], imports_map={})
+        constructor_edges = [
+            edge
+            for edge in fn_to_cls
+            if edge["caller_name"] == "make" and edge["called_name"] == "Inner"
+        ]
+
+        assert fn_to_fn == []
+        assert len(constructor_edges) == 1
+        assert constructor_edges[0]["called_line_number"] == a_inner["line_number"]
+
+    def test_same_named_nested_class_method_resolves_by_owner_line(self, parser):
+        data = _write_and_parse(
+            parser,
+            """package p
+class A {
+    class Worker {
+        fun helper() {}
+        fun run() = helper()
+    }
+}
+class B {
+    class Worker {
+        fun helper() {}
+    }
+}
+""",
+        )
+
+        a_helper = next(
+            fn
+            for fn in data["functions"]
+            if fn["name"] == "helper" and fn.get("class_context_line") == 3
+        )
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map={})
+        edges = [
+            edge
+            for edge in fn_to_fn
+            if edge["caller_name"] == "run" and edge["full_call_name"] == "helper"
+        ]
+
+        assert len(edges) == 1
+        assert edges[0]["called_line_number"] == a_helper["line_number"]
+        assert edges[0]["called_context"] == "Worker"
+
+    def test_qualified_nested_constructor_call_is_bucketed_as_class(self, parser):
+        data = _write_and_parse(
+            parser,
+            """package p
+class A {
+    class Inner
+}
+fun make() = A.Inner()
+""",
+        )
+
+        inner_class = next(cls for cls in data["classes"] if cls["name"] == "Inner")
+        fn_to_fn, fn_to_cls, *_ = build_function_call_groups([data], imports_map={})
+        edges = [
+            edge
+            for edge in fn_to_cls
+            if edge["caller_name"] == "make" and edge["full_call_name"] == "A.Inner"
+        ]
+
+        assert fn_to_fn == []
+        assert len(edges) == 1
+        assert edges[0]["called_name"] == "Inner"
+        assert edges[0]["called_line_number"] == inner_class["line_number"]
+
+    def test_explicit_import_disambiguates_receiver_method_with_duplicate_class_names(self, parser, tmp_path):
+        service_a_path = _write_source(
+            tmp_path,
+            "com/a/Service.kt",
+            """
+            package com.a
+
+            class Service {
+                fun run(): String {
+                    return "a"
+                }
+            }
+            """,
+        )
+        service_b_path = _write_source(
+            tmp_path,
+            "com/b/Service.kt",
+            """
+            package com.b
+
+            class Service {
+                fun run(): String {
+                    return "b"
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/c/Caller.kt",
+            """
+            package com.c
+
+            import com.b.Service
+
+            class Caller {
+                fun execute(): String {
+                    val service: Service = Service()
+                    return service.run()
+                }
+            }
+            """,
+        )
+
+        files = [service_a_path, service_b_path, caller_path]
+        all_data = [parser.parse(path) for path in files]
+        imports_map = pre_scan_kotlin(files, parser.generic_parser_wrapper)
+        service_b_data = next(data for data in all_data if Path(data["path"]) == service_b_path)
+        service_b_run = next(
+            f for f in service_b_data["functions"]
+            if f["name"] == "run" and f["context"] == "Service"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(all_data, imports_map)
+
+        edge = next(
+            e for e in fn_to_fn
+            if e["caller_name"] == "execute" and e["full_call_name"] == "service.run"
+        )
+        assert Path(edge["called_file_path"]).resolve() == service_b_path.resolve()
+        assert edge["called_context"] == "Service"
+        assert edge["called_line_number"] == service_b_run["line_number"]
+
+    def test_explicit_java_import_disambiguates_receiver_method_from_kotlin_class(self, parser, tmp_path):
+        java_service_path = _write_source(
+            tmp_path,
+            "j/Service.java",
+            """
+            package j;
+
+            public class Service {
+                public String run() {
+                    return "java";
+                }
+            }
+            """,
+        )
+        kotlin_service_path = _write_source(
+            tmp_path,
+            "k/Service.kt",
+            """
+            package k
+
+            class Service {
+                fun run(): String {
+                    return "kotlin"
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "c/Use.kt",
+            """
+            package c
+
+            import j.Service
+
+            class Use {
+                fun execute(): String {
+                    val service: Service = Service()
+                    return service.run()
+                }
+            }
+            """,
+        )
+        manager = get_tree_sitter_manager()
+        java_wrapper = MagicMock()
+        java_wrapper.language_name = "java"
+        java_wrapper.language = manager.get_language_safe("java")
+        java_wrapper.parser = manager.create_parser("java")
+        java_parser = JavaTreeSitterParser(java_wrapper)
+
+        java_data = java_parser.parse(java_service_path)
+        kotlin_service_data = parser.parse(kotlin_service_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = {}
+        for symbol_map in (
+            pre_scan_java([java_service_path], java_wrapper),
+            pre_scan_kotlin([kotlin_service_path, caller_path], parser.generic_parser_wrapper),
+        ):
+            for name, paths in symbol_map.items():
+                imports_map.setdefault(name, []).extend(paths)
+        java_run = next(f for f in java_data["functions"] if f["name"] == "run")
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [java_data, kotlin_service_data, caller_data],
+            imports_map,
+        )
+
+        edge = next(
+            e for e in fn_to_fn
+            if e["caller_name"] == "execute" and e["full_call_name"] == "service.run"
+        )
+        assert Path(edge["called_file_path"]).resolve() == java_service_path.resolve()
+        assert edge["called_context"] == "Service"
+        assert edge["called_line_number"] == java_run["line_number"]
+
+    def test_kotlin_call_to_overloaded_java_method_uses_argument_types(self, parser, tmp_path):
+        java_service_path = _write_source(
+            tmp_path,
+            "j/Service.java",
+            """
+            package j;
+
+            public class Service {
+                public void run(String value) {}
+                public void run(int value) {}
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "c/Use.kt",
+            """
+            package c
+
+            import j.Service
+
+            fun use(service: Service) {
+                service.run("x")
+                service.run(1)
+            }
+            """,
+        )
+        manager = get_tree_sitter_manager()
+        java_wrapper = MagicMock()
+        java_wrapper.language_name = "java"
+        java_wrapper.language = manager.get_language_safe("java")
+        java_wrapper.parser = manager.create_parser("java")
+        java_parser = JavaTreeSitterParser(java_wrapper)
+
+        java_data = java_parser.parse(java_service_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = {}
+        for symbol_map in (
+            pre_scan_java([java_service_path], java_wrapper),
+            pre_scan_kotlin([caller_path], parser.generic_parser_wrapper),
+        ):
+            for name, paths in symbol_map.items():
+                imports_map.setdefault(name, []).extend(paths)
+        string_run = next(f for f in java_data["functions"] if f["name"] == "run" and f["arg_types"] == ["String"])
+        int_run = next(f for f in java_data["functions"] if f["name"] == "run" and f["arg_types"] == ["Int"])
+
+        fn_to_fn, *_ = build_function_call_groups([java_data, caller_data], imports_map)
+        edges = [
+            edge
+            for edge in fn_to_fn
+            if edge["caller_name"] == "use" and edge["full_call_name"] == "service.run"
+        ]
+
+        assert [edge["called_line_number"] for edge in edges] == [
+            string_run["line_number"],
+            int_run["line_number"],
+        ]
+
+    def test_kotlin_call_to_java_method_uses_imported_class_context(self, parser, tmp_path):
+        java_service_path = _write_source(
+            tmp_path,
+            "j/Service.java",
+            """
+            package j;
+
+            public class Service {
+                public void run(String value) {}
+            }
+
+            class Helper {
+                public void run(String value) {}
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "c/Use.kt",
+            """
+            package c
+
+            import j.Service
+
+            fun use(service: Service) {
+                service.run("x")
+            }
+            """,
+        )
+        manager = get_tree_sitter_manager()
+        java_wrapper = MagicMock()
+        java_wrapper.language_name = "java"
+        java_wrapper.language = manager.get_language_safe("java")
+        java_wrapper.parser = manager.create_parser("java")
+        java_parser = JavaTreeSitterParser(java_wrapper)
+
+        java_data = java_parser.parse(java_service_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = {}
+        for symbol_map in (
+            pre_scan_java([java_service_path], java_wrapper),
+            pre_scan_kotlin([caller_path], parser.generic_parser_wrapper),
+        ):
+            for name, paths in symbol_map.items():
+                imports_map.setdefault(name, []).extend(paths)
+        service_run = next(
+            f
+            for f in java_data["functions"]
+            if f["name"] == "run" and f["context"] == "Service"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([java_data, caller_data], imports_map)
+        edges = [
+            edge
+            for edge in fn_to_fn
+            if edge["caller_name"] == "use" and edge["full_call_name"] == "service.run"
+        ]
+
+        assert len(edges) == 1
+        assert edges[0]["called_context"] == "Service"
+        assert edges[0]["called_line_number"] == service_run["line_number"]
+
+    def test_scope_function_receiver_does_not_apply_to_receiver_expression_call(self, parser, tmp_path):
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            fun makeSvc(): Svc {
+                return Svc()
+            }
+
+            class Svc {
+                fun makeSvc(): Svc {
+                    return this
+                }
+
+                fun doWork(): String {
+                    return "ok"
+                }
+            }
+
+            class Caller {
+                fun run(): String {
+                    return makeSvc().apply { doWork() }.doWork()
+                }
+            }
+            """,
+        )
+
+        caller_data = parser.parse(caller_path)
+        make_call = next(
+            c for c in caller_data["function_calls"]
+            if c["name"] == "makeSvc"
+        )
+        imports_map = pre_scan_kotlin([caller_path], parser.generic_parser_wrapper)
+        top_level_make_svc = next(
+            f for f in caller_data["functions"]
+            if f["name"] == "makeSvc" and f["context"] is None
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([caller_data], imports_map)
+
+        assert make_call["inferred_obj_type"] is None
+        edge = next(
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "run" and edge["called_name"] == "makeSvc"
+        )
+        assert Path(edge["called_file_path"]).resolve() == caller_path.resolve()
+        assert edge["called_line_number"] == top_level_make_svc["line_number"]
+
+    def test_same_named_methods_keep_parameter_receiver_types_scoped_by_function(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/Scopes.kt",
+            """
+            package com.example
+
+            class A {
+                fun run(service: AService) {
+                    service.doIt()
+                }
+            }
+
+            class B {
+                fun run(service: BService) {
+                    service.doIt()
+                }
+            }
+
+            class AService {
+                fun doIt(): String {
+                    return "a"
+                }
+            }
+
+            class BService {
+                fun doIt(): String {
+                    return "b"
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        targets = {
+            f["context"]: f
+            for f in data["functions"]
+            if f["name"] == "doIt"
+        }
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+        do_it_edges = sorted(
+            (
+                edge for edge in fn_to_fn
+                if edge["full_call_name"] == "service.doIt"
+            ),
+            key=lambda edge: edge["line_number"],
+        )
+
+        assert len(do_it_edges) == 2
+        assert do_it_edges[0]["called_context"] == "AService"
+        assert do_it_edges[0]["called_line_number"] == targets["AService"]["line_number"]
+        assert do_it_edges[1]["called_context"] == "BService"
+        assert do_it_edges[1]["called_line_number"] == targets["BService"]["line_number"]
+
+    def test_destructured_local_receiver_types_are_scoped_by_function(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/DestructureScopes.kt",
+            """
+            package com.example
+
+            class A {
+                fun run() {
+                    val (service) = AService()
+                    service.doIt()
+                }
+            }
+
+            class B {
+                fun run() {
+                    val (service) = BService()
+                    service.doIt()
+                }
+            }
+
+            class AService {
+                fun doIt(): String {
+                    return "a"
+                }
+            }
+
+            class BService {
+                fun doIt(): String {
+                    return "b"
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        targets = {
+            f["context"]: f
+            for f in data["functions"]
+            if f["name"] == "doIt"
+        }
+        services = [
+            v for v in data["variables"]
+            if v["name"] == "service"
+        ]
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+        do_it_edges = sorted(
+            (
+                edge for edge in fn_to_fn
+                if edge["full_call_name"] == "service.doIt"
+            ),
+            key=lambda edge: edge["line_number"],
+        )
+
+        assert {v["context"] for v in services} == {"run"}
+        assert [v["line_number"] for v in services] == [6, 13]
+        assert len(do_it_edges) == 2
+        assert do_it_edges[0]["called_context"] == "AService"
+        assert do_it_edges[0]["called_line_number"] == targets["AService"]["line_number"]
+        assert do_it_edges[1]["called_context"] == "BService"
+        assert do_it_edges[1]["called_line_number"] == targets["BService"]["line_number"]
+
+    def test_overload_resolution_uses_unique_parameter_name_match(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/Accumulator.kt",
+            """
+            package com.example
+
+            class CategoryEnrolmentStates
+            class InstanceProgressRow
+
+            class Accumulator {
+                fun accumulate(enrolmentStates: CategoryEnrolmentStates) {
+                }
+
+                fun accumulate(row: InstanceProgressRow) {
+                }
+            }
+
+            class Caller {
+                fun run(accumulator: Accumulator) {
+                    rows.forEach { row ->
+                        accumulator.accumulate(row)
+                    }
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        row_target = next(
+            f for f in data["functions"]
+            if f["name"] == "accumulate" and f["args"] == ["row"]
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+
+        edge = next(
+            edge for edge in fn_to_fn
+            if edge["full_call_name"] == "accumulator.accumulate"
+        )
+        assert edge["called_context"] == "Accumulator"
+        assert edge["called_line_number"] == row_target["line_number"]
+
+    def test_named_arguments_select_matching_overloads(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/NamedArgs.kt",
+            """
+            package com.example
+
+            class Svc {
+                fun target(value: String) {
+                }
+
+                fun target(count: Int) {
+                }
+
+                fun pick(value: String, count: Int) {
+                }
+
+                fun pick(value: String, enabled: Boolean) {
+                }
+            }
+
+            class Caller {
+                fun run(svc: Svc) {
+                    svc.target(count = 1)
+                    svc.pick(count = 1, value = "x")
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        target_count = next(
+            f for f in data["functions"]
+            if f["name"] == "target" and f["arg_types"] == ["Int"]
+        )
+        pick_count = next(
+            f for f in data["functions"]
+            if f["name"] == "pick" and f["arg_types"] == ["String", "Int"]
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+        edges = {
+            edge["full_call_name"]: edge
+            for edge in fn_to_fn
+            if edge["called_name"] in {"target", "pick"}
+        }
+
+        assert edges["svc.target"]["called_line_number"] == target_count["line_number"]
+        assert edges["svc.pick"]["called_line_number"] == pick_count["line_number"]
+
+    def test_overload_selection_rejects_incompatible_exact_arity_for_default_param(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            class Service {
+                fun run(value: Int, suffix: String = "") {
+                }
+
+                fun run(value: String) {
+                }
+            }
+
+            fun use(service: Service) {
+                service.run(1)
+            }
+            """,
+        )
+
+        int_target = next(
+            f
+            for f in data["functions"]
+            if f["name"] == "run" and f["arg_types"] == ["Int", "String"]
+        )
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map={})
+        edge = next(
+            edge
+            for edge in fn_to_fn
+            if edge["caller_name"] == "use" and edge["full_call_name"] == "service.run"
+        )
+
+        assert edge["called_line_number"] == int_target["line_number"]
+
+    def test_inherited_overload_uses_compatible_base_method(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            open class Base {
+                fun foo(value: Int) {
+                }
+            }
+
+            class Derived : Base() {
+                fun foo(value: String) {
+                }
+            }
+
+            fun run(d: Derived) {
+                d.foo(1)
+            }
+            """,
+        )
+
+        base_target = next(
+            f
+            for f in data["functions"]
+            if f["name"] == "foo" and f["context"] == "Base"
+        )
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map={})
+        edge = next(
+            edge
+            for edge in fn_to_fn
+            if edge["caller_name"] == "run" and edge["full_call_name"] == "d.foo"
+        )
+
+        assert edge["called_context"] == "Base"
+        assert edge["called_line_number"] == base_target["line_number"]
+
+    def test_extension_overload_used_when_member_overloads_incompatible(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            class A {
+                fun foo(value: Int) {
+                }
+
+                fun foo(value: Boolean) {
+                }
+            }
+
+            fun A.foo(value: String) {
+            }
+
+            fun test(a: A) {
+                a.foo("x")
+            }
+            """,
+        )
+        diagnostics = []
+
+        extension_target = next(
+            f
+            for f in data["functions"]
+            if f["name"] == "foo" and f.get("receiver_type") == "A"
+        )
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={},
+            diagnostics=diagnostics,
+        )
+        edge = next(
+            edge
+            for edge in fn_to_fn
+            if edge["caller_name"] == "test" and edge["full_call_name"] == "a.foo"
+        )
+
+        assert edge["called_context"] is None
+        assert edge["called_line_number"] == extension_target["line_number"]
+        assert not diagnostics
+
+    def test_incompatible_receiver_overload_skips_without_line_less_edge(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            class A {
+                fun foo(value: Int) {
+                }
+
+                fun foo(value: Boolean) {
+                }
+            }
+
+            fun test(a: A) {
+                a.foo("x")
+            }
+            """,
+        )
+        diagnostics = []
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={
+                "A": [data["path"]],
+                "com.example.A": [data["path"]],
+            },
+            diagnostics=diagnostics,
+        )
+
+        assert [
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "test" and edge["full_call_name"] == "a.foo"
+        ] == []
+        assert any(
+            diagnostic["reason"] == "unresolved_overloaded_call"
+            and diagnostic["full_call_name"] == "a.foo"
+            for diagnostic in diagnostics
+        )
+
+    def test_ambiguous_top_level_overload_is_skipped_with_diagnostic(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            fun caller(x: Any) {
+                foo(x)
+            }
+
+            fun foo(value: String) {
+            }
+
+            fun foo(value: Int) {
+            }
+            """,
+        )
+        diagnostics = []
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={},
+            diagnostics=diagnostics,
+        )
+
+        assert [
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "caller" and edge["full_call_name"] == "foo"
+        ] == []
+        assert any(
+            diagnostic["reason"] == "ambiguous_function_target"
+            and diagnostic["full_call_name"] == "foo"
+            for diagnostic in diagnostics
+        )
+
+    def test_same_file_call_preserves_caller_function_context(self, parser):
+        data = _write_and_parse(parser, EVENT_PROCESSOR_SRC)
+        direct_helper_calls = [
+            c for c in data["function_calls"] if c["name"] == "directHelper"
+        ]
+        assert direct_helper_calls, "Expected directHelper call to be parsed"
+
+        resolved = resolve_function_call(
+            direct_helper_calls[0],
+            caller_file_path=data["path"],
+            local_names=_local_names(data),
+            local_imports={},
+            imports_map={},
+            skip_external=False,
+        )
+
+        assert resolved is not None
+        assert resolved["type"] == "function"
+        assert resolved["caller_name"] == "submitEvents"
+        assert resolved["called_name"] == "directHelper"
+
+    def test_constructor_property_receiver_resolves_cross_file(self, parser):
+        processor_data = _write_and_parse(parser, EVENT_PROCESSOR_SRC)
+        progress_data = _write_and_parse(parser, PROGRESS_SERVICE_SRC)
+
+        progress_variables = [
+            v for v in processor_data["variables"] if v["name"] == "progressService"
+        ]
+        assert progress_variables, "Expected constructor property progressService"
+        assert progress_variables[0]["type"] == "ProgressService"
+
+        apply_event_calls = [
+            c for c in processor_data["function_calls"] if c["name"] == "applyEvent"
+        ]
+        assert apply_event_calls, "Expected progressService.applyEvent call"
+        assert apply_event_calls[0]["inferred_obj_type"] == "ProgressService"
+
+        resolved = resolve_function_call(
+            apply_event_calls[0],
+            caller_file_path=processor_data["path"],
+            local_names=_local_names(processor_data),
+            local_imports={},
+            imports_map={"ProgressService": [progress_data["path"]]},
+            skip_external=False,
+        )
+
+        assert resolved is not None
+        assert resolved["type"] == "function"
+        assert resolved["caller_name"] == "submitEvents"
+        assert resolved["called_name"] == "applyEvent"
+        assert resolved["called_file_path"] == progress_data["path"]
+
+    def test_kotlin_call_arguments_are_parsed(self, parser):
+        caller_data = _write_and_parse(parser, OVERLOAD_CALLER_SRC)
+
+        target_call = next(
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "service.target"
+        )
+
+        assert target_call["args"] == ['"value"', "true"]
+
+    def test_kotlin_trailing_lambda_call_argument_is_parsed(self, parser):
+        caller_data = _write_and_parse(parser, TRAILING_LAMBDA_CALLER_SRC)
+
+        target_call = next(
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "service.target"
+        )
+
+        assert target_call["args"] == ["{ it.isNotEmpty() }"]
+
+    def test_overloaded_kotlin_method_uses_arity_for_target_line(self, parser):
+        service_data = _write_and_parse(parser, OVERLOADED_SERVICE_SRC)
+        caller_data = _write_and_parse(parser, OVERLOAD_CALLER_SRC)
+
+        two_arg_target = next(
+            f for f in service_data["functions"]
+            if f["name"] == "target" and len(f["args"]) == 2
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [service_data, caller_data],
+            imports_map={
+                "OverloadedService": [service_data["path"]],
+                "AmbiguousCache": [service_data["path"]],
+            },
+        )
+
+        edge = next(
+            e for e in fn_to_fn
+            if e["full_call_name"] == "service.target"
+        )
+        assert edge["called_file_path"] == service_data["path"]
+        assert edge["called_context"] == "OverloadedService"
+        assert edge["called_line_number"] == two_arg_target["line_number"]
+
+    def test_kotlin_overload_uses_argument_type_hint_for_target_line(self, parser):
+        service_data = _write_and_parse(parser, OVERLOADED_SERVICE_SRC)
+        caller_data = _write_and_parse(parser, OVERLOAD_CALLER_SRC)
+
+        iterable_get = next(
+            f for f in service_data["functions"]
+            if f["name"] == "get" and f["arg_types"] == ["Iterable"]
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [service_data, caller_data],
+            imports_map={
+                "OverloadedService": [service_data["path"]],
+                "AmbiguousCache": [service_data["path"]],
+            },
+        )
+
+        edge = next(
+            e for e in fn_to_fn
+            if e["full_call_name"] == "cache.get"
+        )
+        assert edge["called_file_path"] == service_data["path"]
+        assert edge["called_context"] == "AmbiguousCache"
+        assert edge["called_line_number"] == iterable_get["line_number"]
+
+    def test_kotlin_overload_uses_collection_initializer_type_hint(self, parser):
+        service_data = _write_and_parse(parser, OVERLOADED_SERVICE_SRC)
+        caller_data = _write_and_parse(parser, COLLECTION_INITIALIZER_CALLER_SRC)
+
+        sequence_get = next(
+            f for f in service_data["functions"]
+            if f["name"] == "get" and f["arg_types"] == ["Sequence"]
+        )
+        ids_variable = next(
+            v for v in caller_data["variables"]
+            if v["name"] == "ids"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [service_data, caller_data],
+            imports_map={
+                "AmbiguousCache": [service_data["path"]],
+            },
+        )
+
+        edge = next(
+            e for e in fn_to_fn
+            if e["full_call_name"] == "cache.get"
+        )
+        assert ids_variable["initializer_inferred_type"] == "Sequence"
+        assert edge["called_line_number"] == sequence_get["line_number"]
+
+    def test_kotlin_sequence_map_expression_uses_receiver_type_hint(self, parser):
+        service_data = _write_and_parse(parser, OVERLOADED_SERVICE_SRC)
+        caller_data = _write_and_parse(parser, SEQUENCE_MAP_CALLER_SRC)
+
+        sequence_get = next(
+            f for f in service_data["functions"]
+            if f["name"] == "get" and f["arg_types"] == ["Sequence"]
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [service_data, caller_data],
+            imports_map={
+                "AmbiguousCache": [service_data["path"]],
+            },
+        )
+
+        edge = next(
+            e for e in fn_to_fn
+            if e["full_call_name"] == "cache.get"
+        )
+        assert edge["called_line_number"] == sequence_get["line_number"]
+
+    def test_kotlin_partition_and_map_initializer_selects_iterable_overload(self, parser):
+        service_data = _write_and_parse(parser, PARTITION_OVERLOAD_SERVICE_SRC)
+        caller_data = _write_and_parse(parser, PARTITION_OVERLOAD_CALLER_SRC)
+
+        iterable_target = next(
+            f for f in service_data["functions"]
+            if f["name"] == "asStates" and f["arg_types"] == ["Iterable", "InstanceFilter"]
+        )
+        variables = {
+            v["name"]: v for v in caller_data["variables"]
+            if v["name"] in {"valid", "notFound", "items"}
+        }
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [service_data, caller_data],
+            imports_map={
+                "InstanceStateService": [service_data["path"]],
+            },
+        )
+
+        edge = next(
+            e for e in fn_to_fn
+            if e["full_call_name"] == "service.asStates"
+        )
+        assert variables["valid"]["initializer_inferred_type"] == "List"
+        assert variables["notFound"]["initializer_inferred_type"] == "List"
+        assert variables["items"]["initializer_inferred_type"] == "List"
+        assert edge["called_line_number"] == iterable_target["line_number"]
+
+    def test_kotlin_implicit_receiver_property_resolves_declared_member_type(self, parser):
+        data = _write_and_parse(parser, IMPLICIT_RECEIVER_PROPERTY_SRC)
+
+        interface_target = next(
+            f for f in data["functions"]
+            if f["name"] == "isEnrolled" and f["context"] == "EnrolmentState"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={
+                "EnrolmentState": [data["path"]],
+                "EnrolmentStateImpl": [data["path"]],
+            },
+        )
+
+        edge = next(
+            e for e in fn_to_fn
+            if e["full_call_name"] == "enrolmentState.isEnrolled"
+        )
+        assert edge["called_context"] == "EnrolmentState"
+        assert edge["called_line_number"] == interface_target["line_number"]
+
+    def test_kotlin_map_value_and_values_lambda_receivers_use_generic_value_type(self, parser):
+        data = _write_and_parse(parser, MAP_VALUE_RECEIVER_SRC)
+
+        exporter_target = next(
+            f for f in data["functions"]
+            if f["name"] == "buildEventsGroup" and f["context"] == "EventsExporter"
+        )
+        append_target = next(
+            f for f in data["functions"]
+            if f["name"] == "appendEvent" and f["context"] == "EventsGroup"
+        )
+        send_target = next(
+            f for f in data["functions"]
+            if f["name"] == "sendToExporter" and f["context"] == "EventsGroup"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={
+                "EventsExporter": [data["path"]],
+                "EventsGroup": [data["path"]],
+                "CompositeEventsExporter": [data["path"]],
+                "CompositeEventsGroup": [data["path"]],
+            },
+        )
+
+        edges = {
+            (edge["caller_name"], edge["full_call_name"]): edge
+            for edge in fn_to_fn
+            if edge["called_name"] in {"buildEventsGroup", "appendEvent", "sendToExporter"}
+        }
+        assert edges[("buildEventsGroup", "it.value.buildEventsGroup")]["called_line_number"] == exporter_target["line_number"]
+        assert edges[("appendEvent", "eventTypeToGroup[eventType].appendEvent")]["called_line_number"] == append_target["line_number"]
+        assert edges[("sendToExporter", "it.sendToExporter")]["called_line_number"] == send_target["line_number"]
+
+    def test_kotlin_extension_receiver_uses_variable_name_and_builder_type_hints(self, parser):
+        data = _write_and_parse(parser, PRETTY_STRING_RECEIVER_SRC)
+
+        category_target = next(
+            f for f in data["functions"]
+            if f["name"] == "asPrettyString" and f["receiver_type"] == "CategoryId"
+        )
+        record_target = next(
+            f for f in data["functions"]
+            if f["name"] == "asPrettyString" and f["receiver_type"] == "RecordDefinitionId"
+        )
+        full_record_id = next(
+            v for v in data["variables"]
+            if v["name"] == "fullRecordId"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={
+                "CategoryId.asPrettyString": [data["path"]],
+                "ViewId.asPrettyString": [data["path"]],
+                "RecordDefinitionId.asPrettyString": [data["path"]],
+                "asPrettyString": [data["path"]],
+            },
+        )
+
+        edges = {
+            (edge["caller_name"], edge["full_call_name"]): edge
+            for edge in fn_to_fn
+            if edge["called_name"] == "asPrettyString"
+        }
+        assert full_record_id["initializer_inferred_type"] == "RecordDefinitionId"
+        assert edges[("fromNameOnly", "categoryId.asPrettyString")]["called_line_number"] == category_target["line_number"]
+        assert edges[("fromBuilder", "fullRecordId.asPrettyString")]["called_line_number"] == record_target["line_number"]
+
+    def test_ambiguous_overloaded_callable_reference_is_not_over_approximated(self, parser):
+        data = _write_and_parse(parser, AMBIGUOUS_CALLABLE_REFERENCE_SRC)
+
+        direct_target = next(
+            f for f in data["functions"]
+            if f["name"] == "accumulate" and f["arg_types"] == ["A"]
+        )
+        callable_line = next(
+            c["line_number"] for c in data["function_calls"]
+            if c["call_kind"] == "callable_reference"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={
+                "Accumulator": [data["path"]],
+            },
+        )
+
+        direct_edges = [
+            edge for edge in fn_to_fn
+            if edge["full_call_name"] == "accumulator.accumulate"
+            and edge["line_number"] != callable_line
+        ]
+        callable_edges = [
+            edge for edge in fn_to_fn
+            if edge["full_call_name"] == "accumulator.accumulate"
+            and edge["line_number"] == callable_line
+        ]
+        assert len(direct_edges) == 1
+        assert direct_edges[0]["called_line_number"] == direct_target["line_number"]
+        assert callable_edges == []
+
+    def test_skipped_callable_reference_emits_resolution_diagnostic(self, parser):
+        data = _write_and_parse(parser, AMBIGUOUS_CALLABLE_REFERENCE_SRC)
+        diagnostics = []
+
+        build_function_call_groups(
+            [data],
+            imports_map={"Accumulator": [data["path"]]},
+            diagnostics=diagnostics,
+        )
+
+        assert any(
+            diagnostic["reason"] == "unresolved_overloaded_callable_reference"
+            and diagnostic["full_call_name"] == "accumulator.accumulate"
+            for diagnostic in diagnostics
+        )
+
+    def test_callable_reference_expected_collection_type_selects_overload(self, parser):
+        data = _write_and_parse(parser, CALLABLE_REFERENCE_EXPECTED_TYPE_SRC)
+
+        target = next(
+            f for f in data["functions"]
+            if f["name"] == "accumulate" and f["arg_types"] == ["A"]
+        )
+        callable_call = next(
+            c for c in data["function_calls"]
+            if c["call_kind"] == "callable_reference"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={"Accumulator": [data["path"]]},
+        )
+        callable_edges = [
+            edge for edge in fn_to_fn
+            if edge["full_call_name"] == "accumulator.accumulate"
+            and edge["line_number"] == callable_call["line_number"]
+        ]
+
+        assert callable_call["callable_reference_collection_receiver"] == "values"
+        assert len(callable_edges) == 1
+        assert callable_edges[0]["called_line_number"] == target["line_number"]
+
+    def test_callable_reference_collection_return_type_selects_overload(self, parser):
+        data = _write_and_parse(parser, CALLABLE_REFERENCE_COLLECTION_RETURN_SRC)
+
+        target = next(
+            f for f in data["functions"]
+            if f["name"] == "accumulate" and f["arg_types"] == ["A"]
+        )
+        values_var = next(v for v in data["variables"] if v["name"] == "values")
+        callable_call = next(
+            c for c in data["function_calls"]
+            if c["call_kind"] == "callable_reference"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={"Accumulator": [data["path"]], "Repository": [data["path"]]},
+        )
+        callable_edges = [
+            edge for edge in fn_to_fn
+            if edge["full_call_name"] == "accumulator.accumulate"
+            and edge["line_number"] == callable_call["line_number"]
+        ]
+
+        assert values_var["initializer_collection_receiver_name"] == "repository"
+        assert values_var["initializer_collection_member_name"] == "load"
+        assert callable_call["callable_reference_collection_receiver"] == "values"
+        assert len(callable_edges) == 1
+        assert callable_edges[0]["called_line_number"] == target["line_number"]
+
+    def test_kotlin_trailing_lambda_overload_uses_function_type_hint(self, parser):
+        service_data = _write_and_parse(parser, OVERLOADED_SERVICE_SRC)
+        caller_data = _write_and_parse(parser, TRAILING_LAMBDA_CALLER_SRC)
+
+        lambda_target = next(
+            f for f in service_data["functions"]
+            if f["name"] == "target"
+            and f["context"] == "LambdaOverloadService"
+            and f["arg_types"] == ["(String) -> Boolean"]
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [service_data, caller_data],
+            imports_map={
+                "LambdaOverloadService": [service_data["path"]],
+            },
+        )
+
+        edge = next(
+            e for e in fn_to_fn
+            if e["full_call_name"] == "service.target"
+        )
+        assert edge["called_file_path"] == service_data["path"]
+        assert edge["called_context"] == "LambdaOverloadService"
+        assert edge["called_line_number"] == lambda_target["line_number"]
+
+    def test_known_external_receiver_does_not_fall_back_to_unrelated_project_method(self, parser):
+        data = _write_and_parse(parser, EXTERNAL_RECEIVER_SRC)
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={
+                "append": [data["path"]],
+                "ProjectWriter": [data["path"]],
+                "StringBuilder.escape": [data["path"]],
+                "com.example.StringBuilder.escape": [data["path"]],
+            },
+        )
+
+        append_edges = [
+            edge
+            for edge in fn_to_fn
+            if edge["full_call_name"] in {"buffer.append", "append"}
+            and edge["called_name"] == "append"
+        ]
+        escape_edge = next(
+            edge for edge in fn_to_fn
+            if edge["full_call_name"] == "buffer.escape"
+        )
+
+        assert append_edges == []
+        assert escape_edge["called_line_number"] == 4
+
+    def test_kotlin_extension_overload_uses_static_receiver_type(self, parser):
+        data = _write_and_parse(parser, EXTENSION_OVERLOADS_SRC)
+
+        failure_a_target = next(
+            f for f in data["functions"]
+            if f["name"] == "asDetails" and f["receiver_type"] == "FailureA"
+        )
+        failure_b_target = next(
+            f for f in data["functions"]
+            if f["name"] == "asDetails" and f["receiver_type"] == "FailureB"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={
+                "asDetails": [data["path"]],
+                "FailureA.asDetails": [data["path"]],
+                "FailureB.asDetails": [data["path"]],
+                "com.example.FailureA.asDetails": [data["path"]],
+                "com.example.FailureB.asDetails": [data["path"]],
+            },
+        )
+
+        edges = {
+            edge["full_call_name"]: edge
+            for edge in fn_to_fn
+            if edge["called_name"] == "asDetails"
+        }
+        assert edges["FailureA.BAD.asDetails"]["called_line_number"] == failure_a_target["line_number"]
+        assert edges["FailureB.BAD.asDetails"]["called_line_number"] == failure_b_target["line_number"]
+
+    def test_kotlin_extension_overload_uses_property_constant_and_scope_hints(self, parser, tmp_path):
+        support_path = _write_source(
+            tmp_path,
+            "com/example/trace/Tracing.kt",
+            TAG_SPAN_SUPPORT_SRC,
+        )
+        constant_path = _write_source(
+            tmp_path,
+            "com/example/community/Common.kt",
+            TAG_SPAN_CONSTANT_SRC,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            TAG_SPAN_CALLER_SRC,
+        )
+
+        files = [support_path, constant_path, caller_path]
+        support_data = parser.parse(support_path)
+        all_data = [support_data, parser.parse(constant_path), parser.parse(caller_path)]
+        imports_map = pre_scan_kotlin(files, parser.generic_parser_wrapper)
+
+        entity_span_target = next(
+            f for f in support_data["functions"]
+            if f["name"] == "tagSpan"
+            and f["receiver_type"] == "Entity"
+            and f["arg_types"] == ["Span"]
+        )
+        internal_span_builder_target = next(
+            f for f in support_data["functions"]
+            if f["name"] == "tagSpan"
+            and f["receiver_type"] == "InternalEntity"
+            and f["arg_types"] == ["SpanBuilder"]
+        )
+        internal_span_target = next(
+            f for f in support_data["functions"]
+            if f["name"] == "tagSpan"
+            and f["receiver_type"] == "InternalEntity"
+            and f["arg_types"] == ["Span"]
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(all_data, imports_map)
+        edges = {
+            (edge["caller_name"], edge["full_call_name"]): edge
+            for edge in fn_to_fn
+            if edge["called_name"] == "tagSpan"
+        }
+
+        assert edges[("generated", "request.entity.tagSpan")]["called_line_number"] == entity_span_target["line_number"]
+        assert edges[("constant", "COMMUNITY_ENTITY.tagSpan")]["called_line_number"] == internal_span_target["line_number"]
+        assert edges[("member", "eventContext.entity.tagSpan")]["called_line_number"] == internal_span_target["line_number"]
+        assert edges[("scoped", "entity.tagSpan")]["called_line_number"] == internal_span_builder_target["line_number"]
+
+    def test_unqualified_class_member_call_uses_enclosing_class_receiver(self, parser):
+        data = _write_and_parse(parser, IMPLICIT_CLASS_RECEIVER_SRC)
+
+        local_append = next(
+            f for f in data["functions"]
+            if f["name"] == "append" and f["context"] == "LocalWriter"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [data],
+            imports_map={
+                "append": [data["path"]],
+                "LocalWriter": [data["path"]],
+                "OtherWriter": [data["path"]],
+            },
+        )
+
+        edge = next(
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "accept" and edge["full_call_name"] == "append"
+        )
+        assert edge["called_context"] == "LocalWriter"
+        assert edge["called_line_number"] == local_append["line_number"]
+
+    def test_ambiguous_kotlin_overload_is_skipped_with_diagnostic(self, parser):
+        service_data = _write_and_parse(parser, OVERLOADED_SERVICE_SRC)
+        caller_data = _write_and_parse(parser, AMBIGUOUS_OVERLOAD_CALLER_SRC)
+        diagnostics = []
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [service_data, caller_data],
+            imports_map={
+                "OverloadedService": [service_data["path"]],
+                "AmbiguousCache": [service_data["path"]],
+            },
+            diagnostics=diagnostics,
+        )
+
+        assert [
+            e for e in fn_to_fn
+            if e["full_call_name"] == "cache.get"
+        ] == []
+        assert any(
+            diagnostic["reason"] == "unresolved_overloaded_call"
+            and diagnostic["full_call_name"] == "cache.get"
+            for diagnostic in diagnostics
+        )
+
+    def test_local_variable_receiver_resolves_cross_file(self, parser):
+        caller_data = _write_and_parse(parser, RECEIVER_PATTERNS_SRC)
+        progress_data = _write_and_parse(parser, PROGRESS_SERVICE_SRC)
+
+        calls = [
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "localService.applyEvent"
+        ]
+        assert calls, "Expected localService.applyEvent call"
+        assert calls[0]["inferred_obj_type"] == "ProgressService"
+
+        resolved = _resolve_with_progress_service(calls[0], caller_data, progress_data)
+        assert resolved["type"] == "function"
+        assert resolved["caller_name"] == "run"
+        assert resolved["called_file_path"] == progress_data["path"]
+
+    def test_body_property_receiver_resolves_cross_file(self, parser):
+        caller_data = _write_and_parse(parser, RECEIVER_PATTERNS_SRC)
+        progress_data = _write_and_parse(parser, PROGRESS_SERVICE_SRC)
+
+        calls = [
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "bodyService.applyEvent"
+        ]
+        assert calls, "Expected bodyService.applyEvent call"
+        assert calls[0]["inferred_obj_type"] == "ProgressService"
+
+        resolved = _resolve_with_progress_service(calls[0], caller_data, progress_data)
+        assert resolved["type"] == "function"
+        assert resolved["caller_name"] == "run"
+        assert resolved["called_file_path"] == progress_data["path"]
+
+    def test_class_property_receiver_survives_local_shadow_in_other_method(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/PropertyShadow.kt",
+            """
+            package com.example
+
+            class Caller(private val svc: Service) {
+                fun run() {
+                    svc.doIt()
+                }
+
+                fun other() {
+                    val svc: Other = Other()
+                }
+            }
+
+            class Service {
+                fun doIt(): String {
+                    return "service"
+                }
+            }
+
+            class Other {
+                fun doIt(): String {
+                    return "other"
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        service_do_it = next(
+            f for f in data["functions"]
+            if f["name"] == "doIt" and f["context"] == "Service"
+        )
+        svc_call = next(
+            c for c in data["function_calls"]
+            if c["full_name"] == "svc.doIt"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+        edge = next(
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "run" and edge["full_call_name"] == "svc.doIt"
+        )
+
+        assert svc_call["inferred_obj_type"] == "Service"
+        assert edge["called_context"] == "Service"
+        assert edge["called_line_number"] == service_do_it["line_number"]
+
+    def test_inherited_property_receiver_survives_local_shadow_in_other_method(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/InheritedPropertyShadow.kt",
+            """
+            package com.example
+
+            open class Base(protected val svc: Service)
+
+            class Caller(svc: Service) : Base(svc) {
+                fun run() {
+                    svc.doIt()
+                }
+
+                fun other() {
+                    val svc: Other = Other()
+                }
+            }
+
+            class Service {
+                fun doIt(): String {
+                    return "service"
+                }
+            }
+
+            class Other {
+                fun doIt(): String {
+                    return "other"
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        service_do_it = next(
+            f for f in data["functions"]
+            if f["name"] == "doIt" and f["context"] == "Service"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+        edge = next(
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "run" and edge["full_call_name"] == "svc.doIt"
+        )
+
+        assert edge["called_context"] == "Service"
+        assert edge["called_line_number"] == service_do_it["line_number"]
+
+    def test_same_method_local_shadow_blocks_class_property_receiver_fallback(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/PropertyShadowLocal.kt",
+            """
+            package com.example
+
+            class Caller(
+                private val svc: Service,
+                private val holder: Holder
+            ) {
+                fun run() {
+                    val svc = holder.other
+                    svc.doIt()
+                }
+            }
+
+            class Holder(val other: Other)
+
+            class Service {
+                fun doIt(): String {
+                    return "service"
+                }
+            }
+
+            class Other {
+                fun doIt(): String {
+                    return "other"
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        other_do_it = next(
+            f for f in data["functions"]
+            if f["name"] == "doIt" and f["context"] == "Other"
+        )
+        svc_call = next(
+            c for c in data["function_calls"]
+            if c["full_name"] == "svc.doIt"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+        edge = next(
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "run" and edge["full_call_name"] == "svc.doIt"
+        )
+
+        assert svc_call["inferred_obj_type"] != "Service"
+        assert edge["called_context"] == "Other"
+        assert edge["called_line_number"] == other_do_it["line_number"]
+
+    def test_local_receiver_inferred_from_companion_factory(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/CompanionFactory.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run() {
+                    val service = ServiceFactory.create()
+                    service.doIt()
+                }
+            }
+
+            class ServiceFactory {
+                companion object {
+                    fun create(): Service {
+                        return Service()
+                    }
+                }
+            }
+
+            class Service {
+                fun doIt(): String {
+                    return "service"
+                }
+            }
+
+            class Other {
+                fun doIt(): String {
+                    return "other"
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        service_do_it = next(
+            f for f in data["functions"]
+            if f["name"] == "doIt" and f["context"] == "Service"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+        edge = next(
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "run" and edge["full_call_name"] == "service.doIt"
+        )
+
+        assert edge["called_context"] == "Service"
+        assert edge["called_line_number"] == service_do_it["line_number"]
+
+    def test_local_receiver_inferred_from_named_companion_factory(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/NamedCompanionFactory.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run() {
+                    val service = ServiceFactory.create()
+                    service.doIt()
+                }
+            }
+
+            class ServiceFactory {
+                companion object Factory {
+                    fun create(): Service {
+                        return Service()
+                    }
+                }
+            }
+
+            class Service {
+                fun doIt(): String {
+                    return "service"
+                }
+            }
+
+            class Other {
+                fun doIt(): String {
+                    return "other"
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        service_do_it = next(
+            f for f in data["functions"]
+            if f["name"] == "doIt" and f["context"] == "Service"
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+        edge = next(
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "run" and edge["full_call_name"] == "service.doIt"
+        )
+
+        assert edge["called_context"] == "Service"
+        assert edge["called_line_number"] == service_do_it["line_number"]
+
+    def test_later_local_declaration_does_not_shadow_earlier_property_call(self, parser, tmp_path):
+        source_path = _write_source(
+            tmp_path,
+            "com/example/PropertyShadowOrder.kt",
+            """
+            package com.example
+
+            class Caller(private val svc: Service) {
+                fun run() {
+                    svc.doIt()
+                    val svc: Other = Other()
+                    svc.doIt()
+                }
+            }
+
+            class Service {
+                fun doIt(): String {
+                    return "service"
+                }
+            }
+
+            class Other {
+                fun doIt(): String {
+                    return "other"
+                }
+            }
+            """,
+        )
+        data = parser.parse(source_path)
+        imports_map = pre_scan_kotlin([source_path], parser.generic_parser_wrapper)
+        targets = {
+            f["context"]: f
+            for f in data["functions"]
+            if f["name"] == "doIt"
+        }
+        svc_calls = sorted(
+            (
+                c for c in data["function_calls"]
+                if c["full_name"] == "svc.doIt"
+            ),
+            key=lambda call: call["line_number"],
+        )
+
+        fn_to_fn, *_ = build_function_call_groups([data], imports_map)
+        edges = sorted(
+            (
+                edge for edge in fn_to_fn
+                if edge["caller_name"] == "run" and edge["full_call_name"] == "svc.doIt"
+            ),
+            key=lambda edge: edge["line_number"],
+        )
+
+        assert [call["inferred_obj_type"] for call in svc_calls] == ["Service", "Other"]
+        assert [edge["called_context"] for edge in edges] == ["Service", "Other"]
+        assert [edge["called_line_number"] for edge in edges] == [
+            targets["Service"]["line_number"],
+            targets["Other"]["line_number"],
+        ]
+
+    def test_generic_receiver_type_is_normalized(self, parser):
+        caller_data = _write_and_parse(parser, RECEIVER_PATTERNS_SRC)
+
+        variables = [
+            v for v in caller_data["variables"] if v["name"] == "genericServices"
+        ]
+        assert variables, "Expected genericServices constructor property"
+        assert variables[0]["type"] == "List<ProgressService>"
+
+        calls = [
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "genericServices.first"
+        ]
+        assert calls, "Expected genericServices.first call"
+        assert calls[0]["inferred_obj_type"] == "List"
+
+    def test_safe_call_receiver_resolves_cross_file(self, parser):
+        caller_data = _write_and_parse(parser, RECEIVER_PATTERNS_SRC)
+        progress_data = _write_and_parse(parser, PROGRESS_SERVICE_SRC)
+
+        for full_name in (
+            "optionalService.applyEvent",
+            "optionalBodyService.applyEvent",
+        ):
+            calls = [
+                c for c in caller_data["function_calls"]
+                if c["full_name"] == full_name
+            ]
+            assert calls, f"Expected {full_name} safe call"
+            assert calls[0]["inferred_obj_type"] == "ProgressService"
+
+            resolved = _resolve_with_progress_service(calls[0], caller_data, progress_data)
+            assert resolved["type"] == "function"
+            assert resolved["caller_name"] == "run"
+            assert resolved["called_file_path"] == progress_data["path"]
+
+
+class TestKotlinSemanticResolution:
+    def test_parameter_receiver_resolves_cross_file(self, parser):
+        caller_data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            class ParameterCaller {
+                fun run(paramService: ProgressService): String {
+                    return paramService.applyEvent("param")
+                }
+            }
+            """,
+        )
+        progress_data = _write_and_parse(parser, PROGRESS_SERVICE_SRC)
+
+        calls = [
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "paramService.applyEvent"
+        ]
+        assert calls, "Expected paramService.applyEvent call"
+        assert calls[0]["inferred_obj_type"] == "ProgressService"
+
+        resolved = _resolve_with_progress_service(calls[0], caller_data, progress_data)
+        assert resolved["type"] == "function"
+        assert resolved["caller_name"] == "run"
+        assert resolved["called_file_path"] == progress_data["path"]
+
+    def test_imported_top_level_function_resolves_cross_file(self, parser, tmp_path):
+        helper_path = _write_source(
+            tmp_path,
+            "com/example/util/Helpers.kt",
+            """
+            package com.example.util
+
+            fun topLevelHelper(input: String): String {
+                return input
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            import com.example.util.topLevelHelper
+
+            class Caller {
+                fun run(): String {
+                    return topLevelHelper("value")
+                }
+            }
+            """,
+        )
+
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin([helper_path, caller_path], parser.generic_parser_wrapper)
+        local_imports = {
+            imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
+            for imp in caller_data.get("imports", [])
+        }
+        calls = [
+            c for c in caller_data["function_calls"]
+            if c["name"] == "topLevelHelper"
+        ]
+        assert calls, "Expected topLevelHelper call"
+        assert "topLevelHelper" in imports_map
+        assert "com.example.util.topLevelHelper" in imports_map
+
+        resolved = resolve_function_call(
+            calls[0],
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports=local_imports,
+            imports_map=imports_map,
+            skip_external=False,
+        )
+
+        assert resolved is not None
+        assert resolved["type"] == "function"
+        assert resolved["caller_name"] == "run"
+        assert resolved["called_name"] == "topLevelHelper"
+        assert resolved["called_file_path"] == str(helper_path)
+
+    def test_object_and_companion_calls_resolve_cross_file(self, parser, tmp_path):
+        service_path = _write_source(
+            tmp_path,
+            "com/example/UserService.kt",
+            """
+            package com.example
+
+            object UserService {
+                fun findUser(id: String): String {
+                    return id
+                }
+            }
+            """,
+        )
+        logger_path = _write_source(
+            tmp_path,
+            "com/example/Logger.kt",
+            """
+            package com.example
+
+            class Logger {
+                companion object {
+                    fun info(message: String): String {
+                        return message
+                    }
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(): String {
+                    UserService.findUser("42")
+                    return Logger.info("hello")
+                }
+            }
+            """,
+        )
+
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [service_path, logger_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+
+        calls_by_name = {
+            c["name"]: c for c in caller_data["function_calls"]
+            if c["name"] in {"findUser", "info"}
+        }
+        assert set(calls_by_name) == {"findUser", "info"}
+
+        find_user = resolve_function_call(
+            calls_by_name["findUser"],
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports={},
+            imports_map=imports_map,
+            skip_external=False,
+        )
+        assert find_user is not None
+        assert find_user["type"] == "function"
+        assert find_user["called_file_path"] == str(service_path)
+
+        info = resolve_function_call(
+            calls_by_name["info"],
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports={},
+            imports_map=imports_map,
+            skip_external=False,
+        )
+        assert info is not None
+        assert info["type"] == "function"
+        assert info["called_file_path"] == str(logger_path)
+
+    def test_imported_extension_function_resolves_cross_file(self, parser, tmp_path):
+        event_path = _write_source(
+            tmp_path,
+            "com/example/ProgressEvent.kt",
+            """
+            package com.example
+
+            class ProgressEvent(val id: String)
+            """,
+        )
+        extension_path = _write_source(
+            tmp_path,
+            "com/example/ext/ProgressEventExtensions.kt",
+            """
+            package com.example.ext
+
+            import com.example.ProgressEvent
+
+            fun ProgressEvent.enrich(): String {
+                return id
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            import com.example.ext.enrich
+
+            class Caller {
+                fun run(event: ProgressEvent): String {
+                    return event.enrich()
+                }
+            }
+            """,
+        )
+
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [event_path, extension_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+        local_imports = {
+            imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
+            for imp in caller_data.get("imports", [])
+        }
+        calls = [
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "event.enrich"
+        ]
+        assert calls, "Expected event.enrich extension call"
+        assert calls[0]["inferred_obj_type"] == "ProgressEvent"
+        assert calls[0]["extension_receiver_type"] == "ProgressEvent"
+        assert "ProgressEvent.enrich" in imports_map
+        assert "com.example.ext.enrich" in imports_map
+
+        resolved = resolve_function_call(
+            calls[0],
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports=local_imports,
+            imports_map=imports_map,
+            skip_external=False,
+        )
+
+        assert resolved is not None
+        assert resolved["type"] == "function"
+        assert resolved["caller_name"] == "run"
+        assert resolved["called_name"] == "enrich"
+        assert resolved["called_file_path"] == str(extension_path)
+
+    def test_same_package_top_level_function_resolves_without_import(self, parser, tmp_path):
+        helper_path = _write_source(
+            tmp_path,
+            "com/example/Helpers.kt",
+            """
+            package com.example
+
+            fun samePackageHelper(input: String): String {
+                return input
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(): String {
+                    return samePackageHelper("value")
+                }
+            }
+            """,
+        )
+
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin([helper_path, caller_path], parser.generic_parser_wrapper)
+        calls = [
+            c for c in caller_data["function_calls"]
+            if c["name"] == "samePackageHelper"
+        ]
+        assert calls, "Expected samePackageHelper call"
+        assert calls[0]["package"] == "com.example"
+        assert "com.example.samePackageHelper" in imports_map
+
+        resolved = resolve_function_call(
+            calls[0],
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports={},
+            imports_map=imports_map,
+            skip_external=False,
+        )
+
+        assert resolved is not None
+        assert resolved["type"] == "function"
+        assert resolved["called_name"] == "samePackageHelper"
+        assert resolved["called_file_path"] == str(helper_path)
+
+    def test_same_package_extension_function_resolves_without_import(self, parser, tmp_path):
+        event_path = _write_source(
+            tmp_path,
+            "com/example/ProgressEvent.kt",
+            """
+            package com.example
+
+            class ProgressEvent(val id: String)
+            """,
+        )
+        extension_path = _write_source(
+            tmp_path,
+            "com/example/ProgressEventExtensions.kt",
+            """
+            package com.example
+
+            fun ProgressEvent.decorate(): String {
+                return id
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(event: ProgressEvent): String {
+                    return event.decorate()
+                }
+            }
+            """,
+        )
+
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [event_path, extension_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+        calls = [
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "event.decorate"
+        ]
+        assert calls, "Expected event.decorate extension call"
+        assert calls[0]["package"] == "com.example"
+        assert calls[0]["extension_receiver_type"] == "ProgressEvent"
+        assert "com.example.ProgressEvent.decorate" in imports_map
+
+        resolved = resolve_function_call(
+            calls[0],
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports={},
+            imports_map=imports_map,
+            skip_external=False,
+        )
+
+        assert resolved is not None
+        assert resolved["type"] == "function"
+        assert resolved["called_name"] == "decorate"
+        assert resolved["called_file_path"] == str(extension_path)
+
+    def test_import_aliases_resolve_top_level_and_extension_functions(self, parser, tmp_path):
+        event_path = _write_source(
+            tmp_path,
+            "com/example/ProgressEvent.kt",
+            """
+            package com.example
+
+            class ProgressEvent(val id: String)
+            """,
+        )
+        helper_path = _write_source(
+            tmp_path,
+            "com/example/util/AliasedHelpers.kt",
+            """
+            package com.example.util
+
+            fun aliasedHelper(input: String): String {
+                return input
+            }
+            """,
+        )
+        extension_path = _write_source(
+            tmp_path,
+            "com/example/ext/ProgressEventExtensions.kt",
+            """
+            package com.example.ext
+
+            import com.example.ProgressEvent
+
+            fun ProgressEvent.enrich(): String {
+                return id
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            import com.example.util.aliasedHelper as helperAlias
+            import com.example.ext.enrich as addContext
+
+            class Caller {
+                fun run(event: ProgressEvent): String {
+                    helperAlias("value")
+                    return event.addContext()
+                }
+            }
+            """,
+        )
+
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [event_path, helper_path, extension_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+        local_imports = {
+            imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
+            for imp in caller_data.get("imports", [])
+        }
+
+        helper_call = next(
+            c for c in caller_data["function_calls"] if c["name"] == "helperAlias"
+        )
+        helper_resolved = resolve_function_call(
+            helper_call,
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports=local_imports,
+            imports_map=imports_map,
+            skip_external=False,
+        )
+        assert helper_resolved is not None
+        assert helper_resolved["type"] == "function"
+        assert helper_resolved["called_name"] == "aliasedHelper"
+        assert helper_resolved["called_file_path"] == str(helper_path)
+
+        extension_call = next(
+            c for c in caller_data["function_calls"] if c["full_name"] == "event.addContext"
+        )
+        extension_resolved = resolve_function_call(
+            extension_call,
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports=local_imports,
+            imports_map=imports_map,
+            skip_external=False,
+        )
+        assert extension_resolved is not None
+        assert extension_resolved["type"] == "function"
+        assert extension_resolved["called_name"] == "enrich"
+        assert extension_resolved["called_file_path"] == str(extension_path)
+
+    def test_this_and_super_calls_resolve_to_current_and_base_files(self, parser, tmp_path):
+        base_path = _write_source(
+            tmp_path,
+            "com/example/BaseService.kt",
+            """
+            package com.example
+
+            open class BaseService {
+                open fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        derived_path = _write_source(
+            tmp_path,
+            "com/example/DerivedService.kt",
+            """
+            package com.example
+
+            class DerivedService : BaseService() {
+                override fun applyEvent(event: String): String {
+                    this.applyEventLocally(event)
+                    return super.applyEvent(event)
+                }
+
+                fun applyEventLocally(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+
+        derived_data = parser.parse(derived_path)
+        imports_map = pre_scan_kotlin([base_path, derived_path], parser.generic_parser_wrapper)
+        local_class_bases = {
+            c["name"]: c.get("bases", []) for c in derived_data.get("classes", [])
+        }
+
+        calls = {
+            c["full_name"]: c for c in derived_data["function_calls"]
+            if c["full_name"] in {"this.applyEventLocally", "super.applyEvent"}
+        }
+        assert set(calls) == {"this.applyEventLocally", "super.applyEvent"}
+
+        this_resolved = resolve_function_call(
+            calls["this.applyEventLocally"],
+            caller_file_path=derived_data["path"],
+            local_names=_local_names(derived_data),
+            local_imports={},
+            imports_map=imports_map,
+            skip_external=False,
+            local_class_bases=local_class_bases,
+        )
+        assert this_resolved is not None
+        assert this_resolved["type"] == "function"
+        assert this_resolved["called_name"] == "applyEventLocally"
+        assert this_resolved["called_file_path"] == str(derived_path)
+
+        super_resolved = resolve_function_call(
+            calls["super.applyEvent"],
+            caller_file_path=derived_data["path"],
+            local_names=_local_names(derived_data),
+            local_imports={},
+            imports_map=imports_map,
+            skip_external=False,
+            local_class_bases=local_class_bases,
+        )
+        assert super_resolved is not None
+        assert super_resolved["type"] == "function"
+        assert super_resolved["called_name"] == "applyEvent"
+        assert super_resolved["called_file_path"] == str(base_path)
+
+    def test_class_constructor_delegation_resolves_to_base_class(self, parser, tmp_path):
+        base_path = _write_source(
+            tmp_path,
+            "com/example/BaseService.kt",
+            """
+            package com.example
+
+            open class BaseService
+            """,
+        )
+        derived_path = _write_source(
+            tmp_path,
+            "com/example/DerivedService.kt",
+            """
+            package com.example
+
+            class DerivedService() : BaseService()
+            """,
+        )
+
+        derived_data = parser.parse(derived_path)
+        imports_map = pre_scan_kotlin([base_path, derived_path], parser.generic_parser_wrapper)
+        calls = [
+            c for c in derived_data["function_calls"]
+            if c["name"] == "BaseService"
+        ]
+        assert calls, "Expected BaseService constructor delegation call"
+
+        resolved = resolve_function_call(
+            calls[0],
+            caller_file_path=derived_data["path"],
+            local_names=_local_names(derived_data),
+            local_imports={},
+            imports_map=imports_map,
+            skip_external=False,
+        )
+
+        assert resolved is not None
+        assert resolved["type"] == "function"
+        assert resolved["caller_name"] == "DerivedService"
+        assert resolved["called_name"] == "BaseService"
+        assert resolved["called_file_path"] == str(base_path)
+
+    def test_cross_file_chained_return_and_property_receivers_resolve(self, parser, tmp_path):
+        progress_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        provider_path = _write_source(
+            tmp_path,
+            "com/example/Provider.kt",
+            """
+            package com.example
+
+            class Provider {
+                val progressService: ProgressService = ProgressService()
+
+                fun service(): ProgressService {
+                    return ProgressService()
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(provider: Provider): String {
+                    provider.service().applyEvent("chain")
+                    provider.progressService.applyEvent("property")
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        progress_data = parser.parse(progress_path)
+        provider_data = parser.parse(provider_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [progress_path, provider_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+        member_return_types = {
+            (f.get("context"), f["name"]): f["return_type"]
+            for data in (progress_data, provider_data, caller_data)
+            for f in data.get("functions", [])
+            if f.get("return_type")
+        }
+        member_property_types = {
+            (v.get("context"), v["name"]): v["type"]
+            for data in (progress_data, provider_data, caller_data)
+            for v in data.get("variables", [])
+            if v.get("type")
+        }
+
+        calls = {
+            c["full_name"]: c for c in caller_data["function_calls"]
+            if c["full_name"] in {
+                "provider.service().applyEvent",
+                "provider.progressService.applyEvent",
+            }
+        }
+        assert set(calls) == {
+            "provider.service().applyEvent",
+            "provider.progressService.applyEvent",
+        }
+        assert calls["provider.service().applyEvent"]["receiver_base_type"] == "Provider"
+        assert calls["provider.service().applyEvent"]["receiver_member_name"] == "service"
+        assert calls["provider.service().applyEvent"]["receiver_member_kind"] == "function"
+        assert calls["provider.progressService.applyEvent"]["receiver_base_type"] == "Provider"
+        assert calls["provider.progressService.applyEvent"]["receiver_member_name"] == "progressService"
+        assert calls["provider.progressService.applyEvent"]["receiver_member_kind"] == "property"
+
+        for call in calls.values():
+            resolved = resolve_function_call(
+                call,
+                caller_file_path=caller_data["path"],
+                local_names=_local_names(caller_data),
+                local_imports={},
+                imports_map=imports_map,
+                skip_external=False,
+                member_return_types=member_return_types,
+                member_property_types=member_property_types,
+            )
+
+            assert resolved is not None
+            assert resolved["type"] == "function"
+            assert resolved["called_name"] == "applyEvent"
+            assert resolved["called_file_path"] == str(progress_path)
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [progress_data, provider_data, caller_data],
+            imports_map,
+        )
+        resolved_edges = {
+            (edge["full_call_name"], edge["called_file_path"])
+            for edge in fn_to_fn
+        }
+        assert ("provider.service().applyEvent", str(progress_path)) in resolved_edges
+        assert ("provider.progressService.applyEvent", str(progress_path)) in resolved_edges
+
+    def test_wildcard_imports_resolve_top_level_and_extension_functions(self, parser, tmp_path):
+        event_path = _write_source(
+            tmp_path,
+            "com/example/ProgressEvent.kt",
+            """
+            package com.example
+
+            class ProgressEvent(val id: String)
+            """,
+        )
+        helper_path = _write_source(
+            tmp_path,
+            "com/example/util/WildcardHelpers.kt",
+            """
+            package com.example.util
+
+            import com.example.ProgressEvent
+
+            fun wildcardHelper(input: String): String {
+                return input
+            }
+
+            fun ProgressEvent.wildcardEnrich(): String {
+                return id
+            }
+            """,
+        )
+        other_helper_path = _write_source(
+            tmp_path,
+            "com/example/other/WildcardHelpers.kt",
+            """
+            package com.example.other
+
+            import com.example.ProgressEvent
+
+            fun wildcardHelper(input: String): String {
+                return "wrong"
+            }
+
+            fun ProgressEvent.wildcardEnrich(): String {
+                return "wrong"
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            import com.example.util.*
+
+            class Caller {
+                fun run(event: ProgressEvent): String {
+                    wildcardHelper("value")
+                    return event.wildcardEnrich()
+                }
+            }
+            """,
+        )
+
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [event_path, other_helper_path, helper_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+        local_imports = _local_imports(caller_data)
+        assert local_imports["__wildcards__"] == ["com.example.util"]
+
+        helper_call = next(
+            c for c in caller_data["function_calls"] if c["name"] == "wildcardHelper"
+        )
+        helper_resolved = resolve_function_call(
+            helper_call,
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports=local_imports,
+            imports_map=imports_map,
+            skip_external=False,
+        )
+        assert helper_resolved is not None
+        assert helper_resolved["called_file_path"] == str(helper_path)
+
+        extension_call = next(
+            c for c in caller_data["function_calls"] if c["full_name"] == "event.wildcardEnrich"
+        )
+        extension_resolved = resolve_function_call(
+            extension_call,
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports=local_imports,
+            imports_map=imports_map,
+            skip_external=False,
+        )
+        assert extension_resolved is not None
+        assert extension_resolved["called_file_path"] == str(helper_path)
+
+    def test_imported_typealias_receiver_resolves_to_target_type(self, parser, tmp_path):
+        progress_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        alias_path = _write_source(
+            tmp_path,
+            "com/example/types/Aliases.kt",
+            """
+            package com.example.types
+
+            typealias ProgressAlias = com.example.ProgressService
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            import com.example.types.ProgressAlias
+
+            class Caller {
+                fun run(service: ProgressAlias): String {
+                    return service.applyEvent("alias")
+                }
+            }
+            """,
+        )
+
+        progress_data = parser.parse(progress_path)
+        alias_data = parser.parse(alias_path)
+        caller_data = parser.parse(caller_path)
+        assert alias_data["typealiases"] == [
+            {
+                "name": "ProgressAlias",
+                "target": "com.example.ProgressService",
+                "line_number": 4,
+                "path": str(alias_path),
+                "package": "com.example.types",
+                "lang": "kotlin",
+            }
+        ]
+
+        imports_map = pre_scan_kotlin(
+            [progress_path, alias_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+        fn_to_fn, *_ = build_function_call_groups(
+            [progress_data, alias_data, caller_data],
+            imports_map,
+        )
+
+        assert any(
+            edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(progress_path)
+            for edge in fn_to_fn
+        )
+
+    def test_scope_functions_infer_receiver_for_common_kotlin_forms(self, parser, tmp_path):
+        progress_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(service: ProgressService): String {
+                    service.apply { applyEvent("apply") }
+                    service.run { applyEvent("run") }
+                    service.let { it.applyEvent("let") }
+                    service.also { it.applyEvent("also") }
+                    service.let { current -> current.applyEvent("named") }
+                    with(service) { applyEvent("with") }
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        progress_data = parser.parse(progress_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [progress_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+
+        parsed_apply_event_calls = [
+            c for c in caller_data["function_calls"] if c["name"] == "applyEvent"
+        ]
+        assert len(parsed_apply_event_calls) == 6
+        assert all(
+            call["inferred_obj_type"] == "ProgressService"
+            for call in parsed_apply_event_calls
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [progress_data, caller_data],
+            imports_map,
+        )
+        resolved_lines = {
+            edge["line_number"]
+            for edge in fn_to_fn
+            if edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(progress_path)
+        }
+        assert resolved_lines == {6, 7, 8, 9, 10, 11}
+
+    def test_callable_references_resolve_instance_and_type_receivers(self, parser, tmp_path):
+        progress_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(service: ProgressService): String {
+                    val instanceRef = service::applyEvent
+                    val typeRef = ProgressService::applyEvent
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        progress_data = parser.parse(progress_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [progress_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+
+        callable_refs = [
+            c for c in caller_data["function_calls"]
+            if c["call_kind"] == "callable_reference"
+        ]
+        assert {c["full_name"] for c in callable_refs} == {
+            "service.applyEvent",
+            "ProgressService.applyEvent",
+        }
+        instance_ref = next(c for c in callable_refs if c["base_obj"] == "service")
+        assert instance_ref["inferred_obj_type"] == "ProgressService"
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [progress_data, caller_data],
+            imports_map,
+        )
+        resolved_refs = [
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(progress_path)
+        ]
+        assert len(resolved_refs) == 2
+
+    def test_cast_and_non_null_receivers_resolve_to_target_type(self, parser, tmp_path):
+        progress_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(service: Any?, nullableService: ProgressService?): String {
+                    (service as ProgressService).applyEvent("cast")
+                    nullableService!!.applyEvent("nonnull")
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        progress_data = parser.parse(progress_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [progress_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+
+        apply_event_calls = [
+            c for c in caller_data["function_calls"] if c["name"] == "applyEvent"
+        ]
+        assert len(apply_event_calls) == 2
+        assert all(
+            c["inferred_obj_type"] == "ProgressService"
+            for c in apply_event_calls
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [progress_data, caller_data],
+            imports_map,
+        )
+        resolved_lines = {
+            edge["line_number"]
+            for edge in fn_to_fn
+            if edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(progress_path)
+        }
+        assert resolved_lines == {6, 7}
+
+    def test_generic_factory_and_assignment_flow_infer_receivers(self, parser, tmp_path):
+        progress_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        provider_path = _write_source(
+            tmp_path,
+            "com/example/Provider.kt",
+            """
+            package com.example
+
+            class Provider {
+                fun service(): ProgressService {
+                    return ProgressService()
+                }
+
+                fun <T> get(): T {
+                    TODO()
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(provider: Provider): String {
+                    provider.get<ProgressService>().applyEvent("generic")
+                    val assignedService = provider.service()
+                    assignedService.applyEvent("assigned")
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        progress_data = parser.parse(progress_path)
+        provider_data = parser.parse(provider_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [progress_path, provider_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+
+        generic_call = next(
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "provider.get<ProgressService>().applyEvent"
+        )
+        assert generic_call["inferred_obj_type"] == "ProgressService"
+
+        assigned_variable = next(
+            v for v in caller_data["variables"]
+            if v["name"] == "assignedService"
+        )
+        assert assigned_variable["initializer_receiver_name"] == "provider"
+        assert assigned_variable["initializer_member_name"] == "service"
+        assert assigned_variable["initializer_member_kind"] == "function"
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [progress_data, provider_data, caller_data],
+            imports_map,
+        )
+        resolved_lines = {
+            edge["line_number"]
+            for edge in fn_to_fn
+            if edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(progress_path)
+        }
+        assert resolved_lines == {6, 8}
+
+    def test_import_precedence_prefers_explicit_then_same_package_before_wildcard(
+        self,
+        parser,
+        tmp_path,
+    ):
+        explicit_path = _write_source(
+            tmp_path,
+            "com/example/util/ExplicitHelpers.kt",
+            """
+            package com.example.util
+
+            fun explicitHelper(): String {
+                return "explicit"
+            }
+            """,
+        )
+        same_package_path = _write_source(
+            tmp_path,
+            "com/example/SamePackageHelpers.kt",
+            """
+            package com.example
+
+            fun explicitHelper(): String {
+                return "same-package-wrong"
+            }
+
+            fun samePackageHelper(): String {
+                return "same-package"
+            }
+            """,
+        )
+        wildcard_path = _write_source(
+            tmp_path,
+            "com/example/wild/WildcardHelpers.kt",
+            """
+            package com.example.wild
+
+            fun samePackageHelper(): String {
+                return "wildcard-wrong"
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            import com.example.util.explicitHelper
+            import com.example.wild.*
+
+            class Caller {
+                fun run(): String {
+                    explicitHelper()
+                    samePackageHelper()
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [explicit_path, same_package_path, wildcard_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+        local_imports = _local_imports(caller_data)
+
+        explicit_call = next(
+            c for c in caller_data["function_calls"] if c["name"] == "explicitHelper"
+        )
+        same_package_call = next(
+            c for c in caller_data["function_calls"] if c["name"] == "samePackageHelper"
+        )
+
+        explicit_resolved = resolve_function_call(
+            explicit_call,
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports=local_imports,
+            imports_map=imports_map,
+            skip_external=False,
+        )
+        same_package_resolved = resolve_function_call(
+            same_package_call,
+            caller_file_path=caller_data["path"],
+            local_names=_local_names(caller_data),
+            local_imports=local_imports,
+            imports_map=imports_map,
+            skip_external=False,
+        )
+
+        assert explicit_resolved is not None
+        assert explicit_resolved["called_file_path"] == str(explicit_path)
+        assert same_package_resolved is not None
+        assert same_package_resolved["called_file_path"] == str(same_package_path)
+
+    def test_if_and_when_smart_casts_infer_receiver_types(self, parser, tmp_path):
+        progress_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(service: Any): String {
+                    if (service is ProgressService) {
+                        service.applyEvent("if")
+                    }
+                    when (service) {
+                        is ProgressService -> service.applyEvent("when")
+                        else -> Unit
+                    }
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        progress_data = parser.parse(progress_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [progress_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+
+        smart_cast_calls = [
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "service.applyEvent"
+        ]
+        assert len(smart_cast_calls) == 2
+        assert all(c["inferred_obj_type"] == "ProgressService" for c in smart_cast_calls)
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [progress_data, caller_data],
+            imports_map,
+        )
+        resolved_edges = [
+            edge for edge in fn_to_fn
+            if edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(progress_path)
+        ]
+        assert len(resolved_edges) == 2
+
+    def test_negated_and_or_type_checks_do_not_smart_cast(self, parser):
+        caller_data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+
+            class OtherService
+
+            class Caller {
+                fun run(service: Any): String {
+                    if (!(service is ProgressService)) {
+                        service.applyEvent("negated")
+                    }
+                    if (service is ProgressService || service is OtherService) {
+                        service.applyEvent("or")
+                    }
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        apply_event_calls = [
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "service.applyEvent"
+        ]
+        assert len(apply_event_calls) == 2
+        assert all(
+            c["inferred_obj_type"] != "ProgressService"
+            for c in apply_event_calls
+        )
+
+    def test_inherited_member_calls_resolve_to_base_method_file(self, parser, tmp_path):
+        base_path = _write_source(
+            tmp_path,
+            "com/example/BaseService.kt",
+            """
+            package com.example
+
+            open class BaseService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        child_path = _write_source(
+            tmp_path,
+            "com/example/ChildService.kt",
+            """
+            package com.example
+
+            class ChildService : BaseService()
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(service: ChildService): String {
+                    return service.applyEvent("base")
+                }
+            }
+            """,
+        )
+
+        base_data = parser.parse(base_path)
+        child_data = parser.parse(child_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [base_path, child_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [base_data, child_data, caller_data],
+            imports_map,
+        )
+        assert any(
+            edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(base_path)
+            for edge in fn_to_fn
+        )
+        assert not any(
+            edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(child_path)
+            for edge in fn_to_fn
+        )
+
+    def test_interface_default_member_resolves_through_base_interface(self, parser, tmp_path):
+        interface_path = _write_source(
+            tmp_path,
+            "com/example/ProgressPort.kt",
+            """
+            package com.example
+
+            interface ProgressPort {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        service_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService : ProgressPort
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(service: ProgressService): String {
+                    return service.applyEvent("interface")
+                }
+            }
+            """,
+        )
+
+        interface_data = parser.parse(interface_path)
+        service_data = parser.parse(service_path)
+        caller_data = parser.parse(caller_path)
+        assert {c["name"] for c in interface_data["classes"]} == {"ProgressPort"}
+        assert any(
+            f["name"] == "applyEvent" and f["context"] == "ProgressPort"
+            for f in interface_data["functions"]
+        )
+
+        imports_map = pre_scan_kotlin(
+            [interface_path, service_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+        fn_to_fn, *_ = build_function_call_groups(
+            [interface_data, service_data, caller_data],
+            imports_map,
+        )
+        assert any(
+            edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(interface_path)
+            for edge in fn_to_fn
+        )
+
+    def test_elvis_and_safe_cast_receivers_infer_receiver_types(self, parser, tmp_path):
+        progress_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(primary: ProgressService?, fallback: ProgressService, unknown: Any?): String {
+                    (primary ?: fallback).applyEvent("elvis");
+                    (unknown as? ProgressService)?.applyEvent("safeCast")
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        progress_data = parser.parse(progress_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [progress_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+
+        apply_event_calls = [
+            c for c in caller_data["function_calls"]
+            if c["name"] == "applyEvent"
+        ]
+        assert len(apply_event_calls) == 2
+        assert all(c["inferred_obj_type"] == "ProgressService" for c in apply_event_calls)
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [progress_data, caller_data],
+            imports_map,
+        )
+        resolved_lines = {
+            edge["line_number"]
+            for edge in fn_to_fn
+            if edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(progress_path)
+        }
+        assert resolved_lines == {6, 7}
+
+    def test_expression_initializer_flow_infers_receiver_types(self, parser, tmp_path):
+        progress_path = _write_source(
+            tmp_path,
+            "com/example/ProgressService.kt",
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+            """,
+        )
+        caller_path = _write_source(
+            tmp_path,
+            "com/example/Caller.kt",
+            """
+            package com.example
+
+            class Caller {
+                fun run(primary: ProgressService?, fallback: ProgressService, a: ProgressService, b: ProgressService, flag: Boolean): String {
+                    val elvisService = primary ?: fallback
+                    val nestedElvisService = primary ?: (a ?: b) ?: fallback
+                    val ifService = if ((flag)) a else b
+                    val whenService = when (flag) {
+                        true -> a
+                        else -> b
+                    }
+                    elvisService.applyEvent("elvis")
+                    nestedElvisService.applyEvent("nestedElvis")
+                    ifService.applyEvent("if")
+                    whenService.applyEvent("when")
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        progress_data = parser.parse(progress_path)
+        caller_data = parser.parse(caller_path)
+        imports_map = pre_scan_kotlin(
+            [progress_path, caller_path],
+            parser.generic_parser_wrapper,
+        )
+
+        variables_by_name = {
+            v["name"]: v
+            for v in caller_data["variables"]
+            if v["name"] in {
+                "elvisService",
+                "nestedElvisService",
+                "ifService",
+                "whenService",
+            }
+        }
+        assert variables_by_name["elvisService"]["initializer_candidate_names"] == [
+            "primary",
+            "fallback",
+        ]
+        assert variables_by_name["nestedElvisService"]["initializer_candidate_names"] == [
+            "primary",
+            "a",
+            "b",
+            "fallback",
+        ]
+        assert variables_by_name["ifService"]["initializer_candidate_names"] == [
+            "a",
+            "b",
+        ]
+        assert variables_by_name["whenService"]["initializer_candidate_names"] == [
+            "a",
+            "b",
+        ]
+
+        fn_to_fn, *_ = build_function_call_groups(
+            [progress_data, caller_data],
+            imports_map,
+        )
+        resolved_lines = {
+            edge["line_number"]
+            for edge in fn_to_fn
+            if edge["caller_name"] == "run"
+            and edge["called_name"] == "applyEvent"
+            and edge["called_file_path"] == str(progress_path)
+        }
+        assert resolved_lines == {13, 14, 15, 16}
+
+    def test_expression_initializer_flow_requires_consistent_candidate_types(self, parser):
+        caller_data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+
+            class OtherService
+
+            class Caller {
+                fun run(primary: ProgressService, other: OtherService, flag: Boolean): String {
+                    val mixed = if (flag) primary else other
+                    mixed.applyEvent("mixed")
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        mixed_call = next(
+            c for c in caller_data["function_calls"]
+            if c["full_name"] == "mixed.applyEvent"
+        )
+        assert mixed_call["inferred_obj_type"] is None
+
+    def test_elvis_initializer_flow_requires_all_branches_to_be_candidates(self, parser):
+        caller_data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            class ProgressService {
+                fun applyEvent(event: String): String {
+                    return event
+                }
+            }
+
+            class Caller {
+                fun build(): ProgressService {
+                    return ProgressService()
+                }
+
+                fun run(fallback: ProgressService, threshold: Int): String {
+                    val fromCall = build() ?: fallback
+                    val fromComparison = threshold > 0 ?: fallback
+                    fromCall.applyEvent("call")
+                    fromComparison.applyEvent("comparison")
+                    return "done"
+                }
+            }
+            """,
+        )
+
+        variables_by_name = {
+            v["name"]: v
+            for v in caller_data["variables"]
+            if v["name"] in {"fromCall", "fromComparison"}
+        }
+        assert "initializer_candidate_names" not in variables_by_name["fromCall"]
+        assert "initializer_candidate_names" not in variables_by_name["fromComparison"]
+
+        calls_by_name = {
+            c["full_name"]: c
+            for c in caller_data["function_calls"]
+            if c["full_name"] in {
+                "fromCall.applyEvent",
+                "fromComparison.applyEvent",
+            }
+        }
+        assert calls_by_name["fromCall.applyEvent"]["inferred_obj_type"] is None
+        assert calls_by_name["fromComparison.applyEvent"]["inferred_obj_type"] is None

--- a/tests/unit/tools/test_code_finder_fuzzy.py
+++ b/tests/unit/tools/test_code_finder_fuzzy.py
@@ -1,4 +1,7 @@
-from codegraphcontext.tools.code_finder import _levenshtein_distance
+from codegraphcontext.tools.code_finder import (
+    _levenshtein_distance,
+    summarize_kotlin_call_ambiguity,
+)
 
 
 def test_levenshtein_single_typo():
@@ -7,3 +10,55 @@ def test_levenshtein_single_typo():
 
 def test_levenshtein_identical():
     assert _levenshtein_distance("abc", "abc") == 0
+
+
+def test_summarize_kotlin_call_ambiguity_groups_multi_target_calls():
+    rows = [
+        {
+            "caller_name": "run",
+            "caller_path": "/repo/A.kt",
+            "caller_line": 10,
+            "caller_end_line": 20,
+            "call_line": 12,
+            "full_call_name": "service.target",
+            "target_name": "target",
+            "target_path": "/repo/Service.kt",
+            "target_line": 5,
+            "target_context": "Service",
+            "args": ["value"],
+        },
+        {
+            "caller_name": "run",
+            "caller_path": "/repo/A.kt",
+            "caller_line": 10,
+            "caller_end_line": 20,
+            "call_line": 12,
+            "full_call_name": "service.target",
+            "target_name": "target",
+            "target_path": "/repo/Service.kt",
+            "target_line": 9,
+            "target_context": "Service",
+            "args": ["value"],
+        },
+        {
+            "caller_name": "run",
+            "caller_path": "/repo/A.kt",
+            "caller_line": 10,
+            "caller_end_line": 20,
+            "call_line": 13,
+            "full_call_name": "helper",
+            "target_name": "helper",
+            "target_path": "/repo/A.kt",
+            "target_line": 30,
+            "target_context": None,
+            "args": [],
+        },
+    ]
+
+    summary = summarize_kotlin_call_ambiguity(rows)
+
+    assert summary["kotlin_fn_to_fn_edges"] == 3
+    assert summary["ambiguous_groups"] == 1
+    assert summary["ambiguous_edges"] == 2
+    assert summary["top_names"] == [{"name": "target", "groups": 1}]
+    assert summary["examples"][0]["target_count"] == 2

--- a/tests/unit/tools/test_graph_builder_perf_fixes.py
+++ b/tests/unit/tools/test_graph_builder_perf_fixes.py
@@ -266,6 +266,107 @@ class TestCreateAllFunctionCallsV3:
         for q in call_rels:
             assert "MERGE" in q, f"Expected MERGE in CALLS query, got: {q[:120]}"
 
+    def test_calls_merge_identity_excludes_mutable_metadata(self):
+        """CALLS confidence/tier should update without becoming relationship identity."""
+        file_data = [{
+            "path": "/repo/a.py",
+            "functions": [{"name": "foo", "line_number": 1}],
+            "classes": [],
+            "imports": [],
+            "function_calls": [{
+                "name": "foo",
+                "line_number": 5,
+                "full_name": "foo",
+                "args": [],
+                "context": ("bar", None, 4),
+                "confidence": 0.9,
+                "resolution_tier": 1,
+            }],
+        }]
+        calls = self._run(file_data)
+        call_write = next(c for c in calls if "CALLS" in c["query"])
+        merge_clause = call_write["query"].split("MERGE", 1)[1].split("SET", 1)[0]
+
+        assert "confidence" not in merge_clause
+        assert "resolution_tier" not in merge_clause
+        assert "SET call.confidence = row.confidence" in call_write["query"]
+        assert "call.resolution_tier = row.resolution_tier" in call_write["query"]
+
+    def test_function_call_writes_use_precise_target_filters(self):
+        """CALLS writes should use target line/context hints when resolution provides them."""
+        file_data = [{
+            "path": "/repo/a.py",
+            "functions": [
+                {"name": "caller_fn", "line_number": 1, "args": []},
+                {"name": "callee", "line_number": 10, "args": ["value"]},
+                {"name": "callee", "line_number": 20, "args": ["value", "flag"]},
+            ],
+            "classes": [],
+            "imports": [],
+            "function_calls": [{
+                "name": "callee",
+                "line_number": 5,
+                "full_name": "callee",
+                "args": ["value", "true"],
+                "context": ("caller_fn", None, 1),
+            }],
+        }]
+
+        calls = self._run(file_data)
+        call_write = next(c for c in calls if "CALLS" in c["query"])
+
+        assert "called.line_number = row.called_line_number" in call_write["query"]
+        assert "called.context = row.called_context" in call_write["query"]
+        assert call_write["kwargs"]["batch"][0]["called_line_number"] == 20
+        assert call_write["kwargs"]["batch"][0]["called_context"] == ""
+
+    def test_function_call_batch_normalization_preserves_falsy_filters(self):
+        """Only None should become the broad target sentinel; malformed rows are skipped."""
+        from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+        session = _RecordingSession()
+        writer = GraphWriter(_FakeDriver(session))
+        writer.write_function_call_groups(
+            [
+                {},
+                None,
+                {
+                    "caller_name": "caller",
+                    "caller_file_path": "/repo/a.py",
+                    "caller_line_number": 1,
+                    "called_name": "callee",
+                    "called_file_path": "/repo/a.py",
+                    "called_line_number": 0,
+                    "called_context": "",
+                    "line_number": 5,
+                    "args": [],
+                    "full_call_name": "callee",
+                },
+                {
+                    "caller_name": "caller",
+                    "caller_file_path": "/repo/a.py",
+                    "caller_line_number": 1,
+                    "called_name": "bad",
+                    "called_file_path": "/repo/a.py",
+                    "called_line_number": False,
+                    "called_context": False,
+                    "line_number": 6,
+                    "args": [],
+                    "full_call_name": "bad",
+                },
+            ],
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
+
+        call_write = next(c for c in session.calls if "CALLS" in c["query"])
+        assert len(call_write["kwargs"]["batch"]) == 1
+        assert call_write["kwargs"]["batch"][0]["called_line_number"] == 0
+        assert call_write["kwargs"]["batch"][0]["called_context"] == ""
+
     def test_empty_file_data_writes_nothing(self):
         calls = self._run([])
         call_rels = [c for c in calls if "CALLS" in c.get("query", "")]
@@ -351,6 +452,92 @@ class TestAddFileToGraph:
         gb.add_file_to_graph(file_data, "my_repo", {}, repo_path_str="/repo")
         queries = [c["query"] for c in session.calls]
         assert any("UNWIND" in q for q in queries), "Expected UNWIND batch writes"
+
+    def test_class_function_contains_uses_class_context_line(self):
+        """Same-named nested classes in one file should not all own every method."""
+        session = _RecordingSession(responses=[_FakeResult()])
+        gb, _ = _make_graph_builder(session)
+        file_data = {
+            "path": "/repo/A.kt",
+            "lang": "kotlin",
+            "is_dependency": False,
+            "functions": [
+                {
+                    "name": "run",
+                    "line_number": 3,
+                    "args": [],
+                    "class_context": "Worker",
+                    "class_context_line": 2,
+                },
+                {
+                    "name": "run",
+                    "line_number": 8,
+                    "args": [],
+                    "class_context": "Worker",
+                    "class_context_line": 7,
+                },
+            ],
+            "classes": [
+                {"name": "Worker", "line_number": 2},
+                {"name": "Worker", "line_number": 7},
+            ],
+            "variables": [],
+            "imports": [],
+            "function_calls": [],
+        }
+        gb.add_file_to_graph(file_data, "my_repo", {}, repo_path_str="/repo")
+
+        class_fn_call = next(
+            c
+            for c in session.calls
+            if "MATCH (c:Class" in c["query"] and "MERGE (c)-[:CONTAINS]->(fn)" in c["query"]
+        )
+        assert "c.line_number = row.class_line" in class_fn_call["query"]
+        assert class_fn_call["kwargs"]["batch"] == [
+            {"class_name": "Worker", "class_line": 2, "func_name": "run", "func_line": 3},
+            {"class_name": "Worker", "class_line": 7, "func_name": "run", "func_line": 8},
+        ]
+
+    def test_non_javascript_import_rows_are_schema_complete(self):
+        """Imports without full_import_name/source parity should not break Kuzu UNWIND."""
+        session = _RecordingSession(responses=[_FakeResult()])
+        gb, _ = _make_graph_builder(session)
+        file_data = {
+            "path": "/repo/main.go",
+            "lang": "go",
+            "is_dependency": False,
+            "functions": [],
+            "classes": [],
+            "variables": [],
+            "imports": [
+                {
+                    "name": "fmt",
+                    "source": "fmt",
+                    "alias": None,
+                    "line_number": 3,
+                    "lang": "go",
+                }
+            ],
+            "function_calls": [],
+        }
+
+        gb.add_file_to_graph(file_data, "my_repo", {}, repo_path_str="/repo")
+
+        import_call = next(
+            c for c in session.calls
+            if "MERGE (f)-[r:IMPORTS]->(m)" in c["query"]
+        )
+        assert "m.alias" not in import_call["query"]
+        assert import_call["kwargs"]["batch"] == [
+            {
+                "name": "fmt",
+                "full_import_name": "fmt",
+                "imported_name": "fmt",
+                "alias": None,
+                "line_number": 3,
+                "lang": "go",
+            }
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/tools/test_kuzu_relationship_queries.py
+++ b/tests/unit/tools/test_kuzu_relationship_queries.py
@@ -67,5 +67,4 @@ def test_call_chain_avoids_list_extract():
 
     q = recorder["last_query"]
     assert "list_extract" not in q
-    assert "func_nodes[size(func_nodes)]" in q
-
+    assert "func_nodes[size(func_nodes)-1]" in q


### PR DESCRIPTION
## Summary

Improves Kotlin/JVM call graph accuracy and fixes several bugs in Java parsing, schema performance, CLI commands, and MCP tools.

---

## Part 1: Kotlin/JVM call graph precision

Addresses systematic gaps in receiver-based call resolution, cross-file resolution, import handling, type inference, and overload selection.

**What was not working:**
- Same-file calls not attached to correct caller context
- Receiver-based calls: `service.doWork()`, `this.doWork()`, `super.doWork()`, `foo?.bar()`, chained calls
- Cross-file: imported functions, same-package top-level, extension functions, object/companion calls, constructor delegation, inherited methods, interface implementations
- Import forms: aliases, wildcards, same-package (implicit), typealiases
- Overload resolution: wrong target selected when multiple candidates with same name exist

**Changes:**
- `KotlinVisitor`: full receiver chain resolution, safe-call unwrapping, overload scoring, scope-aware lookup
- `resolve_function_call`: Kotlin-aware import alias expansion, wildcard import resolution, companion/object call routing
- Perf: skip Kotlin index builds for non-Kotlin repos; filter unsupported extensions in `discover_files_to_index`

---

## Part 2: Java parser bug fixes

**`fix(java)`: interface/enum methods get `class_context=None`; Cassandra `@Table` picks keyspace not name**

Two bugs in `_extract_orm_mappings` / `_parse_functions`:

1. **MyBatis mapper interface methods had `class_context=None`** — `'class' in context_type` is `False` for `interface_declaration` and `enum_declaration`, so `write_mybatis_links()` MATCH found 0 nodes. Fixed: explicit set membership check against all 4 container types. Impact: ~2000+ READS/WRITES edges were missing.

2. **Cassandra `@Table` regex matched keyspace string instead of table name** — `@Table(keyspace="identity", name="machine_profile_lookup")` matched `"identity"` (first quoted string). Fixed: prefer `\bname\s*=\s*"([^"]+)"` before falling back to bare string.

---

## Part 3: Performance — Parameter node index

**`fix`: add `parameter_unique` index on `(name, path, function_line_number)`**

Without this index, MERGE on Parameter nodes does a full table scan. Adding it drops per-file write time from ~6s → ~14ms (439× speedup) on large Java repos.

---

## Part 4: CLI + MCP bug fixes

**`fix(mcp)`: `cgc report` unpack bug + Spring/bean tools `repo_path` filter**

- `report` command unpacked `_initialize_services()` as 3-tuple but it returns 4 values (added `ResolvedContext`) — caused `ValueError: not enough values to unpack`
- `find_java_spring_endpoints` / `find_java_spring_beans`: filter changed from `STARTS WITH` to `CONTAINS` — absolute paths never match `STARTS WITH '/repo/'`

**`fix`: set `path` on MavenModule nodes + `is_unresolved_external` `UnboundLocalError`**

- `MavenModule.path` was `null` — `WHERE m.path CONTAINS '/repo/'` returned 0 results
- `is_unresolved_external` only initialized inside nested branches but read unconditionally → `NameError` crash after several minutes of indexing

---

## Validated against a large Java codebase (~52K functions, 8K classes)

- Nexus: 483s, 52K+ functions, 1,523 INJECTS, 49 MavenModules ✅
- Tests: 414 passed, 4 pre-existing kuzu-not-installed failures ✅