### PR TITLE
Fix SCIP ignore-directory consistency with shared path ignore utility

### DIFF
--- a/src/codegraphcontext/tools/scip_indexer.py
+++ b/src/codegraphcontext/tools/scip_indexer.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..utils.debug_log import error_logger, info_logger, warning_logger
+from ..utils.path_ignore import file_path_has_ignore_dir_segment
 
 # ---------------------------------------------------------------------------
 # SCIP indexer orchestration
@@ -117,17 +118,6 @@ def detect_project_lang(path: Path, scip_languages: List[str]) -> Optional[str]:
 
     # Return the most frequent language
     return max(counts, key=counts.get)
-
-
-def file_path_has_ignore_dir_segment(path: Path, root: Path) -> bool:
-    """True if the path contains common ignored directory segments (node_modules, etc)."""
-    try:
-        rel = path.relative_to(root)
-        parts = rel.parts
-        ignore = {"node_modules", "vendor", ".git", "target", "build", "dist", "bin", "obj"}
-        return any(p in ignore for p in parts)
-    except ValueError:
-        return False
 
 
 class ScipIndexer:

--- a/tests/unit/tools/test_scip_indexer_c_family.py
+++ b/tests/unit/tools/test_scip_indexer_c_family.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from codegraphcontext.tools.scip_indexer import ScipIndexParser, ScipIndexer
+from codegraphcontext.tools.scip_indexer import ScipIndexParser, ScipIndexer, detect_project_lang
 
 
 def test_compdb_host_paths_to_container(tmp_path: Path) -> None:
@@ -91,6 +91,30 @@ def test_find_csharp_project_nested(sample_projects_path: Path) -> None:
     csproj = ScipIndexer._find_csharp_project(root)
     assert csproj is not None
     assert csproj.name == "Example.App.csproj"
+
+
+def test_detect_project_lang_skips_venv_files(tmp_path: Path) -> None:
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / "src").mkdir()
+    (project_root / "src" / "app.py").write_text("print('ok')\n")
+
+    venv_dir = project_root / ".venv"
+    venv_dir.mkdir()
+    for index in range(3):
+        (venv_dir / f"noise{index}.js").write_text("console.log('noise')\n")
+
+    lang = detect_project_lang(project_root, ["python", "javascript"])
+    assert lang == "python"
+
+
+def test_find_csharp_project_skips_ignored_directories(tmp_path: Path) -> None:
+    root = tmp_path / "sample_project_csharp"
+    ignored_dir = root / ".venv"
+    ignored_dir.mkdir(parents=True)
+    (ignored_dir / "Example.App.csproj").write_text("<Project />\n")
+
+    assert ScipIndexer._find_csharp_project(root) is None
 
 
 def test_build_command_csharp_includes_working_directory(sample_projects_path: Path) -> None:


### PR DESCRIPTION
Fixes #1002 

## Summary

This PR removes duplicated ignore-directory logic from the SCIP indexer and reuses the shared `file_path_has_ignore_dir_segment` utility already used elsewhere in the repository.

Previously, the SCIP indexer maintained a smaller hardcoded ignore set, which could allow files inside ignored directories (such as `.venv`) to influence SCIP language detection and project discovery behavior.

## Changes

* Replaced SCIP-local ignore-directory handling with the shared utility from `utils.path_ignore`
* Removed duplicated ignore logic
* Added focused regression tests for:

  * language detection under ignored directories
  * C# project discovery under ignored directories

## Notes

The patch is intentionally kept small and scoped only to ignore-directory consistency behavior to minimize unintended side effects.

This contribution is part of GSSoC 2026.
