### PR TITLE
docs: align database config key and default

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ A powerful **MCP server** and **CLI toolkit** that indexes local code into a gra
 -   **Interactive Setup:** A user-friendly command-line wizard for easy setup.
 -   **Dual Mode:** Works as a standalone **CLI toolkit** for developers and as an **MCP server** for AI agents.
 -   **Multi-Language Support:** Full support for 20 programming languages.
--   **Flexible Database Backend:** KuzuDB (Default), LadybugDB, FalkorDB Lite (Typical Unix default), FalkorDB Remote, Nornic DB, or Neo4j (all platforms via Docker/native).
+-   **Flexible Database Backend:** FalkorDB Lite (Default), KuzuDB, LadybugDB, FalkorDB Remote, Nornic DB, or Neo4j (all platforms via Docker/native).
 
 
 ---
@@ -234,8 +234,8 @@ _If you’re using CodeGraphContext in your project, feel free to open a PR and 
 
 3.  **Database Setup (Automatic):**
     CodeGraphContext uses an embedded graph database by default.
-    - **KuzuDB:** Default for all platforms.
-    - **FalkorDB Lite:** Preferred on Unix/macOS if available.
+    - **FalkorDB Lite:** Default backend.
+    - **KuzuDB:** Cross-platform embedded backend.
     - **Neo4j:** Run `codegraphcontext neo4j setup` to use an external server.
 
 ---

--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -50,9 +50,9 @@ The Persistence Layer abstracts database operations so that the engine can inter
 
 - **Database Abstraction API**: A client layer exposing methods to write batch transactions (`write_nodes`, `write_edges`) and query graph relationships via Cypher or native bindings.
 - **Embedded Engines**:
-  - **KuzuDB (Default)**: In-process C++ graph engine offering zero-dependency persistence on all platforms.
+  - **FalkorDB Lite (Default)**: Embedded in-memory graph engine (Unix only).
+  - **KuzuDB**: In-process C++ graph engine offering zero-dependency persistence on all platforms.
   - **LadybugDB**: SQL-based embedded graph engine designed for concurrent read/write transactions.
-  - **FalkorDB Lite**: Embedded in-memory graph engine (Unix only).
 - **Networked Server Engines**:
   - **FalkorDB Remote**: Remote client linking to FalkorDB instances.
   - **Neo4j**: Enterprise-scale storage supporting distributed clustering and the Neo4j web browser console.

--- a/docs/docs/concepts/backends.md
+++ b/docs/docs/concepts/backends.md
@@ -6,18 +6,18 @@ CodeGraphContext (CGC) implements a pluggable database architecture. A common in
 
 ## Backend Comparison Matrix
 
-| Feature / Metric | KuzuDB (Default) | LadybugDB | FalkorDB (Lite) | FalkorDB (Remote) | Neo4j |
+| Feature / Metric | FalkorDB (Lite, Default) | KuzuDB | LadybugDB | FalkorDB (Remote) | Neo4j |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Type** | Embedded C++ | Embedded SQL | Embedded In-Memory | Remote Client | Remote Client |
-| **Operating System** | Cross-Platform | Cross-Platform | Linux / macOS | Cross-Platform | Cross-Platform |
+| **Type** | Embedded In-Memory | Embedded C++ | Embedded SQL | Remote Client | Remote Client |
+| **Operating System** | Linux / macOS | Cross-Platform | Cross-Platform | Cross-Platform | Cross-Platform |
 | **Setup Overhead** | None | None | None | Low (Docker) | Medium (Docker/Aura) |
-| **Read Latency** | Very Low | Low | Extremely Low | Low | Medium |
-| **Max Capacity** | Large | Medium | RAM-Bounded | Unlimited | Unlimited |
+| **Read Latency** | Extremely Low | Very Low | Low | Low | Medium |
+| **Max Capacity** | RAM-Bounded | Large | Medium | Unlimited | Unlimited |
 | **Visualization** | CLI / Custom Web UI | CLI / Custom Web UI | CLI / Custom Web UI | Neo4j Client (via Cypher) | Neo4j Browser Console |
 
 ---
 
-## 1. KuzuDB (Recommended Default)
+## 1. KuzuDB
 
 KuzuDB is an in-process property graph database management system. It requires zero configuration and stores graph data inside a directory on your filesystem.
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -31,9 +31,9 @@ pip install codegraphcontext
 
 ## 2. Database Driver Setup
 
-CGC requires Python driver bindings for your selected database backend. KuzuDB is configured by default.
+CGC requires Python driver bindings for your selected database backend. FalkorDB Lite is configured by default.
 
-### Installing KuzuDB Drivers (Recommended Default)
+### Installing KuzuDB Drivers
 KuzuDB is embedded and runs directly inside the Python process.
 ```bash
 pip install kuzu
@@ -63,9 +63,9 @@ pip install neo4j
 Set your preferred default database backend in the global configuration:
 
 ```bash
-cgc config db kuzudb       # Configure KuzuDB (Default)
+cgc config db falkordb     # Configure FalkorDB Lite / Remote (Default)
+cgc config db kuzudb       # Configure KuzuDB
 cgc config db ladybugdb    # Configure LadybugDB
-cgc config db falkordb     # Configure FalkorDB Lite / Remote
 cgc config db neo4j        # Configure Neo4j
 ```
 

--- a/docs/docs/getting-started/prerequisites.md
+++ b/docs/docs/getting-started/prerequisites.md
@@ -30,9 +30,9 @@ CGC supports multiple database engines. You only need to set up the engine that 
 
 | Database Backend | Setup Type | Target Platform | Use Case |
 | :--- | :--- | :--- | :--- |
-| **KuzuDB (Default)** | In-process (Embedded) | Cross-Platform (Linux/macOS/Windows) | Recommended for local development and zero-ops setups. Works natively out-of-the-box on Python 3.10+. |
+| **FalkorDB Lite (Default)** | In-process (Embedded) | Unix-Only (Linux/macOS) | Embedded, high-performance in-memory graph. Requires Python 3.12+. |
+| **KuzuDB** | In-process (Embedded) | Cross-Platform (Linux/macOS/Windows) | Recommended for local development and zero-ops setups. Works natively out-of-the-box on Python 3.10+. |
 | **LadybugDB** | In-process (Embedded) | Cross-Platform | Embedded SQL-based graph engine. Operates similarly to KuzuDB. |
-| **FalkorDB Lite** | In-process (Embedded) | Unix-Only (Linux/macOS) | Embedded, high-performance in-memory graph. Requires Python 3.12+. |
 | **FalkorDB Remote** | Networked Server | Cross-Platform Client | Standard client connecting to a remote FalkorDB instance. |
 | **Neo4j** | Networked Server | Cross-Platform Client | Enterprise setups needing complex clustering, access controls, or Neo4j Browser visualization. |
 

--- a/docs/docs/reference/config.md
+++ b/docs/docs/reference/config.md
@@ -20,17 +20,19 @@ Persists key-value settings to the global environment configuration file:
 
 ```bash
 # Set default database engine
-cgc config set DEFAULT_DATABASE kuzudb
+cgc config set DEFAULT_DATABASE falkordb
 
 # Change file size threshold (in MB)
 cgc config set MAX_FILE_SIZE_MB 25
 ```
 
+`DEFAULT_DATABASE` is the supported configuration key for selecting the database backend. `DEFAULT_BACKEND` is not a valid `cgc config` key.
+
 ### 3. Database Selection Shortcut
 Quickly updates the `DEFAULT_DATABASE` key:
 
 ```bash
-cgc config db kuzudb
+cgc config db falkordb
 ```
 
 Valid database backend identifiers: `kuzudb`, `ladybugdb`, `falkordb` (Lite/embedded), `falkordb-remote`, and `neo4j`.
@@ -50,7 +52,7 @@ cgc config reset
 
 | Config Key | Default | Description |
 | :--- | :--- | :--- |
-| **`DEFAULT_DATABASE`** | `kuzudb` | Active database engine. Options: `kuzudb`, `ladybugdb`, `falkordb`, `falkordb-remote`, `neo4j`. |
+| **`DEFAULT_DATABASE`** | `falkordb` | Active database engine. Options: `kuzudb`, `ladybugdb`, `falkordb`, `falkordb-remote`, `neo4j`. |
 | **`ENABLE_AUTO_WATCH`** | `false` | When `true`, indexing a project automatically initializes a directory watcher. |
 | **`PARALLEL_WORKERS`** | `4` | Max thread pool size for parsing code files concurrently. |
 | **`CACHE_ENABLED`** | `true` | Caches file hashes to support fast incremental scans. |

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -8,7 +8,7 @@ CodeGraphContext is developed to continuously expand static code analysis depth,
 
 The following capabilities are supported in the active release:
 - **Polyglot Parser Suite**: Syntactic support for 19 target languages.
-- **Pluggable Storage Drivers**: Operations across KuzuDB (Default), LadybugDB, FalkorDB, and Neo4j.
+- **Pluggable Storage Drivers**: Operations across FalkorDB (Default), KuzuDB, LadybugDB, and Neo4j.
 - **Model Context Protocol (MCP)**: Implements 25 JSON-RPC tools for LLM agent integration.
 - **Directory Watchers**: watchdog-based monitors for incremental synchronization.
 - **Graph Serialization**: Exporting/importing database contexts as portable `.cgc` bundles.

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -543,7 +543,7 @@ def config_reset():
         console.print("[yellow]Reset cancelled[/yellow]")
 
 @config_app.command("db")
-def config_db(backend: str = typer.Argument(..., help="Database backend: 'neo4j', 'falkordb', 'falkordb-remote', or 'kuzudb'")):
+def config_db(backend: str = typer.Argument(..., help="Database backend: 'neo4j', 'falkordb', 'falkordb-remote', 'kuzudb', or 'ladybugdb'")):
     """
     Quickly switch the default database backend.
     


### PR DESCRIPTION
 ## Summary
  - Document `DEFAULT_DATABASE` as the supported backend config key and explicitly note that `DEFAULT_BACKEND` is invalid.
  - Align docs with the current CLI default of `falkordb`.
  - Update `cgc config db` help text to include `ladybugdb`, which the command already accepts.

  Closes #623

  ## Validation
  - `rg DEFAULT_BACKEND README.md docs src/codegraphcontext/cli/main.py src/codegraphcontext/cli/config_manager.py`
  - `python -m compileall -q src/codegraphcontext/cli/main.py`
  - `mkdocs build --config-file docs/mkdocs.yml --strict`
  - `git diff --check`
