### PR TITLE
fix(falkordb): skip CREATE CONSTRAINT for FalkorDB backends; fix watcher generic file drop

### DIFF
--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -858,6 +858,10 @@ class GraphBuilder:
             if "error" not in file_data:
                 self.add_file_to_graph(file_data, repo_name, imports_map)
                 return file_data
+            if not file_data.get("unsupported"):
+                # Generic file type (.md, .yml, .json, etc.) — create a bare File node
+                self.add_minimal_file_node(path, repo_path)
+                return file_data
             error_logger(f"Skipping graph add for {file_path_str} due to parsing error: {file_data['error']}")
             return None
         return {"deleted": True, "path": file_path_str}

--- a/src/codegraphcontext/tools/indexing/schema.py
+++ b/src/codegraphcontext/tools/indexing/schema.py
@@ -7,6 +7,13 @@ from ...utils.debug_log import info_logger, warning_logger
 
 def create_graph_schema(driver: Any, db_manager: Any) -> None:
     """Create constraints and indexes. *driver* must support .session() context manager."""
+    backend_type = getattr(db_manager, "get_backend_type", lambda: "neo4j")()
+    # FalkorDB (both embedded and remote) has a confirmed null-pointer crash in
+    # EnforceUniqueEntity when composite UNIQUE constraints are used with MERGE.
+    # Skip all CREATE CONSTRAINT statements for FalkorDB backends; the indices
+    # created below are sufficient for MERGE to perform correct deduplication.
+    is_falkordb = backend_type.startswith("falkordb")
+
     with driver.session() as session:
         try:
             # FalkorDB requires a supporting index to exist BEFORE creating a UNIQUE constraint.
@@ -28,50 +35,51 @@ def create_graph_schema(driver: Any, db_manager: Any) -> None:
             session.run("CREATE INDEX IF NOT EXISTS FOR (r:Record) ON (r.name, r.path, r.line_number)")
             session.run("CREATE INDEX IF NOT EXISTS FOR (p:Property) ON (p.name, p.path, p.line_number)")
 
-            session.run(
-                "CREATE CONSTRAINT repository_path IF NOT EXISTS FOR (r:Repository) REQUIRE r.path IS UNIQUE"
-            )
-            session.run("CREATE CONSTRAINT path IF NOT EXISTS FOR (f:File) REQUIRE f.path IS UNIQUE")
-            session.run(
-                "CREATE CONSTRAINT directory_path IF NOT EXISTS FOR (d:Directory) REQUIRE d.path IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT function_unique IF NOT EXISTS FOR (f:Function) REQUIRE (f.name, f.path, f.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT class_unique IF NOT EXISTS FOR (c:Class) REQUIRE (c.name, c.path, c.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT trait_unique IF NOT EXISTS FOR (t:Trait) REQUIRE (t.name, t.path, t.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT interface_unique IF NOT EXISTS FOR (i:Interface) REQUIRE (i.name, i.path, i.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT macro_unique IF NOT EXISTS FOR (m:Macro) REQUIRE (m.name, m.path, m.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT variable_unique IF NOT EXISTS FOR (v:Variable) REQUIRE (v.name, v.path, v.line_number) IS UNIQUE"
-            )
-            session.run("CREATE CONSTRAINT module_name IF NOT EXISTS FOR (m:Module) REQUIRE m.name IS UNIQUE")
-            session.run(
-                "CREATE CONSTRAINT struct_cpp IF NOT EXISTS FOR (cstruct: Struct) REQUIRE (cstruct.name, cstruct.path, cstruct.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT enum_cpp IF NOT EXISTS FOR (cenum: Enum) REQUIRE (cenum.name, cenum.path, cenum.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT union_cpp IF NOT EXISTS FOR (cunion: Union) REQUIRE (cunion.name, cunion.path, cunion.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT annotation_unique IF NOT EXISTS FOR (a:Annotation) REQUIRE (a.name, a.path, a.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT record_unique IF NOT EXISTS FOR (r:Record) REQUIRE (r.name, r.path, r.line_number) IS UNIQUE"
-            )
-            session.run(
-                "CREATE CONSTRAINT property_unique IF NOT EXISTS FOR (p:Property) REQUIRE (p.name, p.path, p.line_number) IS UNIQUE"
-            )
+            if not is_falkordb:
+                session.run(
+                    "CREATE CONSTRAINT repository_path IF NOT EXISTS FOR (r:Repository) REQUIRE r.path IS UNIQUE"
+                )
+                session.run("CREATE CONSTRAINT path IF NOT EXISTS FOR (f:File) REQUIRE f.path IS UNIQUE")
+                session.run(
+                    "CREATE CONSTRAINT directory_path IF NOT EXISTS FOR (d:Directory) REQUIRE d.path IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT function_unique IF NOT EXISTS FOR (f:Function) REQUIRE (f.name, f.path, f.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT class_unique IF NOT EXISTS FOR (c:Class) REQUIRE (c.name, c.path, c.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT trait_unique IF NOT EXISTS FOR (t:Trait) REQUIRE (t.name, t.path, t.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT interface_unique IF NOT EXISTS FOR (i:Interface) REQUIRE (i.name, i.path, i.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT macro_unique IF NOT EXISTS FOR (m:Macro) REQUIRE (m.name, m.path, m.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT variable_unique IF NOT EXISTS FOR (v:Variable) REQUIRE (v.name, v.path, v.line_number) IS UNIQUE"
+                )
+                session.run("CREATE CONSTRAINT module_name IF NOT EXISTS FOR (m:Module) REQUIRE m.name IS UNIQUE")
+                session.run(
+                    "CREATE CONSTRAINT struct_cpp IF NOT EXISTS FOR (cstruct: Struct) REQUIRE (cstruct.name, cstruct.path, cstruct.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT enum_cpp IF NOT EXISTS FOR (cenum: Enum) REQUIRE (cenum.name, cenum.path, cenum.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT union_cpp IF NOT EXISTS FOR (cunion: Union) REQUIRE (cunion.name, cunion.path, cunion.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT annotation_unique IF NOT EXISTS FOR (a:Annotation) REQUIRE (a.name, a.path, a.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT record_unique IF NOT EXISTS FOR (r:Record) REQUIRE (r.name, r.path, r.line_number) IS UNIQUE"
+                )
+                session.run(
+                    "CREATE CONSTRAINT property_unique IF NOT EXISTS FOR (p:Property) REQUIRE (p.name, p.path, p.line_number) IS UNIQUE"
+                )
 
             session.run("CREATE INDEX function_lang IF NOT EXISTS FOR (f:Function) ON (f.lang)")
             session.run("CREATE INDEX class_lang IF NOT EXISTS FOR (c:Class) ON (c.lang)")
@@ -80,8 +88,7 @@ def create_graph_schema(driver: Any, db_manager: Any) -> None:
                 "CREATE INDEX parameter_unique IF NOT EXISTS FOR (p:Parameter) ON (p.name, p.path, p.function_line_number)"
             )
 
-            backend_type = getattr(db_manager, "get_backend_type", lambda: "neo4j")()
-            if backend_type == "falkordb":
+            if is_falkordb and backend_type == "falkordb":
                 for label in ["Function", "Class"]:
                     try:
                         session.run(

--- a/tests/unit/tools/test_falkordb_schema_and_watcher_fixes.py
+++ b/tests/unit/tools/test_falkordb_schema_and_watcher_fixes.py
@@ -1,0 +1,243 @@
+"""
+Regression tests for two FalkorDB + watcher bugs fixed together:
+
+Bug 1 — schema.py: CREATE CONSTRAINT sent to FalkorDB backends
+    FalkorDB has a null-pointer crash (SEGV) in EnforceUniqueEntity when
+    composite UNIQUE constraints are created alongside batched UNWIND…MERGE.
+    Fix: skip all CREATE CONSTRAINT statements when backend_type starts with
+    "falkordb" (covers both embedded "falkordb" and remote "falkordb-remote").
+
+Bug 2 — graph_builder.py update_file_in_graph: generic files silently dropped
+    parse_file() returns {"error": "Generic file type …", "unsupported": False}
+    for .md, .yml, .json, etc.  The watcher's update_file_in_graph() checked
+    only `"error" not in file_data`, so generic files were logged as errors and
+    returned None — the add_minimal_file_node() path was never reached.
+    Fix: mirror pipeline.py logic — call add_minimal_file_node when
+    "error" in file_data and not file_data.get("unsupported").
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _RecordingSession:
+    """Records every query string passed to .run()."""
+
+    def __init__(self):
+        self.queries: list[str] = []
+
+    def run(self, query: str, **_kwargs):
+        self.queries.append(query)
+        return MagicMock(result_set=[])
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeDriver:
+    def __init__(self, session: _RecordingSession):
+        self._session = session
+
+    def session(self):
+        return self._session
+
+
+def _make_db_manager(backend_type: str):
+    m = MagicMock()
+    m.get_backend_type.return_value = backend_type
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: schema.py — CREATE CONSTRAINT must not be sent to FalkorDB backends
+# ---------------------------------------------------------------------------
+
+class TestCreateGraphSchemaFalkorDB:
+
+    def _run_schema(self, backend_type: str):
+        from codegraphcontext.tools.indexing.schema import create_graph_schema
+
+        session = _RecordingSession()
+        driver = _FakeDriver(session)
+        db_manager = _make_db_manager(backend_type)
+        create_graph_schema(driver, db_manager)
+        return session.queries
+
+    def test_embedded_falkordb_sends_no_create_constraint(self):
+        """Backend 'falkordb' (embedded Lite) must not receive CREATE CONSTRAINT."""
+        queries = self._run_schema("falkordb")
+        constraint_queries = [q for q in queries if "CREATE CONSTRAINT" in q]
+        assert constraint_queries == [], (
+            f"Expected no CREATE CONSTRAINT for 'falkordb', got: {constraint_queries}"
+        )
+
+    def test_remote_falkordb_sends_no_create_constraint(self):
+        """Backend 'falkordb-remote' must not receive CREATE CONSTRAINT.
+
+        This was the primary regression: the original guard used
+        `backend_type == 'falkordb'` (strict equality), so 'falkordb-remote'
+        was not matched and CONSTRAINT statements were sent — crashing the server.
+        """
+        queries = self._run_schema("falkordb-remote")
+        constraint_queries = [q for q in queries if "CREATE CONSTRAINT" in q]
+        assert constraint_queries == [], (
+            f"Expected no CREATE CONSTRAINT for 'falkordb-remote', got: {constraint_queries}"
+        )
+
+    def test_neo4j_sends_create_constraint(self):
+        """Neo4j backend must still receive CREATE CONSTRAINT statements."""
+        queries = self._run_schema("neo4j")
+        constraint_queries = [q for q in queries if "CREATE CONSTRAINT" in q]
+        assert len(constraint_queries) > 0, "Expected CREATE CONSTRAINT queries for neo4j"
+
+    def test_embedded_falkordb_still_sends_create_index(self):
+        """Indices are always sent — they are what makes MERGE deduplication work."""
+        queries = self._run_schema("falkordb")
+        index_queries = [q for q in queries if "CREATE INDEX" in q]
+        assert len(index_queries) > 0, "Expected CREATE INDEX queries for 'falkordb'"
+
+    def test_remote_falkordb_still_sends_create_index(self):
+        """Indices are always sent for 'falkordb-remote' too."""
+        queries = self._run_schema("falkordb-remote")
+        index_queries = [q for q in queries if "CREATE INDEX" in q]
+        assert len(index_queries) > 0, "Expected CREATE INDEX queries for 'falkordb-remote'"
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: update_file_in_graph — generic files must reach add_minimal_file_node
+# ---------------------------------------------------------------------------
+
+class TestUpdateFileInGraphGenericFiles:
+    """
+    update_file_in_graph is the watcher's incremental update path.
+    Before the fix, generic files (.md, .yml, .json, .cfg, etc.) were silently
+    dropped: parse_file() returned {"error": ..., "unsupported": False} and the
+    method logged an error then returned None, never calling add_minimal_file_node.
+    """
+
+    def _make_graph_builder_stub(self):
+        """Build a minimal GraphBuilder stub with the real update_file_in_graph method."""
+        from codegraphcontext.tools.graph_builder import GraphBuilder
+        from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+        session = _RecordingSession()
+        driver = _FakeDriver(session)
+
+        gb = GraphBuilder.__new__(GraphBuilder)
+        gb.driver = driver
+        gb._writer = GraphWriter(driver)
+        gb.parsers = {}
+        gb.generic_extensions = {".md", ".yml", ".yaml", ".json", ".toml", ".cfg", ".txt"}
+        gb.generic_filenames = {"Makefile", "Dockerfile", ".gitignore"}
+        return gb
+
+    def test_generic_file_calls_add_minimal_file_node(self, tmp_path):
+        """A .md file must trigger add_minimal_file_node, not be silently dropped."""
+        gb = self._make_graph_builder_stub()
+        readme = tmp_path / "README.md"
+        readme.write_text("# Hello")
+
+        generic_result = {"path": str(readme), "error": "Generic file type .md", "unsupported": False}
+
+        with (
+            patch.object(gb, "delete_file_from_graph"),
+            patch.object(gb, "parse_file", return_value=generic_result),
+            patch.object(gb, "add_file_to_graph") as mock_add_full,
+            patch.object(gb, "add_minimal_file_node") as mock_add_minimal,
+        ):
+            result = gb.update_file_in_graph(readme, tmp_path, imports_map={})
+
+        mock_add_minimal.assert_called_once_with(readme, tmp_path)
+        mock_add_full.assert_not_called()
+        assert result == generic_result
+
+    def test_unsupported_file_is_still_skipped(self, tmp_path):
+        """A truly unsupported extension (unsupported=True) must NOT call add_minimal_file_node."""
+        gb = self._make_graph_builder_stub()
+        weird = tmp_path / "binary.xyz"
+        weird.write_bytes(b"\x00\x01")
+
+        unsupported_result = {"path": str(weird), "error": "No parser for .xyz", "unsupported": True}
+
+        with (
+            patch.object(gb, "delete_file_from_graph"),
+            patch.object(gb, "parse_file", return_value=unsupported_result),
+            patch.object(gb, "add_file_to_graph") as mock_add_full,
+            patch.object(gb, "add_minimal_file_node") as mock_add_minimal,
+        ):
+            result = gb.update_file_in_graph(weird, tmp_path, imports_map={})
+
+        mock_add_minimal.assert_not_called()
+        mock_add_full.assert_not_called()
+        assert result is None
+
+    def test_code_file_calls_add_file_to_graph(self, tmp_path):
+        """A parseable code file must still go through add_file_to_graph (not minimal)."""
+        gb = self._make_graph_builder_stub()
+        source = tmp_path / "main.py"
+        source.write_text("def hello(): pass")
+
+        code_result = {"path": str(source), "functions": [{"name": "hello"}]}
+
+        with (
+            patch.object(gb, "delete_file_from_graph"),
+            patch.object(gb, "parse_file", return_value=code_result),
+            patch.object(gb, "add_file_to_graph") as mock_add_full,
+            patch.object(gb, "add_minimal_file_node") as mock_add_minimal,
+        ):
+            result = gb.update_file_in_graph(source, tmp_path, imports_map={})
+
+        mock_add_full.assert_called_once()
+        mock_add_minimal.assert_not_called()
+        assert result == code_result
+
+    def test_deleted_file_returns_deleted_sentinel(self, tmp_path):
+        """A file that no longer exists on disk must return the deleted sentinel."""
+        gb = self._make_graph_builder_stub()
+        gone = tmp_path / "gone.py"
+        # Deliberately NOT created — it doesn't exist
+
+        with (
+            patch.object(gb, "delete_file_from_graph"),
+            patch.object(gb, "add_file_to_graph") as mock_add_full,
+            patch.object(gb, "add_minimal_file_node") as mock_add_minimal,
+        ):
+            result = gb.update_file_in_graph(gone, tmp_path, imports_map={})
+
+        mock_add_full.assert_not_called()
+        mock_add_minimal.assert_not_called()
+        assert result == {"deleted": True, "path": str(gone.resolve())}
+
+    @staticmethod
+    def _generic_extensions_sample():
+        return [".md", ".yml", ".yaml", ".json", ".cfg", ".txt", ".toml"]
+
+    def test_all_generic_extensions_reach_minimal_node(self, tmp_path):
+        """Parametric check: every generic extension must reach add_minimal_file_node."""
+        gb = self._make_graph_builder_stub()
+
+        for ext in self._generic_extensions_sample():
+            f = tmp_path / f"file{ext}"
+            f.write_text("content")
+            generic_result = {
+                "path": str(f),
+                "error": f"Generic file type {ext}",
+                "unsupported": False,
+            }
+
+            with (
+                patch.object(gb, "delete_file_from_graph"),
+                patch.object(gb, "parse_file", return_value=generic_result),
+                patch.object(gb, "add_file_to_graph"),
+                patch.object(gb, "add_minimal_file_node") as mock_minimal,
+            ):
+                gb.update_file_in_graph(f, tmp_path, imports_map={})
+
+            assert mock_minimal.called, f"add_minimal_file_node not called for {ext}"


### PR DESCRIPTION
Fixes #931

## Changes

### `src/codegraphcontext/tools/indexing/schema.py`

- Detect the active backend **before** opening the session: `backend_type = getattr(db_manager, 'get_backend_type', lambda: 'neo4j')()`
- Compute `is_falkordb = backend_type.startswith('falkordb')` — covers both `'falkordb'` (embedded Lite) and `'falkordb-remote'` (TCP server)
- Wrap all `CREATE CONSTRAINT` statements in `if not is_falkordb:` — FalkorDB has a confirmed null-pointer crash (SEGV) in `EnforceUniqueEntity` when composite UNIQUE constraints are used with batched `UNWIND…MERGE`. Indices alone are sufficient for correct `MERGE` deduplication.
- Fix the fulltext index block to use `is_falkordb and backend_type == 'falkordb'` (embedded-only feature)

### `src/codegraphcontext/tools/graph_builder.py`

- In `update_file_in_graph()`, add the missing branch for generic files (`.md`, `.yml`, `.json`, etc.):
  ```python
  if not file_data.get('unsupported'):
      self.add_minimal_file_node(path, repo_path)
      return file_data
  ```
  This mirrors the logic already present in `pipeline.py` and prevents the watcher from silently removing `File` nodes for generic file types on every change.

### `tests/unit/tools/test_falkordb_schema_and_watcher_fixes.py` (new, 10 tests)

| Test | Covers |
|---|---|
| `test_embedded_falkordb_sends_no_create_constraint` | Bug 1 — embedded backend |
| `test_remote_falkordb_sends_no_create_constraint` | Bug 1 — remote backend (the regression) |
| `test_neo4j_sends_create_constraint` | Neo4j still receives constraints |
| `test_embedded_falkordb_still_sends_create_index` | Indices always sent |
| `test_remote_falkordb_still_sends_create_index` | Indices always sent for remote |
| `test_generic_file_calls_add_minimal_file_node` | Bug 2 — generic file gets File node |
| `test_unsupported_file_is_still_skipped` | Truly unsupported files still skipped |
| `test_code_file_calls_add_file_to_graph` | Code files still fully indexed |
| `test_deleted_file_returns_deleted_sentinel` | Deleted file path unchanged |
| `test_all_generic_extensions_reach_minimal_node` | All generic extensions covered |

## Test results

```
10 passed in 1.03s
```