### PR TITLE
fix: prevent path traversal in report generation

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -351,8 +351,18 @@ class MCPServer:
 
     def generate_report_tool(self, **args) -> Dict[str, Any]:
         from .tools.report_generator import generate_report
+
         output_path_raw = args.get("output_path")
         output_path = Path(output_path_raw) if output_path_raw else self.cwd / "CGC_REPORT.md"
+
+        base_dir = self.cwd.resolve()
+        output_path = output_path.resolve()
+
+        try:
+            output_path.relative_to(base_dir)
+        except ValueError:
+            return {"error": "Invalid output_path: path traversal is not allowed"}
+
         try:
             report = generate_report(
                 self.db_manager,
@@ -361,7 +371,7 @@ class MCPServer:
                 god_node_limit=int(args.get("god_node_limit", 15)),
                 complexity_limit=int(args.get("complexity_limit", 15)),
                 cross_module_limit=int(args.get("cross_module_limit", 20)),
-            )
+                )
             return {"status": "ok", "output_path": str(output_path), "report": report}
         except Exception as exc:
             return {"error": str(exc)}


### PR DESCRIPTION
## Summary

This PR fixes a path traversal vulnerability in `generate_report_tool`.

### Changes Made

* Added path validation using `Path.resolve()`
* Ensured the output path remains within the project workspace
* Blocked directory traversal attempts such as `../` and `../../`
* Returned a clear error message when an invalid path is provided

### Security Impact

Prevents malicious users from writing report files outside the intended project directory.

Fixes #1009
