### PR TITLE
fix: eliminate ClientResponseError for listIndexedRepositories (graceful offline fallback + null-result guard)

### DIFF
--- a/website/api/v1/query.ts
+++ b/website/api/v1/query.ts
@@ -183,8 +183,10 @@ export default async function handler(req: any, res: any) {
         });
       });
 
-      // Give Supabase's network routing table 250ms to fully propagate before broadcasting
-      await new Promise<void>((resolve) => setTimeout(resolve, 250));
+      // Give Supabase's network routing table extra time after tab-wake reconnects.
+      // Global tools (list_indexed_repositories, etc.) need more headroom than repo-scoped ones.
+      const propagationDelay = isGlobalTool ? 500 : 250;
+      await new Promise<void>((resolve) => setTimeout(resolve, propagationDelay));
 
       // Prepare arguments (pass all params, ensuring repo is set)
       const toolArgs = {
@@ -210,15 +212,25 @@ export default async function handler(req: any, res: any) {
         });
       }
 
-      // Wait up to 4.5 seconds, but resolve IMMEDIATELY as soon as the client responds!
+      // Wait up to 6 seconds (tab wake-up + Supabase propagation can take up to 5s).
+      // Resolve IMMEDIATELY as soon as the client responds!
       const safetyTimeout = setTimeout(() => {
         if (resolveWaitPromise) resolveWaitPromise();
-      }, 4500);
+      }, 6000);
 
       await waitPromise;
       clearTimeout(safetyTimeout);
 
       if (!hasResponded) {
+        // For list_indexed_repositories, return a graceful empty result instead of a hard 412.
+        // ChatGPT converts any non-2xx into a ClientResponseError, so we MUST stay 200.
+        if (query_type === "list_indexed_repositories") {
+          return res.status(200).json({
+            indexed_repositories: [],
+            status: "offline",
+            message: "Browser tunnel is offline. Open https://cgc.codes/explore to activate the live index."
+          });
+        }
         return res.status(412).json({
           status: "offline",
           error: "Browser-as-a-Server dashboard is currently offline or closed.",
@@ -233,8 +245,18 @@ export default async function handler(req: any, res: any) {
         });
       }
 
+      // Guard against undefined result (e.g. browser responded but result was missing).
+      // res.json(undefined) produces `{}` which ChatGPT flags as ClientResponseError.
+      const toolResult = toolResponse?.result;
+      if (toolResult === undefined || toolResult === null) {
+        if (query_type === "list_indexed_repositories") {
+          return res.status(200).json({ indexed_repositories: [] });
+        }
+        return res.status(200).json({ status: "success", result: null });
+      }
+
       // Return the exact result content payload from Python MCPServer
-      return res.status(200).json(toolResponse?.result);
+      return res.status(200).json(toolResult);
     }
 
   } catch (error: any) {


### PR DESCRIPTION
## Problem

Three compounding bugs in `api/v1/query.ts` were causing ChatGPT to report a `ClientResponseError` every time it called the `listIndexedRepositories` action:

### Bug 1 — HTTP 412 triggers `ClientResponseError` in ChatGPT (root cause)
When the browser tunnel was offline or hadn't finished reconnecting after a tab-sleep wake-up, the handler returned **HTTP 412**. ChatGPT converts _any_ non-2xx response into a `ClientResponseError` regardless of the JSON body.

### Bug 2 — `res.json(undefined)` silently produces `{}`
If the browser responded but `toolResponse.result` was `undefined` (race window right after channel reconnection), Express serialized it to `{}`. ChatGPT sees an empty object and raises `ClientResponseError`.

### Bug 3 — 250ms propagation delay too short after tab-wake reconnects
After a browser tab wakes from sleep, `KuzuCoordinator` tears down its Supabase channels and re-subscribes. Supabase needs more than 250ms to propagate the updated routing table. Broadcasts fired during this window were silently dropped.

---

## Fix

| Change | Before | After |
|--------|--------|-------|
| `list_indexed_repositories` offline response | HTTP 412 | HTTP 200 `{ indexed_repositories: [], status: "offline" }` |
| Undefined `toolResponse.result` | `res.json(undefined)` → `{}` | Explicit guard → safe fallback |
| Global-tool propagation delay | 250 ms | 500 ms |
| Overall tunnel wait timeout | 4.5 s | 6 s |

## Verification

Tested live against `https://cgc.codes/api/v1/query/list_indexed_repositories` with no browser open:

```json
{
  "indexed_repositories": [],
  "status": "offline",
  "message": "Browser tunnel is offline. Open https://cgc.codes/explore to activate the live index."
}
```
HTTP 200 ✅ — ChatGPT no longer throws `ClientResponseError`.