### PR TITLE
fix: remove hardcoded Linux path from test_issue_10_fix

### DIFF
--- a/tests/test_issue_806_fix.py
+++ b/tests/test_issue_806_fix.py
@@ -481,7 +481,7 @@ print(f"RESULT:{result}")
             [sys.executable, "-c", code],
             capture_output=True,
             text=True,
-            cwd="/home/pc1/Desktop/CodeGraphContext",
+            cwd=str(Path(__file__).resolve().parent.parent),
         )
         output = result.stdout + result.stderr
         # Look for RESULT: in output


### PR DESCRIPTION
## Summary

This PR fixes a cross-platform test failure caused by a hardcoded Linux repository path in `tests/test_issue_806_fix.py`.

## Changes

* Replaced the hardcoded repository path:

```python
cwd="/home/pc1/Desktop/CodeGraphContext"
```

with:

```python
cwd=str(Path(__file__).resolve().parent.parent)
```

* Ensures the test works regardless of repository location or operating system.
* Improves cross-platform compatibility for contributors using Windows.

## Issue

Fixes #1019

## Testing

Executed:

```bash
python -m pytest tests/test_issue_806_fix.py -v
```

Result:

```text
3 passed, 14 skipped
```

The previously failing Windows test now passes successfully.
