### PR TITLE
fix(api): pass cypher query argument to query handler

### DIFF
--- a/src/codegraphcontext/api/router.py
+++ b/src/codegraphcontext/api/router.py
@@ -87,7 +87,7 @@ async def execute_query(
     server: MCPServer = Depends(get_server)
 ):
     result = await server.handle_tool_call("execute_cypher_query", {
-        "query": request.query,
+        "cypher_query": request.query,
         "params": request.params
     })
     

--- a/tests/unit/api/test_query_router.py
+++ b/tests/unit/api/test_query_router.py
@@ -1,0 +1,41 @@
+import asyncio
+import importlib
+import sys
+import types
+
+from codegraphcontext.api.schemas import QueryRequest
+
+
+class FakeServer:
+    def __init__(self):
+        self.tool_name = None
+        self.arguments = None
+
+    async def handle_tool_call(self, tool_name, arguments):
+        self.tool_name = tool_name
+        self.arguments = arguments
+        return {"rows": [{"count": 1}]}
+
+
+def test_execute_query_passes_cypher_query_argument(monkeypatch):
+    server_module = types.ModuleType("codegraphcontext.server")
+    server_module.MCPServer = object
+    monkeypatch.setitem(sys.modules, "codegraphcontext.server", server_module)
+
+    router_module = importlib.import_module("codegraphcontext.api.router")
+
+    server = FakeServer()
+    request = QueryRequest(
+        query="MATCH (n) RETURN count(n) AS count",
+        params={"limit": 10},
+    )
+
+    response = asyncio.run(router_module.execute_query(request, server=server))
+
+    assert response.status == "ok"
+    assert response.data == {"rows": [{"count": 1}]}
+    assert server.tool_name == "execute_cypher_query"
+    assert server.arguments == {
+        "cypher_query": "MATCH (n) RETURN count(n) AS count",
+        "params": {"limit": 10},
+    }


### PR DESCRIPTION
## Summary

Fixes #1023.

The `/api/v1/query` route was forwarding the request body as `query`, but the `execute_cypher_query` handler reads `cypher_query`. That meant a valid HTTP request could arrive at the API layer and still be rejected by the tool handler as an empty query.

This PR changes the route to pass the key expected by the handler and adds a focused regression test around the route function.

Raised and worked on as part of GSSoC 2026.

## Testing

```bash
PYTHONPATH=src python -m pytest tests/unit/api/test_query_router.py -q
PYTHONPATH=src python -m pytest tests/unit/tools/test_cypher_query_readonly.py tests/unit/tools/test_falkordb_kuzu_session_kwargs.py -q
```

`ruff` was not available in my local environment (`No module named ruff`), so I could not run the formatting/lint command locally.
