### PR TITLE
Add .mts and .cts support to TypeScript indexing

### DIFF
--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -43,6 +43,8 @@ class GraphBuilder:
             ".cjs": "javascript",
             ".go": "go",
             ".ts": "typescript",
+            ".mts": "typescript",
+            ".cts": "typescript",
             ".d.ts": "typescript",
             ".tsx": "tsx",
             ".cpp": "cpp",

--- a/src/codegraphcontext/tools/indexing/pre_scan.py
+++ b/src/codegraphcontext/tools/indexing/pre_scan.py
@@ -53,6 +53,8 @@ def _register_prescans() -> Dict[str, _PreScanFn]:
         ".cjs": make_js(".cjs"),
         ".go": lambda files, gp: go_lang_module.pre_scan_go(files, gp(".go")),
         ".ts": lambda files, gp: ts_lang_module.pre_scan_typescript(files, gp(".ts")),
+        ".mts": lambda files, gp: ts_lang_module.pre_scan_typescript(files, gp(".mts")),
+        ".cts": lambda files, gp: ts_lang_module.pre_scan_typescript(files, gp(".cts")),
         ".d.ts": lambda files, gp: ts_lang_module.pre_scan_typescript(files, gp(".d.ts")),
         ".tsx": lambda files, gp: tsx_lang_module.pre_scan_typescript(files, gp(".tsx")),
         ".cpp": lambda files, gp: cpp_lang_module.pre_scan_cpp(files, gp(".cpp")),

--- a/tests/unit/tools/test_typescript_module_extensions.py
+++ b/tests/unit/tools/test_typescript_module_extensions.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import codegraphcontext.tools.languages.typescript as ts_lang_module
+import codegraphcontext.tools.languages.typescriptjsx as tsx_lang_module
+
+from codegraphcontext.tools.indexing import pre_scan as pre_scan_module
+from codegraphcontext.tools.indexing.pre_scan import pre_scan_for_imports
+
+
+def test_graph_builder_registry_lists_typescript_module_extensions():
+    graph_builder_source = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "codegraphcontext"
+        / "tools"
+        / "graph_builder.py"
+    )
+    source_text = graph_builder_source.read_text(encoding="utf-8")
+
+    assert '".ts": "typescript"' in source_text
+    assert '".tsx": "tsx"' in source_text
+    assert '".d.ts": "typescript"' in source_text
+    assert '".mts": "typescript"' in source_text
+    assert '".cts": "typescript"' in source_text
+
+
+def test_pre_scan_dispatches_typescript_module_extensions(monkeypatch):
+    calls = []
+
+    def fake_pre_scan_typescript(files, parser):
+        calls.append((tuple(".d.ts" if path.name.endswith(".d.ts") else path.suffix for path in files), parser))
+        return {}
+
+    monkeypatch.setattr(pre_scan_module, "_PRESCAN_REGISTRY", None)
+    monkeypatch.setattr(ts_lang_module, "pre_scan_typescript", fake_pre_scan_typescript)
+    monkeypatch.setattr(tsx_lang_module, "pre_scan_typescript", fake_pre_scan_typescript)
+
+    files = [
+        Path("/tmp/example.ts"),
+        Path("/tmp/example.tsx"),
+        Path("/tmp/example.d.ts"),
+        Path("/tmp/example.mts"),
+        Path("/tmp/example.cts"),
+        Path("/tmp/example.py"),
+    ]
+
+    pre_scan_for_imports(
+        files,
+        {".ts", ".tsx", ".d.ts", ".mts", ".cts"},
+        lambda ext: f"parser:{ext}",
+    )
+
+    assert [suffixes for suffixes, _ in calls] == [
+        (".ts",),
+        (".tsx",),
+        (".d.ts",),
+        (".mts",),
+        (".cts",),
+    ]
+    assert [parser for _, parser in calls] == [
+        "parser:.ts",
+        "parser:.tsx",
+        "parser:.d.ts",
+        "parser:.mts",
+        "parser:.cts",
+    ]


### PR DESCRIPTION
Fixes #1027 

## Summary

CodeGraphContext currently recognizes `.ts`, `.tsx`, and `.d.ts` files, but does not recognize `.mts` and `.cts` TypeScript module extensions.

As a result, valid TypeScript source files using modern ES module (`.mts`) and CommonJS module (`.cts`) formats are skipped during indexing and import pre-scan.

## Changes

* Added `.mts` support to the TypeScript file registry in `graph_builder.py`
* Added `.cts` support to the TypeScript file registry in `graph_builder.py`
* Added `.mts` support to TypeScript pre-scan dispatch registration
* Added `.cts` support to TypeScript pre-scan dispatch registration
* Added regression tests covering `.ts`, `.tsx`, `.d.ts`, `.mts`, and `.cts` dispatch behavior

## Validation

* Added focused regression coverage for TypeScript module extensions
* Verified `.mts` and `.cts` are routed through the TypeScript pre-scan path
* Verified existing `.ts`, `.tsx`, and `.d.ts` behavior remains unchanged

## Notes

This is a small correctness fix that aligns CodeGraphContext with modern TypeScript module extensions and improves indexing coverage for TypeScript projects.

This contribution is part of GSSoC 2026.
