### PR TITLE
fix(falkordb): make embedded backend resilient to redis-py >= 6 (#1035)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,30 @@ dependencies = [
     "nbformat",
     "nbconvert>=7.16.6",
     "pathspec>=0.12.1",
-    "falkordb>=0.1.0",
+    # ------------------------------------------------------------------
+    # Backend driver pins (see issue #1035)
+    #
+    # FalkorDB and its embedded sibling ``falkordblite`` co-evolve with
+    # ``redis-py``: the most recent ``falkordblite`` releases (>= 0.10) and
+    # ``falkordb`` releases (>= 1.6) require ``redis>=7.1`` / ``redis>=7.4``,
+    # but redis-py >= 6 breaks the Unix-socket path FalkorDB Lite uses
+    # (``UnixDomainSocketConnection`` lacks a ``host`` attribute, which the
+    # new maintenance-notifications handshake dereferences unconditionally).
+    #
+    # Until upstream resolves this we pin a known-good triple:
+    #   * redis-py 5.x           — last series that keeps UDS path working
+    #   * falkordblite < 0.10    — last series compatible with redis>=4.5
+    #   * falkordb < 1.6         — last series compatible with redis<7.1
+    #
+    # ``redis`` itself is now declared explicitly so a fresh resolver run
+    # (``uvx``, ``pipx install --force``, etc.) cannot silently pick up
+    # redis-py 6/7/8 again and reintroduce the bug.
+    # ------------------------------------------------------------------
+    "redis>=5,<6",
+    "falkordb>=1.0,<1.6",
+    "falkordblite>=0.7,<0.10; sys_platform != 'win32' and python_version >= '3.12'",
     "requests>=2.28.0",
     "protobuf>=3.20,<3.21",
-    "falkordblite>=0.1.0; sys_platform != 'win32' and python_version >= '3.12'",
     "kuzu; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
     "ladybug; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
     "fastapi>=0.100.0",
@@ -44,6 +64,28 @@ parsing = [
     "tree-sitter>=0.21.0,<0.26.0; python_version != '3.13'",
     "tree-sitter-language-pack>=0.6.0,<1.0.0; python_version != '3.13'",
     "tree-sitter-c-sharp>=0.21.0; python_version != '3.13'",
+]
+# Named backend extras let users (and CI) opt into a single, tested driver
+# triple instead of inheriting whatever the default install pulls. They
+# install the same ranges as the defaults today; the long-term plan
+# (tracked separately) is to make the defaults lean and require an extra.
+falkordb-embedded = [
+    "falkordblite>=0.7,<0.10; sys_platform != 'win32' and python_version >= '3.12'",
+    "falkordb>=1.0,<1.6",
+    "redis>=5,<6",
+]
+falkordb-remote = [
+    "falkordb>=1.0,<1.6",
+    "redis>=5,<6",
+]
+kuzu = [
+    "kuzu; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
+]
+ladybug = [
+    "ladybug; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
+]
+neo4j = [
+    "neo4j>=5.15.0",
 ]
 dev = [
     "pytest>=7.4.0",

--- a/src/codegraphcontext/core/__init__.py
+++ b/src/codegraphcontext/core/__init__.py
@@ -101,6 +101,12 @@ def get_database_manager(db_path: Optional[str] = None) -> Union['DatabaseManage
             from .database_falkordb import FalkorDBManager, FalkorDBUnavailableError
             try:
                 mgr = FalkorDBManager(db_path=db_path)
+                # Eagerly probe the connection so any FalkorDBUnavailableError
+                # (e.g. redis-py/falkordblite version mismatch — issue #1035)
+                # surfaces *here*, while we can still fall back to KùzuDB.
+                # ``get_driver`` is idempotent (singleton-guarded), so the
+                # subsequent real call from server.py costs nothing.
+                mgr.get_driver()
                 info_logger(f"Using FalkorDB Lite (explicit) at {db_path or 'default path'}")
                 return mgr
             except FalkorDBUnavailableError as falkor_err:
@@ -153,6 +159,9 @@ def get_database_manager(db_path: Optional[str] = None) -> Union['DatabaseManage
         from .database_falkordb import FalkorDBManager, FalkorDBUnavailableError
         try:
             mgr = FalkorDBManager(db_path=db_path)
+            # Eagerly probe so dep/version failures (issue #1035) surface here
+            # while we can still fall through to KùzuDB below.
+            mgr.get_driver()
             info_logger(f"Using FalkorDB Lite (default) at {db_path or 'default path'}")
             return mgr
         except FalkorDBUnavailableError as falkor_err:

--- a/src/codegraphcontext/core/database_falkordb.py
+++ b/src/codegraphcontext/core/database_falkordb.py
@@ -23,17 +23,51 @@ from typing import Optional, Tuple
 from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logger, warning_logger
 
 # ---------------------------------------------------------------------------
-# Compatibility patch: redis-py >= 5.x added OpenTelemetry error telemetry that
-# accesses conn.port inside its error handler. UnixDomainSocketConnection never
-# had a 'port' attribute, so any exception raised during a Unix-socket connection
-# (e.g. the sentinel-detection INFO call inside FalkorDB.__init__) would produce
-# a secondary AttributeError masking the real problem.
-# Patching the class at import time costs nothing and fixes all call-sites.
+# Compatibility patch: newer redis-py releases assume every Connection exposes
+# ``host`` and ``port`` attributes, but ``UnixDomainSocketConnection`` historically
+# has neither. Two failure modes have been observed in the wild:
+#
+#   1. redis-py >= 5.x added OpenTelemetry error telemetry that reads ``conn.port``
+#      inside its error handler. The missing attribute raised a secondary
+#      ``AttributeError`` that masked the real connection error.
+#   2. redis-py >= 6.x added a maintenance-notifications handshake
+#      (``activate_maint_notifications_handling_if_enabled`` →
+#      ``_enable_maintenance_notifications``) that raises ``ValueError`` on any
+#      connection without a ``host`` attribute — breaking FalkorDB Lite's
+#      Unix-socket connection entirely (upstream issue #1035).
+#
+# Patching the class at import time is cheap and fixes every call-site. The
+# values themselves are inert sentinels: FalkorDB Lite never uses TCP, so no
+# code path will dereference them as a real ``(host, port)`` pair.
 # ---------------------------------------------------------------------------
 try:
     from redis.connection import UnixDomainSocketConnection as _UDSC
+
+    # ``port`` was never an attribute on UDSC; if it is missing, install a sentinel.
     if not hasattr(_UDSC, 'port'):
         _UDSC.port = 0  # type: ignore[attr-defined]
+
+    # ``host`` is trickier. On redis-py >= 6 ``UDSC`` inherits an *abstract*
+    # ``host`` property (from ``MaintNotificationsAbstractConnection``) whose
+    # default body just returns ``None``. The maintenance-notifications
+    # handshake then does ``getattr(self, "host", None)``; because the property
+    # *exists* on the class, ``getattr`` returns ``None`` instead of falling
+    # through to its default — and the handshake raises ValueError.
+    #
+    # ``hasattr(_UDSC, 'host')`` is therefore the wrong check: we must inspect
+    # an instance. We probe a bare instance (``object.__new__`` skips
+    # ``__init__``, so we don't need a path) and override the class attribute
+    # with an inert string whenever the inherited property would yield ``None``.
+    try:
+        _probe = object.__new__(_UDSC)
+        if getattr(_probe, 'host', None) is None:
+            _UDSC.host = 'localhost'  # type: ignore[attr-defined]
+        del _probe
+    except Exception:
+        # Probing failed for an unrelated reason; do the safe thing and
+        # install the sentinel anyway. Worst case we shadow a working property
+        # with a constant, which is still preferable to a crash.
+        _UDSC.host = 'localhost'  # type: ignore[attr-defined]
 except Exception:
     pass  # redis not installed or class structure changed — safe to ignore
 
@@ -149,8 +183,19 @@ class FalkorDBManager:
                         from falkordb import FalkorDB
                         
                         info_logger(f"Connecting to FalkorDB Lite at {self.socket_path}")
-                        self._driver = FalkorDB(unix_socket_path=self.socket_path)
-                        self._graph = self._driver.select_graph(self.graph_name)
+                        try:
+                            self._driver = FalkorDB(unix_socket_path=self.socket_path)
+                            self._graph = self._driver.select_graph(self.graph_name)
+                        except ValueError as ve:
+                            # redis-py >= 6 raises ValueError on Unix-socket connections that
+                            # lack a 'host' attribute (see upstream issue #1035). Even with the
+                            # import-time shim above, newer redis-py revisions may shift the
+                            # check. Convert to FalkorDBUnavailableError so the caller can fall
+                            # back to KùzuDB instead of crashing the whole MCP server.
+                            raise FalkorDBUnavailableError(
+                                f"FalkorDB Lite client refused the Unix-socket connection: {ve}. "
+                                "This typically indicates a redis-py / falkordblite version mismatch."
+                            ) from ve
                         
                         # Test the connection
                         try:
@@ -167,6 +212,10 @@ class FalkorDBManager:
                             "  pip install falkordblite"
                         )
                         raise ValueError("FalkorDB client missing.") from e
+                    except FalkorDBUnavailableError:
+                        # Propagate as-is so get_database_manager() can trigger the
+                        # documented KùzuDB fallback.
+                        raise
                     except Exception as e:
                         error_logger(f"Failed to initialize FalkorDB: {e}")
                         raise
@@ -195,6 +244,13 @@ class FalkorDBManager:
                 test_graph.query("RETURN 1")
                 info_logger("Connected to existing (functional) FalkorDB Lite process.")
                 return
+            except ValueError as ve:
+                # redis-py >= 6 maintenance-notifications handshake (issue #1035) — this
+                # backend cannot work in the current environment regardless of socket state.
+                raise FalkorDBUnavailableError(
+                    f"FalkorDB Lite client refused the Unix-socket connection: {ve}. "
+                    "This typically indicates a redis-py / falkordblite version mismatch."
+                ) from ve
             except Exception as e:
                 # Stale socket, unresponsive, or "brainless" (unknown command GRAPH.QUERY)
                 info_logger(f"Existing FalkorDB process at {self.socket_path} is stale or non-functional: {e}")
@@ -247,6 +303,13 @@ class FalkorDBManager:
                     test_graph = d.select_graph('__cgc_health_check')
                     test_graph.query("RETURN 1")
                     return
+                except ValueError as ve:
+                    # redis-py version mismatch — no point retrying, the handshake
+                    # will keep failing the same way until the user fixes deps.
+                    raise FalkorDBUnavailableError(
+                        f"FalkorDB Lite client refused the Unix-socket connection: {ve}. "
+                        "This typically indicates a redis-py / falkordblite version mismatch."
+                    ) from ve
                 except Exception as e:
                     last_error = e
             
@@ -265,7 +328,11 @@ class FalkorDBManager:
             
             time.sleep(0.5)
             
-        raise RuntimeError(f"Timed out waiting for FalkorDB Lite to start. Last error: {last_error}")
+        # Timeout is also a "backend not usable here" signal — raise the typed
+        # exception so the documented KùzuDB fallback fires instead of crashing.
+        raise FalkorDBUnavailableError(
+            f"Timed out waiting for FalkorDB Lite to start. Last error: {last_error}"
+        )
 
     def close_driver(self):
         """Closes the connection."""


### PR DESCRIPTION
Three independent failures combine in issue #1035 when `codegraphcontext` is launched via `uvx`/`pipx` with the FalkorDB Lite backend:

1. `redis` is unpinned, so a fresh resolution pulls redis-py 8.x.
2. redis-py >= 6 added a maintenance-notifications handshake that reads `getattr(self, "host", None)` on every connection. `UnixDomainSocketConnection` inherits an abstract `host` property whose body returns `None`, so the handshake raises `ValueError: Cannot enable maintenance notifications for connection object that doesn't have a host attribute.` and FalkorDB Lite cannot connect at all.
3. That `ValueError` escapes `_ensure_server_running` instead of being converted to `FalkorDBUnavailableError`, so the documented KùzuDB fallback never fires and the whole MCP server dies.

This change fixes all three:

* **pyproject.toml** — pin a known-good driver triple (`redis>=5,<6`, `falkordb>=1.0,<1.6`, `falkordblite>=0.7,<0.10`) and add named backend extras (`falkordb-embedded`, `falkordb-remote`, `kuzu`, `ladybug`, `neo4j`) so users and CI can opt into a single tested driver set instead of inheriting whatever the resolver picks.

* **core/database_falkordb.py** — extend the import-time `UnixDomainSocketConnection` shim to actually override the inherited `host` property on redis-py >= 6 (a `hasattr` check is fooled by the abstract property; probe a bare instance instead). Convert any `ValueError` raised by the FalkorDB client — and the startup timeout — into `FalkorDBUnavailableError` so the typed fallback path fires.

* **core/__init__.py** — eagerly probe `mgr.get_driver()` in `get_database_manager()` so dep/version failures surface at backend-selection time, while we can still fall back to KùzuDB. `get_driver()` is singleton-guarded, so the subsequent real call from `server.py` is a no-op.

Validation:

* `uv pip install --dry-run -e .` resolves to `redis 5.3.1` / `falkordblite 0.9.0` / `falkordb 1.2.0` — the triple the upstream issue verified as working.
* All 40 FalkorDB-related unit tests pass; full unit suite shows 459 pass / 14 skip / 2 fail, where the 2 failures are pre-existing on `main` in `test_database_kuzu_compat.py` and unrelated to this change.
* End-to-end smoke test: with `CGC_RUNTIME_DB_TYPE=falkordb` and a simulated upstream failure, `get_database_manager()` now returns a `KuzuDBManager` instead of crashing.
* Direct shim probe against redis-py 8.0.0: instance-level `UDSC.host` now returns `'localhost'` instead of `None`.

Fixes #1035

Amp-Thread-ID: https://ampcode.com/threads/T-019e87c8-6ac6-767f-8c8f-32e947357abc