### PR TITLE
fix: show full help (including report) when cgc --help or cgc -h is used

### DIFF
--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -2574,6 +2574,10 @@ def main(
     if version_:
         console.print(f"CodeGraphContext [bold cyan]{get_version()}[/bold cyan]")
         raise typer.Exit()
+    
+    if help_:
+        typer.echo(ctx.get_help())
+        raise typer.Exit()
 
     if ctx.invoked_subcommand is None:
         console.print("[bold green]👋 Welcome to CodeGraphContext (cgc)![/bold green]\n")


### PR DESCRIPTION
Closes #944

## Problem
`cgc --help` and `cgc -h` were showing the welcome screen instead of the full command list. This meant the `report` command (and all others) were invisible to users who naturally reach for --help first. The `help_` parameter was declared in the main callback with `is_eager=True` but never actually handled — so the flag was silently ignored.

## Fix
Added the missing `if help_:` handler in the main callback to properly display the full Typer help output and exit.

## Testing
- `cgc --help` now shows full command list including `report`
- `cgc -h` same
- `cgc help` still works as before