### PR TITLE
[BUG] Allow larger browser-indexed scripts

### DIFF
--- a/website/src/lib/parser.worker.ts
+++ b/website/src/lib/parser.worker.ts
@@ -607,6 +607,8 @@ let nodeIdSequence = 1;
 let repoId = -1;
 let repoRootPrefix = ''; // common path prefix stripped before building folder hierarchy
 let indexOptions: { indexVariables?: boolean } = { indexVariables: true };
+const MAX_PARSEABLE_FILE_CHARS = 1_000_000;
+const MAX_PARSEABLE_MINIFIED_FILE_CHARS = 200_000;
 
 /**
  * Compute the longest common directory prefix of all queued file paths.
@@ -841,9 +843,12 @@ async function processNextBatch() {
 
     const isPathIgnored = f.path.split(/[\/\\]/).some(part => IGNORED_DIRS.has(part));
 
-    if (f.content.length > 200000 || isPathIgnored) {
-      if (f.content.length > 200000) {
-        console.warn(`[Diagnostic] Skipping very large file (${(f.content.length / 1024).toFixed(1)} KB): ${f.path}`);
+    const isLikelyMinified = /\.min\.[cm]?[jt]sx?$/.test(f.path) || /(^|[\/\\])(vendor|lib)[\/\\]/.test(f.path);
+    const maxFileChars = isLikelyMinified ? MAX_PARSEABLE_MINIFIED_FILE_CHARS : MAX_PARSEABLE_FILE_CHARS;
+
+    if (f.content.length > maxFileChars || isPathIgnored) {
+      if (f.content.length > maxFileChars) {
+        console.warn(`[Diagnostic] Skipping very large file (${(f.content.length / 1024).toFixed(1)} KB, limit ${(maxFileChars / 1024).toFixed(0)} KB): ${f.path}`);
       }
       continue;
     }


### PR DESCRIPTION
Fixes #1000 browser-side indexing skipping first-party JavaScript files that are larger than the old hardcoded 200 KB threshold.

## Root Cause

The web parser worker skipped every file over `200000` characters before creating a file node or parsing definitions. In `aikohanasaki/Aikobots`, important first-party files such as `public/script.js` are larger than that threshold, which made it look like words/paths such as `script` were not being indexed.

## Changes

- Replaces the single hardcoded 200 KB limit with named thresholds.
- Allows normal source files up to about 1 MB.
- Keeps likely minified/vendor files capped at 200 KB to avoid pulling in heavy generated libraries.
- Improves the diagnostic log to include the active skip limit.

## Validation

- Ran `npm run build` in `website` successfully.
- Confirmed the referenced Aikobots repo has large first-party script files, including `public/script.js`, that were previously above the old cutoff.