### PR TITLE
fix(api): declare MCP SSE runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "falkordblite>=0.1.0; sys_platform != 'win32' and python_version >= '3.12'",
     "kuzu; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
     "ladybug; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
+    "mcp>=1.0.0",
     "fastapi>=0.100.0",
     "uvicorn>=0.22.0"
 ]

--- a/tests/unit/api/test_mcp_sse_dependency.py
+++ b/tests/unit/api/test_mcp_sse_dependency.py
@@ -1,0 +1,11 @@
+import tomllib
+from pathlib import Path
+
+
+def test_mcp_sse_runtime_dependency_is_declared():
+    pyproject_path = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text())
+
+    dependencies = pyproject["project"]["dependencies"]
+
+    assert any(dependency.startswith("mcp") for dependency in dependencies)


### PR DESCRIPTION
## Summary

Fixes #1024.

The FastAPI app imports `codegraphcontext.api.mcp_sse` unconditionally, and that module imports the Python MCP SDK:

- `mcp.server`
- `mcp.server.models`
- `mcp.server.sse`

`pyproject.toml` did not declare `mcp`, so a clean install could still fail when loading the advertised `/api/v1/mcp/sse` route.

This PR adds the missing runtime dependency and a small packaging regression test so the dependency does not get dropped accidentally.

Raised and worked on as part of GSSoC 2026.

## Testing

```bash
PYTHONPATH=src python -m pytest tests/unit/api/test_mcp_sse_dependency.py -q
```

I also verified the package exists on PyPI with:

```bash
python -m pip index versions mcp
```

`ruff` is not installed in my local environment (`No module named ruff`), so I could not run the lint command locally.
