### PR TITLE
Accept .cgc suffix in registry download lookups

### DIFF
--- a/src/codegraphcontext/cli/registry_commands.py
+++ b/src/codegraphcontext/cli/registry_commands.py
@@ -168,6 +168,8 @@ def download_bundle(name: str, output_dir: Optional[str] = None, auto_load: bool
     and base names (e.g., 'python-bitcoin-utils' - picks most recent version).
     """
     console.print(f"[cyan]Looking for bundle '{name}'...[/cyan]")
+
+    lookup_name = name[:-4] if name.lower().endswith('.cgc') else name
     
     bundles = fetch_available_bundles()
     
@@ -178,7 +180,7 @@ def download_bundle(name: str, output_dir: Optional[str] = None, auto_load: bool
     # Strategy 1: Try exact match on full_name (with version)
     bundle = None
     for b in bundles:
-        if b.get('full_name', '').lower() == name.lower():
+        if b.get('full_name', '').lower() == lookup_name.lower():
             bundle = b
             console.print(f"[dim]Found exact match: {b.get('full_name')}[/dim]")
             break
@@ -188,7 +190,7 @@ def download_bundle(name: str, output_dir: Optional[str] = None, auto_load: bool
     if not bundle:
         matching_bundles = []
         for b in bundles:
-            if b.get('name', '').lower() == name.lower():
+            if b.get('name', '').lower() == lookup_name.lower():
                 matching_bundles.append(b)
         
         if matching_bundles:
@@ -211,7 +213,7 @@ def download_bundle(name: str, output_dir: Optional[str] = None, auto_load: bool
     if not bundle:
         # Find bundles with similar base names
         suggestions = []
-        name_lower = name.lower()
+        name_lower = lookup_name.lower()
         for b in bundles:
             base_name = b.get('name', '').lower()
             full_name = b.get('full_name', '').lower()

--- a/tests/unit/cli/test_registry_command.py
+++ b/tests/unit/cli/test_registry_command.py
@@ -73,6 +73,47 @@ def test_registry_list_still_works():
     )
 
 
+@pytest.mark.parametrize("bundle_name", ["numpy", "numpy.cgc"])
+def test_registry_download_accepts_cgc_suffix(bundle_name, tmp_path):
+    """Running `cgc registry download` should accept names with an optional .cgc suffix."""
+    import importlib
+    import sys
+
+    fake_requests = MagicMock()
+
+    class DummyResponse:
+        status_code = 200
+        headers = {"content-length": "4"}
+        content = b"data"
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=8192):
+            yield b"data"
+
+    fake_requests.get.return_value = DummyResponse()
+    bundle = {
+        "name": "numpy",
+        "full_name": "numpy-main-abc123",
+        "bundle_name": "numpy-main-abc123.cgc",
+        "download_url": "https://example.com/numpy.cgc",
+        "generated_at": "2026-05-29T00:00:00Z",
+        "size": "1",
+        "repo": "numpy/numpy",
+        "source": "on-demand",
+    }
+
+    with patch.dict(sys.modules, {"requests": fake_requests}):
+        import codegraphcontext.cli.registry_commands as reg_cmds
+        importlib.reload(reg_cmds)
+        with patch.object(reg_cmds, "fetch_available_bundles", return_value=[bundle]), patch.object(reg_cmds.console, "print"):
+            result = reg_cmds.download_bundle(bundle_name, output_dir=str(tmp_path), auto_load=True)
+
+    assert result == str(tmp_path / "numpy-main-abc123.cgc")
+    assert (tmp_path / "numpy-main-abc123.cgc").read_bytes() == b"data"
+
+
 def test_registry_no_subcommand_no_error_message():
     """Running `cgc registry` should NOT produce an error about a missing command."""
     result = runner.invoke(app, ["registry"])


### PR DESCRIPTION
Fixes #1016 

## Summary

This PR updates registry bundle lookup logic to accept bundle names with an optional `.cgc` suffix.

Currently:

```bash
cgc registry download numpy
```

resolves successfully, while:

```bash
cgc registry download numpy.cgc
```

does not resolve the same bundle even though both inputs refer to the same registry artifact.

## Changes

* Normalize registry lookup input by stripping a trailing `.cgc` suffix before bundle matching.
* Preserve existing lookup behavior for bundle names without a suffix.
* Preserve local-path handling and download behavior.
* Add a regression test covering both:

  * `numpy`
  * `numpy.cgc`

## Validation

* Added a focused regression test for `.cgc`-suffixed bundle names.
* Verified existing lookup behavior remains unchanged for standard bundle names.
* Performed syntax validation on modified files.

## Notes

This patch is intentionally small and scoped only to registry bundle name resolution.

This contribution is part of GSSoC 2026.