### PR TITLE
fix: support file path argument in analyze complexity command (#946)

### DIFF
--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-05-19 12:40 UTC_
+_Generated: 2026-05-25 12:49 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -2268,10 +2268,10 @@ def analyze_inheritance_tree(
 
 @analyze_app.command("complexity")
 def analyze_complexity(
-    path: Optional[str] = typer.Argument(None, help="Specific function name to analyze"),
+    path: Optional[str] = typer.Argument(None, help="Function name or file path to analyze"),
     threshold: int = typer.Option(10, "--threshold", "-t", help="Complexity threshold for warnings"),
     limit: int = typer.Option(20, "--limit", "-l", help="Maximum results to show"),
-    file: Optional[str] = typer.Option(None, "--file", "-f", help="Specific file path (only used when function name is provided)"),
+    file: Optional[str] = typer.Option(None, "--file", "-f", help="Specific file path to scope analysis"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
 ):
     """
@@ -2282,16 +2282,55 @@ def analyze_complexity(
         cgc analyze complexity --threshold 15     # Functions over threshold
         cgc analyze complexity my_function        # Specific function
         cgc analyze complexity my_function -f file.py # Specific function in file
+        cgc analyze complexity src/main.py        # Most complex functions in file
+        cgc analyze complexity main.py            # Most complex functions in file
+        cgc analyze complexity --file src/main.py # Alternative file syntax
     """
     _load_credentials()
     services = _initialize_services(context)
     if not all(services[:3]):
         return
     db_manager, graph_builder, code_finder = services[:3]
-    
+
+    _FILE_EXTENSIONS = ('.py', '.js', '.ts', '.jsx', '.tsx', '.go', '.rs', '.rb',
+                        '.java', '.cpp', '.c', '.cs', '.swift', '.kt', '.scala',
+                        '.php', '.lua', '.zig', '.ex', '.exs', '.r', '.m', '.sh')
+
+    def _is_file_path(value: str) -> bool:
+        if '/' in value or '\\' in value:
+            return True
+        return any(value.endswith(ext) for ext in _FILE_EXTENSIONS)
+
+    def _render_complexity_table(results, title):
+        if not results:
+            console.print("[yellow]No complexity data available for this file[/yellow]")
+            return
+        table = Table(show_header=True, header_style="bold magenta", box=box.ROUNDED)
+        table.add_column("Function", style="cyan")
+        table.add_column("Complexity", style="yellow", justify="right")
+        table.add_column("Location", style="dim", overflow="fold")
+        for func in results:
+            complexity = func.get('complexity', 0)
+            color = "red" if complexity > threshold else "yellow" if complexity > threshold/2 else "green"
+            fpath = func.get('path', '')
+            line_str = str(func.get('line_number', ''))
+            location_str = f"{fpath}:{line_str}" if line_str else fpath
+            table.add_row(
+                func.get('function_name', ''),
+                f"[{color}]{complexity}[/{color}]",
+                location_str
+            )
+        console.print(f"\n[bold cyan]{title}[/bold cyan]")
+        console.print(table)
+        console.print(f"\n[dim]{len([f for f in results if f.get('complexity', 0) > threshold])} function(s) exceed threshold[/dim]")
+
     try:
-        if path:
-            # Specific function
+        if path and _is_file_path(path):
+            # File path provided as positional argument
+            results = code_finder.find_most_complex_functions_in_file(path, limit)
+            _render_complexity_table(results, f"Most Complex Functions in '{path}' (threshold: {threshold}):")
+        elif path:
+            # Specific function name
             result = code_finder.get_cyclomatic_complexity(path, file)
             if result:
                 console.print(f"\n[bold cyan]Complexity for '{path}':[/bold cyan]")
@@ -2300,35 +2339,14 @@ def analyze_complexity(
                 console.print(f"  Line: [dim]{result.get('line_number', '')}[/dim]")
             else:
                 console.print(f"[yellow]Function '{path}' not found or has no complexity data[/yellow]")
+        elif file:
+            # --file option without positional arg
+            results = code_finder.find_most_complex_functions_in_file(file, limit)
+            _render_complexity_table(results, f"Most Complex Functions in '{file}' (threshold: {threshold}):")
         else:
-            # Most complex functions
+            # Global - most complex functions
             results = code_finder.find_most_complex_functions(limit)
-            
-            if not results:
-                console.print("[yellow]No complexity data available[/yellow]")
-                return
-            
-            table = Table(show_header=True, header_style="bold magenta", box=box.ROUNDED)
-            table.add_column("Function", style="cyan")
-            table.add_column("Complexity", style="yellow", justify="right")
-            table.add_column("Location", style="dim", overflow="fold")
-            
-            for func in results:
-                complexity = func.get('complexity', 0)
-                color = "red" if complexity > threshold else "yellow" if complexity > threshold/2 else "green"
-                path = func.get('path', '')
-                line_str = str(func.get('line_number', ''))
-                location_str = f"{path}:{line_str}" if line_str else path
-
-                table.add_row(
-                    func.get('function_name', ''),
-                    f"[{color}]{complexity}[/{color}]",
-                    location_str
-                )
-            
-            console.print(f"\n[bold cyan]Most Complex Functions (threshold: {threshold}):[/bold cyan]")
-            console.print(table)
-            console.print(f"\n[dim]{len([f for f in results if f.get('complexity', 0) > threshold])} function(s) exceed threshold[/dim]")
+            _render_complexity_table(results, f"Most Complex Functions (threshold: {threshold}):")
     finally:
         db_manager.close_driver()
 

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -1357,6 +1357,23 @@ class CodeFinder:
             result = session.run(query, limit=limit, repo_path=repo_path)
             return result.data()
 
+    def find_most_complex_functions_in_file(self, file_path: str, limit: int = 20, repo_path: Optional[str] = None) -> List[Dict]:
+        """Find the most complex functions in a specific file."""
+        with self.driver.session() as session:
+            repo_filter = "AND f.path STARTS WITH $repo_path" if repo_path else ""
+            query = f"""
+                MATCH (f:Function)
+                WHERE f.cyclomatic_complexity IS NOT NULL
+                  AND (f.path ENDS WITH $file_path OR f.path = $file_path)
+                  {repo_filter}
+                RETURN f.name as function_name, f.path as path,
+                       f.cyclomatic_complexity as complexity, f.line_number as line_number
+                ORDER BY f.cyclomatic_complexity DESC
+                LIMIT $limit
+            """
+            result = session.run(query, file_path=file_path, limit=limit, repo_path=repo_path)
+            return result.data()
+
     def list_indexed_repositories(self) -> List[Dict]:
         """List all indexed repositories."""
         with self.driver.session() as session:

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -185,6 +185,9 @@ class _FakeCodeFinder:
     def find_most_complex_functions(self, *_args, **_kwargs):
         return [{"function_name": "complex", "complexity": 12, "path": "repo/main.py", "line_number": 20}]
 
+    def find_most_complex_functions_in_file(self, *_args, **_kwargs):
+        return [{"function_name": "complex", "complexity": 12, "path": "repo/main.py", "line_number": 20}]
+
     def find_dead_code(self, *_args, **_kwargs):
         return {
             "potentially_unused_functions": [{"function_name": "unused", "path": "repo/main.py", "line_number": 30}],

--- a/tests/unit/cli/test_analyze_complexity_file_path.py
+++ b/tests/unit/cli/test_analyze_complexity_file_path.py
@@ -1,0 +1,188 @@
+"""Tests for issue #946: cgc analyze complexity <file_path> support."""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+from typer.testing import CliRunner
+
+import codegraphcontext.cli.main as cli_main
+from codegraphcontext.cli.main import app
+
+runner = CliRunner()
+
+class _FakeDBManager:
+    def get_driver(self):
+        return MagicMock()
+
+    def close_driver(self):
+        pass
+
+
+class _FakeGraphBuilder:
+    pass
+
+
+class _FakeCodeFinder:
+    """Tracks which methods are called so we can assert routing."""
+
+    def __init__(self):
+        self.calls = []
+
+    def get_cyclomatic_complexity(self, *args, **kwargs):
+        self.calls.append(("get_cyclomatic_complexity", args, kwargs))
+        return {"complexity": 5, "path": "repo/utils.py", "line_number": 10}
+
+    def find_most_complex_functions(self, *args, **kwargs):
+        self.calls.append(("find_most_complex_functions", args, kwargs))
+        return [{"function_name": "big_func", "complexity": 15, "path": "repo/main.py", "line_number": 1}]
+
+    def find_most_complex_functions_in_file(self, *args, **kwargs):
+        self.calls.append(("find_most_complex_functions_in_file", args, kwargs))
+        return [{"function_name": "handler", "complexity": 8, "path": "repo/main.py", "line_number": 42}]
+
+
+@pytest.fixture
+def cli_env(monkeypatch, tmp_path):
+    """Set up minimal CLI stubs for complexity command testing."""
+    monkeypatch.setattr(cli_main.config_manager, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cli_main.config_manager, "CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(cli_main, "_load_credentials", lambda *a, **kw: None)
+
+    code_finder = _FakeCodeFinder()
+    monkeypatch.setattr(
+        cli_main,
+        "_initialize_services",
+        lambda *a, **kw: (_FakeDBManager(), _FakeGraphBuilder(), code_finder, MagicMock()),
+    )
+    return code_finder
+
+class TestIsFilePathDetection:
+    """Verify that the file-path heuristic correctly distinguishes
+    file paths from function names."""
+
+    def _is_file_path(self, value: str) -> bool:
+        """Mirror the logic in analyze_complexity."""
+        _FILE_EXTENSIONS = (
+            '.py', '.js', '.ts', '.jsx', '.tsx', '.go', '.rs', '.rb',
+            '.java', '.cpp', '.c', '.cs', '.swift', '.kt', '.scala',
+            '.php', '.lua', '.zig', '.ex', '.exs', '.r', '.m', '.sh',
+        )
+        if '/' in value or '\\' in value:
+            return True
+        return any(value.endswith(ext) for ext in _FILE_EXTENSIONS)
+
+    # Paths with separators
+    def test_path_with_slash(self):
+        assert self._is_file_path("src/main.py") is True
+
+    def test_path_with_backslash(self):
+        assert self._is_file_path("src\\main.py") is True
+
+    def test_deep_path(self):
+        assert self._is_file_path("src/codegraphcontext/tools/code_finder.py") is True
+
+    # Bare filenames with extensions
+    def test_bare_python_file(self):
+        assert self._is_file_path("main.py") is True
+
+    def test_bare_js_file(self):
+        assert self._is_file_path("index.js") is True
+
+    def test_bare_go_file(self):
+        assert self._is_file_path("server.go") is True
+
+    def test_bare_ts_file(self):
+        assert self._is_file_path("app.ts") is True
+
+    def test_bare_rust_file(self):
+        assert self._is_file_path("lib.rs") is True
+
+    #  Function names (should NOT be treated as file paths) 
+    def test_simple_function_name(self):
+        assert self._is_file_path("my_function") is False
+
+    def test_class_method_name(self):
+        assert self._is_file_path("process_data") is False
+
+    def test_snake_case_function(self):
+        assert self._is_file_path("calculate_total") is False
+
+    def test_camel_case_function(self):
+        assert self._is_file_path("processData") is False
+
+
+# CLI routing tests
+
+class TestComplexityCommandRouting:
+    """Verify that the CLI routes to the correct CodeFinder method
+    based on the positional argument."""
+
+    def test_no_args_calls_global(self, cli_env):
+        """cgc analyze complexity → find_most_complex_functions"""
+        result = runner.invoke(app, ["analyze", "complexity"])
+        assert result.exit_code == 0, result.output
+        assert cli_env.calls[0][0] == "find_most_complex_functions"
+
+    def test_function_name_calls_get_complexity(self, cli_env):
+        """cgc analyze complexity my_function → get_cyclomatic_complexity"""
+        result = runner.invoke(app, ["analyze", "complexity", "my_function"])
+        assert result.exit_code == 0, result.output
+        assert cli_env.calls[0][0] == "get_cyclomatic_complexity"
+
+    def test_file_path_with_slash_calls_file_method(self, cli_env):
+        """cgc analyze complexity src/main.py → find_most_complex_functions_in_file"""
+        result = runner.invoke(app, ["analyze", "complexity", "src/main.py"])
+        assert result.exit_code == 0, result.output
+        assert cli_env.calls[0][0] == "find_most_complex_functions_in_file"
+
+    def test_bare_filename_calls_file_method(self, cli_env):
+        """cgc analyze complexity main.py → find_most_complex_functions_in_file"""
+        result = runner.invoke(app, ["analyze", "complexity", "main.py"])
+        assert result.exit_code == 0, result.output
+        assert cli_env.calls[0][0] == "find_most_complex_functions_in_file"
+
+    def test_file_option_without_positional_calls_file_method(self, cli_env):
+        """cgc analyze complexity --file src/main.py → find_most_complex_functions_in_file"""
+        result = runner.invoke(app, ["analyze", "complexity", "--file", "src/main.py"])
+        assert result.exit_code == 0, result.output
+        assert cli_env.calls[0][0] == "find_most_complex_functions_in_file"
+
+    def test_function_name_with_file_option_calls_get_complexity(self, cli_env):
+        """cgc analyze complexity my_func -f main.py → get_cyclomatic_complexity"""
+        result = runner.invoke(app, ["analyze", "complexity", "my_func", "-f", "main.py"])
+        assert result.exit_code == 0, result.output
+        assert cli_env.calls[0][0] == "get_cyclomatic_complexity"
+
+
+# Output content tests
+
+class TestComplexityCommandOutput:
+    """Verify that the CLI output contains expected content."""
+
+    def test_file_path_shows_table_with_file_title(self, cli_env):
+        result = runner.invoke(app, ["analyze", "complexity", "src/main.py"])
+        assert result.exit_code == 0
+        assert "src/main.py" in result.output
+        assert "handler" in result.output
+
+    def test_global_shows_threshold_info(self, cli_env):
+        result = runner.invoke(app, ["analyze", "complexity"])
+        assert result.exit_code == 0
+        assert "threshold" in result.output.lower()
+
+    def test_function_name_shows_single_result(self, cli_env):
+        result = runner.invoke(app, ["analyze", "complexity", "my_func"])
+        assert result.exit_code == 0
+        assert "Complexity for" in result.output
+
+    def test_empty_file_results_shows_message(self, cli_env):
+        """When no functions found in file, show appropriate message."""
+        cli_env.find_most_complex_functions_in_file = lambda *a, **kw: (
+            cli_env.calls.append(("find_most_complex_functions_in_file", a, kw)) or []
+        )
+        result = runner.invoke(app, ["analyze", "complexity", "empty.py"])
+        assert result.exit_code == 0
+        assert "No complexity data" in result.output


### PR DESCRIPTION
Fixes #946

## Problem
`cgc analyze complexity <file_path>` treated the argument as a function name, causing "not found or has no complexity data" even for indexed files.

## Solution
- Added `find_most_complex_functions_in_file()` method to `CodeFinder` that queries functions scoped to a specific file using `ENDS WITH` matching
- Updated the CLI to detect file paths (via `/`, `\`, or known extensions like `.py`, `.js`, `.go`, etc.) and route to the new method
- Added support for `cgc analyze complexity --file <path>` as an alternative syntax without positional arg

## Files changed
- `src/codegraphcontext/tools/code_finder.py` - new query method
- `src/codegraphcontext/cli/main.py` - CLI routing logic
- `tests/integration/cli/test_cli_commands.py` - mock stub
- `tests/unit/cli/test_analyze_complexity_file_path.py` - **22 new tests (all passing)**