### PR TITLE
Fix MCP JSON alwaysAllow configuration

### DIFF
--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -92,8 +92,8 @@ def _generate_mcp_json(creds):
                     "disabledTools": [],
                     "disabled": False
                 },
-                "disabled": False,
-                "alwaysAllow": []
+                "disabled": False 
+        
             }
         }
     }


### PR DESCRIPTION
Fixes #625

Updated MCP JSON alwaysAllow configuration in setup_wizard.py.