### PR TITLE
fix: add WebSocket keepalive and update UI/offline instructions to pr…

### DIFF
--- a/website/api/v1/query.ts
+++ b/website/api/v1/query.ts
@@ -15,7 +15,7 @@ function offlineResponse(query_type: string, cleanRepo: string) {
 
   const base = {
     status: "offline",
-    message: `Browser tunnel is offline. Open ${openUrl} in a browser tab to activate the live code graph, then retry.`,
+    message: `Browser tunnel is offline. Open ${openUrl} in a browser tab, keep that tab active (not in the background), wait a few seconds for the tunnel to connect, then retry in ChatGPT.`,
   };
 
   switch (query_type) {
@@ -157,8 +157,8 @@ export default async function handler(req: any, res: any) {
         });
       }
 
-      // 3s cap — total fn time ~4.8s when offline, well under Vercel's 10s Hobby limit
-      const safetyTimeout = setTimeout(() => { if (resolveWait) resolveWait(); }, 3000);
+      // 6s cap — background tabs can delay Supabase broadcast delivery; stay under Vercel 10s limit
+      const safetyTimeout = setTimeout(() => { if (resolveWait) resolveWait(); }, 6000);
       await waitPromise;
       clearTimeout(safetyTimeout);
 
@@ -220,8 +220,8 @@ export default async function handler(req: any, res: any) {
         });
       }
 
-      // 3s cap — total fn time ~4.8s when offline, well under Vercel's 10s Hobby limit
-      const safetyTimeout = setTimeout(() => { if (resolveWait) resolveWait(); }, 3000);
+      // 6s cap — background tabs can delay Supabase broadcast delivery; stay under Vercel 10s limit
+      const safetyTimeout = setTimeout(() => { if (resolveWait) resolveWait(); }, 6000);
       await waitPromise;
       clearTimeout(safetyTimeout);
 

--- a/website/src/components/CodeGraphViewer.tsx
+++ b/website/src/components/CodeGraphViewer.tsx
@@ -1484,9 +1484,9 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
               target="_blank"
               rel="noopener noreferrer"
               className={`flex items-center gap-2 text-[11px] uppercase tracking-widest font-bold px-4 py-2 border rounded-full transition-all backdrop-blur-md shadow-2xl cursor-pointer ${isDark ? 'bg-black/40 hover:bg-white/10 text-white border-white/10' : 'bg-white/80 hover:bg-white text-gray-800 border-black/10'}`}
-              title="Keep this tab open in background so ChatGPT can query this workspace!"
+              title="Open the CGC ChatGPT GPT. Keep this cgc.codes tab focused (not behind ChatGPT) so the signaling tunnel stays online."
             >
-              <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse shadow-[0_0_6px_#10b981]" />
+              <div className="w-2 h-2 rounded-full bg-amber-500/80 shadow-[0_0_6px_#f59e0b]" title="Tunnel status is not shown here — keep this tab active while using ChatGPT" />
               <MessageSquare className="w-3.5 h-3.5 text-purple-400" />
               ChatGPT
             </a>
@@ -1601,7 +1601,7 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
                   onClick={() => setShowMobileMenu(false)}
                   className={`flex items-center gap-2 text-[11px] uppercase tracking-widest font-bold px-4 py-2 border rounded-xl transition-all text-left w-full ${isDark ? 'hover:bg-white/5 border-white/5 text-white' : 'hover:bg-black/5 border-black/5 text-gray-800'}`}
                 >
-                  <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse shadow-[0_0_6px_#10b981]" />
+                  <div className="w-2 h-2 rounded-full bg-amber-500/80 shadow-[0_0_6px_#f59e0b]" />
                   <MessageSquare className="w-3.5 h-3.5 text-purple-400" />
                   ChatGPT Tunnel
                 </a>

--- a/website/src/lib/kuzu-coordinator.ts
+++ b/website/src/lib/kuzu-coordinator.ts
@@ -26,6 +26,7 @@ export class KuzuCoordinator {
   
   private isSubscribed = false;
   private isStarted = false; // Tracks if start() has been explicitly called by the parent component
+  private keepaliveInterval: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     supabaseUrl: string,
@@ -182,6 +183,21 @@ export class KuzuCoordinator {
           console.log(`[KuzuCoordinator] ✅ Subscribed to global channel: ${globalChannelName}`);
         }
       });
+
+    // Keep WebSocket warm when ChatGPT tab steals focus (Firefox/Chrome throttle background tabs)
+    if (this.keepaliveInterval) clearInterval(this.keepaliveInterval);
+    this.keepaliveInterval = setInterval(() => {
+      if (!this.isStarted) return;
+      try {
+        this.globalChannel?.send({
+          type: "broadcast",
+          event: "tunnel-keepalive",
+          payload: { t: Date.now() }
+        });
+      } catch {
+        /* ignore */
+      }
+    }, 15000);
   }
 
   public async stop(keepStarted = false) {
@@ -204,6 +220,10 @@ export class KuzuCoordinator {
         await this.supabase.removeChannel(this.globalChannel);
       } catch (err) {}
       this.globalChannel = null;
+    }
+    if (this.keepaliveInterval) {
+      clearInterval(this.keepaliveInterval);
+      this.keepaliveInterval = null;
     }
     this.isSubscribed = false;
   }


### PR DESCRIPTION
…event background tab throttling and clarify connection status

- Add a 'tunnel-keepalive' broadcast message every 15 seconds to prevent browser throttling of background tabs.
- Update offline instructions and tooltip to advise keeping the tab focused/active.
- Change the green pulse indicator to static amber, clarifying that live tunnel status isn't dynamically shown on the client.
- Increase the offline safety timeout to 6 seconds to accommodate slower broadcast delivery in background tabs.