### PR TITLE
Feature/interactive export fixes

### DIFF
--- a/website/src/components/CodeGraphViewer.tsx
+++ b/website/src/components/CodeGraphViewer.tsx
@@ -16,6 +16,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useTheme } from "next-themes";
 import FlowchartSVG from "./FlowchartSVG";
 import { packageCgcBundle, downloadBlob, publishCgcBundle } from "../lib/cgc-exporter";
+import { exportSvg } from "../lib/svg-exporter";
+import { packageInteractiveExport } from "../lib/html-exporter";
 import { toast } from "sonner";
 import { getOrCreateSessionId } from "../lib/utils";
 import {
@@ -367,6 +369,7 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [focusSet, setFocusSet] = useState<{ nodes: Set<number>, links: Set<any> } | null>(null);
+  const [simulationReady, setSimulationReady] = useState(false);
 
   // Publish and Export parameters
   const { owner, repo } = useParams();
@@ -438,6 +441,49 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
     } catch (err: any) {
       console.error(err);
       toast.error("Failed to export bundle: " + err.message);
+    }
+  };
+
+  const handleSvgExport = async () => {
+    try {
+      if (graphMode === 'mermaid') {
+        const svgEl = document.getElementById('flowchart-svg');
+        if (svgEl) {
+          const svgString = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n` + svgEl.outerHTML;
+          const blob = new Blob([svgString], { type: 'image/svg+xml' });
+          downloadBlob(blob, 'flowchart-export.svg');
+          toast.success("Flowchart SVG exported successfully!");
+          return;
+        }
+      }
+
+      await exportSvg(filteredData, nodeColors, edgeColors, isDark);
+      toast.success("SVG exported successfully!");
+    } catch (err: any) {
+      toast.error("Failed to export SVG: " + err.message);
+    }
+  };
+
+  const handleHtmlExport = async () => {
+    try {
+      let filename = "interactive-graph.zip";
+      if (data.metadata?.repo) {
+         filename = `${data.metadata.repo.replace(/\//g, '_')}_interactive.zip`;
+      }
+      
+      const exportMode = graphMode === 'mermaid' ? 'mermaid' : 'classic';
+      const blob = await packageInteractiveExport(
+        filteredData.nodes, 
+        filteredData.links, 
+        data.metadata || {}, 
+        nodeColors,
+        edgeColors,
+        exportMode
+      );
+      downloadBlob(blob, filename);
+      toast.success("Interactive HTML exported successfully!");
+    } catch (err: any) {
+      toast.error("Failed to export Interactive HTML: " + err.message);
     }
   };
 
@@ -549,6 +595,8 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
   const [graphMode, setGraphMode] = useState<VisualizationMode>('classic');
   const [showModeMenu, setShowModeMenu] = useState(false);
   const modeMenuRef = useRef<HTMLDivElement>(null);
+  const [showExportMenu, setShowExportMenu] = useState(false);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
 
   // Sidebar resize / collapse
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_W);
@@ -579,6 +627,9 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
     const handler = (e: MouseEvent) => {
       if (modeMenuRef.current && !modeMenuRef.current.contains(e.target as Node)) {
         setShowModeMenu(false);
+      }
+      if (exportMenuRef.current && !exportMenuRef.current.contains(e.target as Node)) {
+        setShowExportMenu(false);
       }
     };
     document.addEventListener('mousedown', handler);
@@ -1557,15 +1608,69 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
 
           {/* Desktop Top Right Badges */}
           <div className="hidden md:flex items-center gap-3">
-            {/* Export Button */}
-            <button
-              onClick={handleExport}
-              className={`flex items-center gap-2 text-[11px] uppercase tracking-widest font-bold px-4 py-2 border rounded-full transition-all backdrop-blur-md shadow-2xl cursor-pointer ${isDark ? 'bg-black/40 hover:bg-white/10 text-white border-white/10' : 'bg-white/80 hover:bg-white text-gray-800 border-black/10'}`}
-              title="Download code graph as a .cgc file"
-            >
-              <Download className="w-3.5 h-3.5 text-blue-400" />
-              Export
-            </button>
+            {/* Export Menu Dropdown */}
+            <div ref={exportMenuRef} className="relative">
+              <button
+                onClick={() => setShowExportMenu(v => !v)}
+                className={`flex items-center gap-2 text-[11px] uppercase tracking-widest font-bold px-4 py-2 border rounded-full transition-all backdrop-blur-md shadow-2xl cursor-pointer ${isDark ? 'bg-black/40 hover:bg-white/10 text-white border-white/10' : 'bg-white/80 hover:bg-white text-gray-800 border-black/10'}`}
+                title="Export graph data and visualizations"
+              >
+                <Download className="w-3.5 h-3.5 text-blue-400" />
+                Export
+                <ChevronDown className={`w-3 h-3 text-gray-400 transition-transform ${showExportMenu ? 'rotate-180' : ''}`} />
+              </button>
+              <AnimatePresence>
+                {showExportMenu && (
+                  <motion.div
+                    initial={{ opacity: 0, y: -8, scale: 0.96 }}
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={{ opacity: 0, y: -8, scale: 0.96 }}
+                    transition={{ duration: 0.15 }}
+                    className={`absolute right-0 top-full mt-2 backdrop-blur-xl border rounded-2xl shadow-2xl overflow-hidden min-w-[200px] py-1.5 z-[100] flex flex-col ${isDark ? 'bg-black/90 border-white/10' : 'bg-white/95 border-black/10'}`}
+                  >
+                    {/* Export HTML Button */}
+                    <button
+                      onClick={() => { handleHtmlExport(); setShowExportMenu(false); }}
+                      className={`flex items-center gap-3 px-4 py-2.5 transition-all cursor-pointer text-left w-full ${isDark ? 'hover:bg-white/5 text-white' : 'hover:bg-black/5 text-gray-800'}`}
+                      title="Download interactive HTML graph"
+                    >
+                      <Download className="w-3.5 h-3.5 text-green-400 flex-shrink-0" />
+                      <div className="flex flex-col">
+                        <span className="text-[12px] font-bold">Interactive HTML</span>
+                        <span className="text-[10px] text-gray-500 font-normal">Self-contained browser view</span>
+                      </div>
+                    </button>
+
+                    {/* Export SVG Button */}
+                    <button
+                      onClick={() => { handleSvgExport(); setShowExportMenu(false); }}
+                      disabled={!simulationReady}
+                      className={`flex items-center gap-3 px-4 py-2.5 transition-all text-left w-full ${!simulationReady ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${isDark ? 'hover:bg-white/5 text-white' : 'hover:bg-black/5 text-gray-800'}`}
+                      title={simulationReady ? "Download SVG snapshot" : "Waiting for simulation to stabilize..."}
+                    >
+                      <Download className="w-3.5 h-3.5 text-purple-400 flex-shrink-0" />
+                      <div className="flex flex-col">
+                        <span className="text-[12px] font-bold">Vector SVG</span>
+                        <span className="text-[10px] text-gray-500 font-normal">High-res 2D snapshot</span>
+                      </div>
+                    </button>
+
+                    {/* Export CGC Button */}
+                    <button
+                      onClick={() => { handleExport(); setShowExportMenu(false); }}
+                      className={`flex items-center gap-3 px-4 py-2.5 transition-all cursor-pointer text-left w-full ${isDark ? 'hover:bg-white/5 text-white' : 'hover:bg-black/5 text-gray-800'}`}
+                      title="Download code graph as a .cgc file"
+                    >
+                      <Download className="w-3.5 h-3.5 text-blue-400 flex-shrink-0" />
+                      <div className="flex flex-col">
+                        <span className="text-[12px] font-bold">CGC Bundle</span>
+                        <span className="text-[10px] text-gray-500 font-normal">Raw graph context bundle</span>
+                      </div>
+                    </button>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
 
             {/* Publish Button */}
             <button
@@ -1671,6 +1776,25 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
                 transition={{ duration: 0.15 }}
                 className={`absolute right-0 top-full mt-2 backdrop-blur-2xl border rounded-2xl shadow-2xl overflow-hidden min-w-[200px] p-3 z-[100] flex flex-col gap-2.5 ${isDark ? 'bg-black/90 border-white/10' : 'bg-white/95 border-black/10'}`}
               >
+                {/* Mobile Export HTML */}
+                <button
+                  onClick={() => { handleHtmlExport(); setShowMobileMenu(false); }}
+                  className={`flex items-center gap-2 text-[11px] uppercase tracking-widest font-bold px-4 py-2 border rounded-xl transition-all cursor-pointer text-left w-full ${isDark ? 'hover:bg-white/5 border-white/5 text-white' : 'hover:bg-black/5 border-black/5 text-gray-800'}`}
+                >
+                  <Download className="w-3.5 h-3.5 text-green-400" />
+                  Export HTML
+                </button>
+
+                {/* Mobile Export SVG */}
+                <button
+                  onClick={() => { handleSvgExport(); setShowMobileMenu(false); }}
+                  disabled={!simulationReady}
+                  className={`flex items-center gap-2 text-[11px] uppercase tracking-widest font-bold px-4 py-2 border rounded-xl transition-all text-left w-full ${!simulationReady ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${isDark ? 'hover:bg-white/5 border-white/5 text-white' : 'hover:bg-black/5 border-black/5 text-gray-800'}`}
+                >
+                  <Download className="w-3.5 h-3.5 text-purple-400" />
+                  Export SVG
+                </button>
+
                 {/* Mobile Export */}
                 <button
                   onClick={() => { handleExport(); setShowMobileMenu(false); }}
@@ -1850,6 +1974,7 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
         ) : (
           <ForceGraph2D
             ref={fgRef}
+            onEngineStop={() => setSimulationReady(true)}
             graphData={filteredData}
             width={dimensions.width - effectiveSidebarW - effectiveCodePanelW}
             height={dimensions.height}

--- a/website/src/components/CodeGraphViewer.tsx
+++ b/website/src/components/CodeGraphViewer.tsx
@@ -693,6 +693,10 @@ export default function CodeGraphViewer({ data, onClose }: { data: any, onClose:
     return { degreeMap: dm, maxDegree: max };
   }, [filteredData]);
 
+  useEffect(() => {
+    setSimulationReady(false);
+  }, [filteredData]);
+
   const nodeCanvasObject = useCallback((node: any, ctx: any, globalScale: number) => {
     if (!visibleNodeTypes.has(node.type)) return;
     if (!Number.isFinite(node.x) || !Number.isFinite(node.y)) return;

--- a/website/src/components/FlowchartSVG.tsx
+++ b/website/src/components/FlowchartSVG.tsx
@@ -366,7 +366,10 @@ export default function FlowchartSVG({
   /* ── Render ────────────────────────────────────────────────────────── */
 
   return (
+    <div style={{ position: "relative", width, height }}>
     <svg
+      id="flowchart-svg"
+      xmlns="http://www.w3.org/2000/svg"
       ref={svgRef}
       width={width}
       height={height}
@@ -624,38 +627,38 @@ export default function FlowchartSVG({
         })}
       </g>
 
-      {/* Orphan modules toggle (fixed position, not affected by pan/zoom) */}
-      {orphanIds.size > 0 && (
-        <g
-          transform={`translate(${width - 200}, 16)`}
-          onClick={() => setShowOrphans((v) => !v)}
-          style={{ cursor: "pointer" }}
-        >
-          <rect
-            width={180}
-            height={28}
-            rx={14}
-            fill={showOrphans ? (isDark ? "#1e1e2e" : "#e8e8f0") : (isDark ? "#111118" : "#f0f0f5")}
-            stroke={showOrphans ? "#f59e0b55" : (isDark ? "#ffffff18" : "#00000018")}
-            strokeWidth={1}
-          />
-          <text
-            x={90}
-            y={15}
-            textAnchor="middle"
-            dominantBaseline="middle"
-            fontSize={10}
-            fontWeight={700}
-            fontFamily="Inter,system-ui,sans-serif"
-            fill={showOrphans ? "#f59e0b" : (isDark ? "#666" : "#888")}
-            style={{ letterSpacing: "0.06em" }}
-          >
-            {showOrphans
-              ? `HIDE ${orphanIds.size} EXTERNAL`
-              : `SHOW ${orphanIds.size} EXTERNAL`}
-          </text>
-        </g>
-      )}
     </svg>
+
+    {/* Orphan modules toggle — HTML overlay */}
+    {orphanIds.size > 0 && (
+      <button
+        onClick={() => setShowOrphans((v) => !v)}
+        style={{
+          position: "absolute",
+          bottom: 16,
+          left: 16,
+          zIndex: 10,
+          padding: "6px 18px",
+          borderRadius: 9999,
+          border: `1px solid ${showOrphans ? "rgba(245,158,11,0.35)" : (isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)")}`,
+          background: showOrphans
+            ? (isDark ? "rgba(30,30,46,0.9)" : "rgba(232,232,240,0.9)")
+            : (isDark ? "rgba(17,17,24,0.9)" : "rgba(240,240,245,0.9)"),
+          color: showOrphans ? "#f59e0b" : (isDark ? "#666" : "#888"),
+          fontSize: 10,
+          fontWeight: 700,
+          fontFamily: "Inter,system-ui,sans-serif",
+          letterSpacing: "0.06em",
+          cursor: "pointer",
+          backdropFilter: "blur(8px)",
+          transition: "all 0.2s",
+        }}
+      >
+        {showOrphans
+          ? `HIDE ${orphanIds.size} EXTERNAL`
+          : `SHOW ${orphanIds.size} EXTERNAL`}
+      </button>
+    )}
+    </div>
   );
 }

--- a/website/src/lib/html-exporter.ts
+++ b/website/src/lib/html-exporter.ts
@@ -1,5 +1,11 @@
 import JSZip from "jszip";
 
+async function fetchD3(): Promise<string> {
+  const res = await fetch('https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js');
+  if (!res.ok) throw new Error('Failed to fetch d3 for bundling');
+  return res.text();
+}
+
 interface GraphNode {
   id: string | number;
   name: string;
@@ -70,7 +76,8 @@ const SHARED_CSS = `
 function generateClassicHTML(
   dataJson: string,
   nodeColorsJson: string,
-  edgeColorsJson: string
+  edgeColorsJson: string,
+  d3Bundle: string
 ): string {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -90,7 +97,7 @@ function generateClassicHTML(
   <div id="tooltip"></div>
   <div id="legend"></div>
   <canvas id="canvas"></canvas>
-  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  ${d3Bundle ? `<script>${d3Bundle}</script>` : `<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>`}
   <script>
   (function() {
     var rawData = ${dataJson};
@@ -248,7 +255,8 @@ function generateClassicHTML(
 function generateFlowchartHTML(
   dataJson: string,
   nodeColorsJson: string,
-  edgeColorsJson: string
+  edgeColorsJson: string,
+  d3Bundle: string
 ): string {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -281,7 +289,7 @@ function generateFlowchartHTML(
   <div id="tooltip"></div>
   <div id="legend"></div>
   <svg id="chart"></svg>
-  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  ${d3Bundle ? `<script>${d3Bundle}</script>` : `<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>`}
   <script>
   (function() {
     var rawData = ${dataJson};
@@ -586,10 +594,18 @@ export async function packageInteractiveExport(
   // Compact data json for inline use (no pretty-print)
   const inlineDataJson = JSON.stringify(graphData);
 
+  let d3Bundle = '';
+  try {
+    d3Bundle = await fetchD3();
+  } catch {
+    // fallback to CDN if fetch fails (e.g. user is already offline at export time)
+    d3Bundle = '';
+  }
+
   // Generate HTML based on mode
   const htmlContent = mode === 'mermaid'
-    ? generateFlowchartHTML(inlineDataJson, nodeColorsJson, edgeColorsJson)
-    : generateClassicHTML(inlineDataJson, nodeColorsJson, edgeColorsJson);
+    ? generateFlowchartHTML(inlineDataJson, nodeColorsJson, edgeColorsJson, d3Bundle)
+    : generateClassicHTML(inlineDataJson, nodeColorsJson, edgeColorsJson, d3Bundle);
 
   zip.file("index.html", htmlContent);
 

--- a/website/src/lib/html-exporter.ts
+++ b/website/src/lib/html-exporter.ts
@@ -1,0 +1,618 @@
+import JSZip from "jszip";
+
+interface GraphNode {
+  id: string | number;
+  name: string;
+  type: string;
+  file?: string;
+  val?: number;
+  properties?: Record<string, any>;
+  color?: string;
+}
+
+interface GraphLink {
+  id?: string;
+  source: string | number | { id: string | number };
+  target: string | number | { id: string | number };
+  type: string;
+}
+
+interface GraphMetadata {
+  repo?: string;
+  branch?: string;
+  commit?: string;
+  version?: string;
+  [key: string]: any;
+}
+
+/* ── Shared CSS for both modes ─────────────────────────────────────── */
+const SHARED_CSS = `
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body, html { width: 100%; height: 100%; overflow: hidden; background: #020202; font-family: Inter, system-ui, -apple-system, sans-serif; color: #e2e8f0; }
+    #controls {
+      position: absolute; top: 16px; right: 16px; z-index: 100;
+      display: flex; gap: 8px;
+    }
+    .btn {
+      background: rgba(0,0,0,0.4); color: #e2e8f0;
+      border: 1px solid rgba(255,255,255,0.1);
+      padding: 8px 16px; cursor: pointer; border-radius: 9999px;
+      font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase;
+      font-family: Inter, system-ui, sans-serif;
+      backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+      transition: all 0.2s ease; outline: none;
+    }
+    .btn:hover { background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.2); }
+    .btn.active { background: rgba(59,130,246,0.15); border-color: rgba(59,130,246,0.4); color: #93c5fd; }
+    #tooltip {
+      position: absolute; display: none;
+      background: rgba(10,10,18,0.95); color: #fff;
+      padding: 8px 14px; border-radius: 10px;
+      border: 1px solid rgba(255,255,255,0.08);
+      pointer-events: none; z-index: 200;
+      font-size: 12px; font-weight: 500;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+      backdrop-filter: blur(8px);
+    }
+    #legend {
+      position: absolute; bottom: 16px; left: 16px; z-index: 100;
+      background: rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 12px; padding: 12px 16px;
+      backdrop-filter: blur(12px); max-height: 40vh; overflow-y: auto;
+    }
+    .leg-item { display: flex; align-items: center; gap: 8px; margin: 3px 0; }
+    .leg-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+    .leg-lbl { font-size: 10px; color: #888; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; }
+    .leg-cnt { font-size: 10px; color: #444; margin-left: auto; }
+`;
+
+/* ── Classic Mode: d3-force + Canvas (same engine as the website) ── */
+function generateClassicHTML(
+  dataJson: string,
+  nodeColorsJson: string,
+  edgeColorsJson: string
+): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Interactive Code Graph</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>${SHARED_CSS}
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+  <div id="controls">
+    <button class="btn active" id="btn-layout">Stop Layout</button>
+    <button class="btn" id="btn-reset">Reset View</button>
+  </div>
+  <div id="tooltip"></div>
+  <div id="legend"></div>
+  <canvas id="canvas"></canvas>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  <script>
+  (function() {
+    var rawData = ${dataJson};
+    var NC = ${nodeColorsJson};
+    var EC = ${edgeColorsJson};
+
+    var nodes = rawData.nodes;
+    var links = rawData.links;
+    var canvas = document.getElementById('canvas');
+    var ctx = canvas.getContext('2d');
+    var W = window.innerWidth, H = window.innerHeight;
+    canvas.width = W; canvas.height = H;
+
+    /* sizing — matches website logic */
+    var N = nodes.length;
+    var nScale = N > 3000 ? 0.3 : N > 1000 ? 0.5 : N > 400 ? 0.7 : 1.0;
+    var nSize = 3.0;
+
+    /* force simulation — same params as ForceGraph2D on the website */
+    var sim = d3.forceSimulation(nodes)
+      .force('link', d3.forceLink(links).id(function(d){return d.id}).distance(30).strength(0.3))
+      .force('charge', d3.forceManyBody().strength(N > 1000 ? -15 : -30))
+      .force('center', d3.forceCenter(0, 0))
+      .force('collision', d3.forceCollide().radius(function(d){return Math.max(2,(d.val||1)*0.8*nSize*nScale)}))
+      .velocityDecay(0.4)
+      .alphaDecay(0.05)
+      .on('tick', render);
+
+    var tx = W/2, ty = H/2, tk = 1;
+    var hovered = null;
+
+    function rgba(hex, a) {
+      if (!hex || hex[0] !== '#') return 'rgba(100,100,100,' + a + ')';
+      var r = parseInt(hex.slice(1,3),16), g = parseInt(hex.slice(3,5),16), b = parseInt(hex.slice(5,7),16);
+      return 'rgba('+r+','+g+','+b+','+a+')';
+    }
+
+    function render() {
+      ctx.clearRect(0,0,W,H);
+      ctx.fillStyle = '#020202';
+      ctx.fillRect(0,0,W,H);
+      ctx.save();
+      ctx.translate(tx,ty);
+      ctx.scale(tk,tk);
+      var gs = tk;
+
+      /* draw links */
+      for (var i = 0; i < links.length; i++) {
+        var l = links[i], s = l.source, t = l.target;
+        if (!s || !t || !isFinite(s.x) || !isFinite(t.x)) continue;
+        ctx.beginPath();
+        ctx.moveTo(s.x,s.y);
+        ctx.lineTo(t.x,t.y);
+        ctx.strokeStyle = rgba(EC[l.type] || '#ffffff', 0.25);
+        ctx.lineWidth = Math.max(0.15, 0.5 / gs);
+        ctx.stroke();
+      }
+
+      /* draw nodes */
+      for (var i = 0; i < nodes.length; i++) {
+        var nd = nodes[i];
+        if (!isFinite(nd.x) || !isFinite(nd.y)) continue;
+        var col = NC[nd.type] || NC.Other || '#42a5f5';
+        var r = Math.max(0.5, (nd.val||1) * 0.8 * nSize * nScale);
+        var isH = hovered && nd.id === hovered.id;
+
+        /* hover halo */
+        if (isH) {
+          ctx.beginPath();
+          ctx.arc(nd.x, nd.y, r*2.5, 0, 6.283);
+          ctx.fillStyle = rgba(col, 0.3);
+          ctx.fill();
+        }
+
+        /* circle */
+        ctx.beginPath();
+        ctx.arc(nd.x, nd.y, r, 0, 6.283);
+        ctx.fillStyle = col;
+        ctx.fill();
+
+        /* label */
+        var showLbl = isH || gs > 2.0;
+        if (showLbl && nd.name) {
+          var fs = Math.max(2, Math.round((isH ? 14 : 10) / gs));
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillStyle = isH ? '#ffffff' : '#c0c0c0';
+          ctx.font = (isH ? 'bold ' : '') + fs + 'px Inter,sans-serif';
+          ctx.shadowColor = '#000'; ctx.shadowBlur = 4;
+          ctx.fillText(nd.name, nd.x, nd.y + r + fs/2 + 4);
+          ctx.shadowBlur = 0;
+        }
+      }
+      ctx.restore();
+    }
+
+    /* d3-zoom for pan/zoom */
+    var zoomBeh = d3.zoom().scaleExtent([0.01,100])
+      .on('zoom', function(e){ tx=e.transform.x; ty=e.transform.y; tk=e.transform.k; render(); });
+    d3.select(canvas).call(zoomBeh).call(zoomBeh.transform, d3.zoomIdentity.translate(W/2,H/2));
+
+    /* hover detection */
+    canvas.addEventListener('mousemove', function(e) {
+      var mx = (e.clientX - tx)/tk, my = (e.clientY - ty)/tk;
+      var found = null, best = Infinity;
+      for (var i = 0; i < nodes.length; i++) {
+        var nd = nodes[i];
+        if (!isFinite(nd.x)) continue;
+        var rr = Math.max(3, (nd.val||1)*0.8*nSize*nScale);
+        var dd = Math.hypot(nd.x-mx, nd.y-my);
+        if (dd < rr*1.5 && dd < best) { found = nd; best = dd; }
+      }
+      if (found !== hovered) { hovered = found; if (sim.alpha() < 0.01) render(); }
+      canvas.style.cursor = found ? 'pointer' : 'grab';
+      var tip = document.getElementById('tooltip');
+      if (found) {
+        var c = NC[found.type] || '#42a5f5';
+        tip.innerHTML = '<strong>' + (found.name||'?') + '</strong><br><span style="color:'+c+';font-size:10px;text-transform:uppercase;letter-spacing:0.05em;font-weight:700">' + found.type + '</span>';
+        tip.style.display = 'block';
+        tip.style.left = (e.clientX+15)+'px';
+        tip.style.top = (e.clientY+15)+'px';
+      } else { tip.style.display = 'none'; }
+    });
+
+    /* layout toggle */
+    var running = true;
+    document.getElementById('btn-layout').addEventListener('click', function(){
+      if (running) { sim.stop(); running=false; this.textContent='Start Layout'; this.classList.remove('active'); }
+      else { sim.alpha(1).restart(); running=true; this.textContent='Stop Layout'; this.classList.add('active'); }
+    });
+
+    /* reset view */
+    document.getElementById('btn-reset').addEventListener('click', function(){
+      d3.select(canvas).transition().duration(500).call(zoomBeh.transform, d3.zoomIdentity.translate(W/2,H/2));
+    });
+
+    /* resize */
+    window.addEventListener('resize', function(){ W=innerWidth; H=innerHeight; canvas.width=W; canvas.height=H; render(); });
+
+    /* legend */
+    var types = {};
+    nodes.forEach(function(n){ types[n.type] = (types[n.type]||0)+1; });
+    var leg = document.getElementById('legend');
+    leg.innerHTML = Object.entries(types).sort(function(a,b){return b[1]-a[1]}).map(function(e){
+      var c = NC[e[0]] || '#42a5f5';
+      return '<div class="leg-item"><span class="leg-dot" style="background:'+c+'"></span><span class="leg-lbl">'+e[0]+'</span><span class="leg-cnt">'+e[1]+'</span></div>';
+    }).join('');
+  })();
+  </script>
+</body>
+</html>`;
+}
+
+/* ── Flowchart Mode: Vanilla JS tree layout + SVG ──────────────────── */
+function generateFlowchartHTML(
+  dataJson: string,
+  nodeColorsJson: string,
+  edgeColorsJson: string
+): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Interactive Flowchart</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>${SHARED_CSS}
+    svg { display: block; background: #020202; }
+    .node-body { transition: fill 0.15s; }
+    .node-body:hover { fill: #181822 !important; }
+    .expand-btn { cursor: pointer; }
+    .expand-btn:hover rect { fill-opacity: 0.3; }
+    #orphan-btn {
+      position: absolute; bottom: 16px; right: 16px; z-index: 10;
+      padding: 6px 18px; border-radius: 9999px;
+      background: rgba(17,17,24,0.9); color: #888;
+      border: 1px solid rgba(255,255,255,0.1);
+      font-size: 10px; font-weight: 700; letter-spacing: 0.06em;
+      cursor: pointer; backdrop-filter: blur(8px);
+      transition: all 0.2s;
+    }
+    #orphan-btn.active { background: rgba(30,30,46,0.9); border-color: rgba(245,158,11,0.35); color: #f59e0b; }
+  </style>
+</head>
+<body>
+  <div id="controls">
+    <button class="btn" id="btn-reset">Reset View</button>
+  </div>
+  <div id="tooltip"></div>
+  <div id="legend"></div>
+  <svg id="chart"></svg>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  <script>
+  (function() {
+    var rawData = ${dataJson};
+    var NC = ${nodeColorsJson};
+    var EC = ${edgeColorsJson};
+
+    var NODE_W = 200, NODE_H = 40, LEVEL_GAP = 280, NODE_GAP = 16, SLOT_R = 3.5;
+    var nodes = rawData.nodes;
+    var links = rawData.links;
+
+    var W = window.innerWidth, H = window.innerHeight;
+    var svg = d3.select('#chart').attr('width', W).attr('height', H);
+
+    /* build containment tree */
+    var nodeMap = new Map(nodes.map(function(n){return [String(n.id), n]}));
+    var childMap = new Map();
+    var parentMap = new Map();
+    var crossLinks = [];
+
+    links.forEach(function(l) {
+      var s = String(l.source), t = String(l.target);
+      if (l.type === 'CONTAINS') {
+        if (!childMap.has(s)) childMap.set(s, []);
+        childMap.get(s).push(t);
+        parentMap.set(t, s);
+      } else { crossLinks.push({source:s, target:t, type:l.type}); }
+    });
+
+    var roots = nodes.filter(function(n){return !parentMap.has(String(n.id))}).map(function(n){return String(n.id)});
+    var orphanIds = new Set(roots.filter(function(r){ return !(childMap.get(r)||[]).some(function(k){return nodeMap.has(k)}); }));
+    var expanded = new Set(roots);
+    var positions = new Map();
+    var showOrphans = false;
+
+    /* compute visible nodes */
+    function getVisible() {
+      var vis = new Set();
+      var q = roots.slice();
+      while (q.length) {
+        var id = q.shift();
+        if (!nodeMap.has(id)) continue;
+        if (orphanIds.has(id) && !showOrphans) continue;
+        vis.add(id);
+        if (expanded.has(id)) {
+          var kids = childMap.get(id) || [];
+          kids.forEach(function(k){ if(nodeMap.has(k)) q.push(k); });
+        }
+      }
+      return vis;
+    }
+
+    function hasKids(id) { return (childMap.get(id)||[]).some(function(k){return nodeMap.has(k)}); }
+    function kidCount(id) { return (childMap.get(id)||[]).filter(function(k){return nodeMap.has(k)}).length; }
+
+    /* layout */
+    function doLayout() {
+      var vis = getVisible();
+      positions = new Map();
+
+      function subtreeH(id) {
+        if (!expanded.has(id) || !vis.has(id)) return NODE_H;
+        var kids = (childMap.get(id)||[]).filter(function(k){return vis.has(k)});
+        if (!kids.length) return NODE_H;
+        return kids.reduce(function(s,k){return s + subtreeH(k) + NODE_GAP}, -NODE_GAP);
+      }
+
+      function place(id, x, yCenter) {
+        positions.set(id, {x: x, y: yCenter - NODE_H/2});
+        if (!expanded.has(id)) return;
+        var kids = (childMap.get(id)||[]).filter(function(k){return vis.has(k)});
+        if (!kids.length) return;
+        var total = subtreeH(id);
+        var oy = yCenter - total/2;
+        kids.forEach(function(kid) {
+          var kh = subtreeH(kid);
+          place(kid, x + LEVEL_GAP, oy + kh/2);
+          oy += kh + NODE_GAP;
+        });
+      }
+
+      var treeRoots = roots.filter(function(r){return vis.has(r) && !orphanIds.has(r)});
+      var totalH = treeRoots.reduce(function(s,r){ return s + subtreeH(r) + NODE_GAP*3; }, 0);
+      var y = -totalH/2;
+      treeRoots.forEach(function(r) {
+        var rh = subtreeH(r);
+        place(r, 40, y + rh/2);
+        y += rh + NODE_GAP*3;
+      });
+
+      if (showOrphans) {
+        var orphans = roots.filter(function(r){return orphanIds.has(r) && vis.has(r)});
+        var maxX = 40;
+        positions.forEach(function(p) { if (p.x + NODE_W > maxX) maxX = p.x + NODE_W; });
+        var orphanStartX = maxX + LEVEL_GAP;
+        var COLS = 2, COL_W = NODE_W + 20, ROW_H = NODE_H + NODE_GAP, gridTop = -totalH/2;
+        for (var i = 0; i < orphans.length; i++) {
+          var col = i % COLS, row = Math.floor(i / COLS);
+          positions.set(orphans[i], { x: orphanStartX + col * COL_W, y: gridTop + row * ROW_H });
+        }
+      }
+
+      return vis;
+    }
+
+    /* rendering */
+    /* defs */
+    var defs = svg.append('defs');
+    defs.append('filter').attr('id','glow').attr('x','-20%').attr('y','-20%').attr('width','140%').attr('height','140%')
+      .append('feGaussianBlur').attr('stdDeviation','3').attr('result','blur');
+    /* grid pattern */
+    var pat = defs.append('pattern').attr('id','grid').attr('width',40).attr('height',40).attr('patternUnits','userSpaceOnUse');
+    pat.append('path').attr('d','M 40 0 L 0 0 0 40').attr('fill','none').attr('stroke','#0d0d14').attr('stroke-width',0.6);
+
+    svg.append('rect').attr('width',W).attr('height',H).attr('fill','url(#grid)').style('pointer-events','none');
+    var gMain = svg.append('g');
+
+    /* zoom */
+    var zoomBeh = d3.zoom().scaleExtent([0.04, 4])
+      .on('zoom', function(e) {
+        gMain.attr('transform', e.transform);
+        pat.attr('patternTransform', 'translate('+e.transform.x+','+e.transform.y+') scale('+e.transform.k+')');
+      });
+    svg.call(zoomBeh).call(zoomBeh.transform, d3.zoomIdentity.translate(W/2, H/2).scale(0.65));
+
+    document.getElementById('btn-reset').addEventListener('click', function() {
+      svg.transition().duration(500).call(zoomBeh.transform, d3.zoomIdentity.translate(W/2,H/2).scale(0.65));
+    });
+
+    function draw() {
+      gMain.selectAll('*').remove();
+      var vis = doLayout();
+
+      /* edges */
+      var gEdges = gMain.append('g');
+
+      /* CONTAINS edges */
+      vis.forEach(function(id) {
+        if (!expanded.has(id)) return;
+        var sp = positions.get(id);
+        if (!sp) return;
+        (childMap.get(id)||[]).filter(function(k){return vis.has(k)}).forEach(function(kid) {
+          var tp = positions.get(kid);
+          if (!tp) return;
+          var sx = sp.x + NODE_W, sy = sp.y + NODE_H/2;
+          var txx = tp.x, tyy = tp.y + NODE_H/2;
+          var mx = (sx+txx)/2;
+          gEdges.append('path')
+            .attr('d', 'M'+sx+','+sy+' C'+mx+','+sy+' '+mx+','+tyy+' '+txx+','+tyy)
+            .attr('fill','none').attr('stroke','#4a4a5a').attr('stroke-width',1.6).attr('opacity',0.7);
+        });
+      });
+
+      /* cross-link edges */
+      crossLinks.forEach(function(cl) {
+        if (!vis.has(cl.source) || !vis.has(cl.target)) return;
+        var sp = positions.get(cl.source), tp = positions.get(cl.target);
+        if (!sp || !tp) return;
+        var sx = sp.x + NODE_W, sy = sp.y + NODE_H/2;
+        var txx = tp.x, tyy = tp.y + NODE_H/2;
+        var mx = (sx+txx)/2;
+        var col = EC[cl.type] || '#555';
+        gEdges.append('path')
+          .attr('d', 'M'+sx+','+sy+' C'+mx+','+sy+' '+mx+','+tyy+' '+txx+','+tyy)
+          .attr('fill','none').attr('stroke',col).attr('stroke-width',2).attr('opacity',0.85)
+          .attr('stroke-dasharray','6 3');
+      });
+
+      /* nodes */
+      var gNodes = gMain.append('g');
+      vis.forEach(function(id) {
+        var nd = nodeMap.get(id);
+        var pos = positions.get(id);
+        if (!nd || !pos) return;
+        var color = NC[nd.type] || '#78909c';
+        var isExp = expanded.has(id);
+        var hk = hasKids(id);
+        var kc = kidCount(id);
+
+        var g = gNodes.append('g').attr('transform','translate('+pos.x+','+pos.y+')').style('cursor','pointer');
+
+        /* body */
+        g.append('rect').attr('class','node-body')
+          .attr('width',NODE_W).attr('height',NODE_H).attr('rx',6)
+          .attr('fill','#0e0e14').attr('stroke',color).attr('stroke-width',1).attr('opacity',0.95);
+
+        /* connection slots */
+        g.append('circle').attr('cx',0).attr('cy',NODE_H/2).attr('r',SLOT_R).attr('fill',color).attr('opacity',0.5);
+        g.append('circle').attr('cx',NODE_W).attr('cy',NODE_H/2).attr('r',SLOT_R).attr('fill',color).attr('opacity',0.5);
+
+        /* name */
+        var name = (nd.name||'Unknown');
+        if (name.length > 22) name = name.slice(0,20) + '\\u2026';
+        g.append('text').attr('x',12).attr('y',16)
+          .attr('font-size',12).attr('font-family','Inter,system-ui,sans-serif').attr('font-weight',600)
+          .attr('fill','#d4d4d8').style('pointer-events','none').text(name);
+
+        /* type badge */
+        g.append('text').attr('x',12).attr('y',33)
+          .attr('font-size',8).attr('font-family','Inter,system-ui,sans-serif').attr('font-weight',700)
+          .attr('fill',color).attr('opacity',0.55).style('pointer-events','none')
+          .style('letter-spacing','0.08em').text((nd.type||'').toUpperCase());
+
+        /* expand/collapse */
+        if (hk) {
+          var btn = g.append('g').attr('class','expand-btn');
+          btn.append('rect')
+            .attr('x',NODE_W-30).attr('y',(NODE_H-18)/2).attr('width',24).attr('height',18).attr('rx',4)
+            .attr('fill',isExp ? color : color).attr('fill-opacity', isExp ? 0.13 : 0.07)
+            .attr('stroke',color).attr('stroke-width',0.5);
+          btn.append('text')
+            .attr('x',NODE_W-18).attr('y',NODE_H/2+1)
+            .attr('font-size',11).attr('font-weight',700).attr('text-anchor','middle').attr('dominant-baseline','middle')
+            .attr('fill',color).style('pointer-events','none')
+            .text(isExp ? '\\u2212' : '+'+kc);
+          btn.on('click', function(e) {
+            e.stopPropagation();
+            if (expanded.has(id)) expanded.delete(id); else expanded.add(id);
+            draw();
+          });
+        }
+
+        /* hover tooltip */
+        g.on('mouseenter', function(e) {
+          var tip = document.getElementById('tooltip');
+          tip.innerHTML = '<strong>'+(nd.name||'?')+'</strong><br><span style="color:'+color+';font-size:10px;text-transform:uppercase;letter-spacing:0.05em;font-weight:700">'+(nd.type||'')+'</span>';
+          tip.style.display = 'block';
+          tip.style.left = (e.clientX+15)+'px';
+          tip.style.top = (e.clientY+15)+'px';
+        });
+        g.on('mouseleave', function() { document.getElementById('tooltip').style.display='none'; });
+      });
+    }
+
+    draw();
+
+    /* orphans toggle */
+    if (orphanIds.size > 0) {
+      var btn = document.createElement('button');
+      btn.id = 'orphan-btn';
+      btn.textContent = 'SHOW ' + orphanIds.size + ' EXTERNAL';
+      document.body.appendChild(btn);
+      btn.addEventListener('click', function() {
+        showOrphans = !showOrphans;
+        btn.textContent = (showOrphans ? 'HIDE ' : 'SHOW ') + orphanIds.size + ' EXTERNAL';
+        if (showOrphans) btn.classList.add('active'); else btn.classList.remove('active');
+        draw();
+      });
+    }
+
+    /* legend */
+    var types = {};
+    nodes.forEach(function(n){ types[n.type] = (types[n.type]||0)+1; });
+    var leg = document.getElementById('legend');
+    leg.innerHTML = Object.entries(types).sort(function(a,b){return b[1]-a[1]}).map(function(e){
+      var c = NC[e[0]] || '#78909c';
+      return '<div class="leg-item"><span class="leg-dot" style="background:'+c+'"></span><span class="leg-lbl">'+e[0]+'</span><span class="leg-cnt">'+e[1]+'</span></div>';
+    }).join('');
+
+    /* resize */
+    window.addEventListener('resize', function(){ W=innerWidth; H=innerHeight; svg.attr('width',W).attr('height',H); });
+  })();
+  </script>
+</body>
+</html>`;
+}
+
+/* ── Main export function ──────────────────────────────────────────── */
+export async function packageInteractiveExport(
+  nodes: GraphNode[],
+  links: GraphLink[],
+  metadata: GraphMetadata,
+  nodeColors: Record<string, string>,
+  edgeColors: Record<string, string>,
+  mode: 'classic' | 'mermaid' = 'classic'
+): Promise<Blob> {
+  const zip = new JSZip();
+
+  // Serialize graph data in d3-compatible format
+  const graphData = {
+    nodes: nodes.map(n => ({
+      id: String(n.id),
+      name: n.name || String(n.id),
+      type: n.type,
+      val: n.val || 1,
+      file: n.file || ''
+    })),
+    links: links.map(l => {
+      const sourceId = typeof l.source === 'object' ? l.source.id : l.source;
+      const targetId = typeof l.target === 'object' ? l.target.id : l.target;
+      return { source: String(sourceId), target: String(targetId), type: l.type };
+    }),
+    metadata
+  };
+
+  const graphDataJson = JSON.stringify(graphData, null, 2);
+  zip.file("graph-data.json", graphDataJson);
+
+  // Serialize colors
+  const nodeColorsJson = JSON.stringify(nodeColors);
+  const edgeColorsJson = JSON.stringify(edgeColors);
+
+  // Compact data json for inline use (no pretty-print)
+  const inlineDataJson = JSON.stringify(graphData);
+
+  // Generate HTML based on mode
+  const htmlContent = mode === 'mermaid'
+    ? generateFlowchartHTML(inlineDataJson, nodeColorsJson, edgeColorsJson)
+    : generateClassicHTML(inlineDataJson, nodeColorsJson, edgeColorsJson);
+
+  zip.file("index.html", htmlContent);
+
+  // README
+  const repoStr = metadata.repo || 'Unknown Repository';
+  const readmeContent = `# Code Graph Export: ${repoStr}
+
+This is an interactive HTML export of the code graph from CodeGraphContext.
+
+## Usage
+1. Open \`index.html\` in any modern web browser.
+2. **Pan**: Click and drag the background.
+3. **Zoom**: Scroll wheel.
+4. **Hover**: Mouse over nodes to see details.
+${mode === 'classic' ? '5. **Layout**: Use the Stop/Start Layout button to control physics simulation.' : '5. **Expand/Collapse**: Click the +/− buttons on nodes to explore the tree.'}
+6. **Reset**: Click Reset View to return to default zoom.
+
+## Data
+The raw graph data is available in \`graph-data.json\`.
+
+Generated by [CodeGraphContext](https://codegraphcontext.com).`;
+
+  zip.file("README.md", readmeContent);
+
+  return await zip.generateAsync({ type: "blob" });
+}

--- a/website/src/lib/supabase-client.ts
+++ b/website/src/lib/supabase-client.ts
@@ -1,17 +1,17 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
-const DEFAULT_URL = "https://husyiuqyswpudlyuskno.supabase.co";
-const DEFAULT_ANON_KEY =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh1c3lpdXF5c3dwdWRseXVza25vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk2NDUwNDYsImV4cCI6MjA5NTIyMTA0Nn0.dNCRxdGlL5vgug0sB4BwhCfBx_nAt9oR0RT2Upv0al8";
-
 let sharedClient: SupabaseClient | null = null;
 
 /** Single Supabase client for realtime tunnels (avoids duplicate GoTrueClient warnings). */
 export function getSupabaseClient(): SupabaseClient {
   if (sharedClient) return sharedClient;
 
-  const url = import.meta.env.VITE_SUPABASE_URL || DEFAULT_URL;
-  const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || DEFAULT_ANON_KEY;
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  
+  if (!url || !anonKey) {
+    throw new Error("Missing Supabase environment variables: VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY");
+  }
   sharedClient = createClient(url, anonKey, {
     realtime: { params: { eventsPerSecond: 10 } },
   });

--- a/website/src/lib/svg-exporter.ts
+++ b/website/src/lib/svg-exporter.ts
@@ -34,6 +34,22 @@ export async function exportSvg(
   const bgColor = isDark ? '#020202' : '#f5f5f7';
   const textColor = isDark ? '#ffffff' : '#1a1a1a';
 
+  // Collect unique edge colors
+  const uniqueEdgeColors = new Set<string>();
+  links.forEach((link: any) => {
+    const color = edgeColors[link.type] || (isDark ? '#ffffff' : '#000000');
+    uniqueEdgeColors.add(color);
+  });
+
+  // Build marker defs
+  const markerDefs = Array.from(uniqueEdgeColors).map(color => {
+    const id = 'arrow-' + color.replace('#', '');
+    return `<marker id="${id}" viewBox="0 0 10 10" refX="9" refY="5"
+      markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="${color}" opacity="0.6"/>
+    </marker>`;
+  }).join('\n');
+
   // Build SVG string
   const svgElements: string[] = [];
   
@@ -52,9 +68,10 @@ export async function exportSvg(
       const y2 = targetPos.y - minY + padding;
       
       const linkColor = edgeColors[link.type] || (isDark ? '#ffffff' : '#000000');
+      const arrowId = 'arrow-' + linkColor.replace('#', '');
       
       svgElements.push(
-        `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${linkColor}" stroke-opacity="0.3" stroke-width="0.8" />`
+        `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${linkColor}" stroke-opacity="0.3" stroke-width="0.8" marker-end="url(#${arrowId})" />`
       );
     }
   });
@@ -66,7 +83,9 @@ export async function exportSvg(
       const cx = pos.x - minX + padding;
       const cy = pos.y - minY + padding;
       const color = nodeColors[node.type] || nodeColors.Other || '#42a5f5';
-      const r = (node.val || 1) * 2;
+      const N = nodes.length;
+      const nScale = N > 3000 ? 0.3 : N > 1000 ? 0.5 : N > 400 ? 0.7 : 1.0;
+      const r = Math.max(1.5, (node.val || 1) * 0.8 * 3.0 * nScale);
       
       svgElements.push(
         `<circle cx="${cx}" cy="${cy}" r="${r}" fill="${color}" stroke="${isDark ? '#000000' : '#ffffff'}" stroke-width="0.5" />`
@@ -81,8 +100,9 @@ export async function exportSvg(
           .replace(/"/g, '&quot;')
           .replace(/'/g, '&apos;');
           
+        const fontSize = Math.max(8, r * 1.5);
         svgElements.push(
-          `<text x="${cx}" y="${cy + r + 4}" font-family="sans-serif" font-size="4" fill="${textColor}" text-anchor="middle">${safeLabel}</text>`
+          `<text x="${cx}" y="${cy + r + fontSize + 2}" font-family="Inter, ui-monospace, sans-serif" font-size="${fontSize}" fill="${textColor}" text-anchor="middle">${safeLabel}</text>`
         );
       }
     }
@@ -90,6 +110,9 @@ export async function exportSvg(
 
   const svgString = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" style="background-color: ${bgColor};">
+  <defs>
+    ${markerDefs}
+  </defs>
   ${svgElements.join('\n  ')}
 </svg>`;
 

--- a/website/src/lib/svg-exporter.ts
+++ b/website/src/lib/svg-exporter.ts
@@ -1,0 +1,106 @@
+// SVG Exporter — reconstructs an SVG from live d3-force positions
+
+export async function exportSvg(
+  graphData: { nodes: any[], links: any[] },
+  nodeColors: Record<string, string> = {},
+  edgeColors: Record<string, string> = {},
+  isDark: boolean = true
+) {
+  if (!graphData) return;
+
+  const { nodes, links } = graphData;
+  
+  if (!nodes || nodes.length === 0) return;
+
+  // Build a position map and compute bounding box
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  const posMap: Record<string, { x: number, y: number }> = {};
+  
+  nodes.forEach((node: any) => {
+    if (typeof node.x === 'number' && typeof node.y === 'number') {
+      const x = node.x;
+      const y = node.y;
+      posMap[node.id] = { x, y };
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+    }
+  });
+
+  const padding = 50;
+  const width = (maxX - minX) + padding * 2;
+  const height = (maxY - minY) + padding * 2;
+  const bgColor = isDark ? '#020202' : '#f5f5f7';
+  const textColor = isDark ? '#ffffff' : '#1a1a1a';
+
+  // Build SVG string
+  const svgElements: string[] = [];
+  
+  // Draw edges first
+  links.forEach((link: any) => {
+    const sourceId = typeof link.source === 'object' ? link.source.id : link.source;
+    const targetId = typeof link.target === 'object' ? link.target.id : link.target;
+    
+    const sourcePos = posMap[sourceId];
+    const targetPos = posMap[targetId];
+    
+    if (sourcePos && targetPos) {
+      const x1 = sourcePos.x - minX + padding;
+      const y1 = sourcePos.y - minY + padding;
+      const x2 = targetPos.x - minX + padding;
+      const y2 = targetPos.y - minY + padding;
+      
+      const linkColor = edgeColors[link.type] || (isDark ? '#ffffff' : '#000000');
+      
+      svgElements.push(
+        `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${linkColor}" stroke-opacity="0.3" stroke-width="0.8" />`
+      );
+    }
+  });
+
+  // Draw nodes on top
+  nodes.forEach((node: any) => {
+    const pos = posMap[node.id];
+    if (pos) {
+      const cx = pos.x - minX + padding;
+      const cy = pos.y - minY + padding;
+      const color = nodeColors[node.type] || nodeColors.Other || '#42a5f5';
+      const r = (node.val || 1) * 2;
+      
+      svgElements.push(
+        `<circle cx="${cx}" cy="${cy}" r="${r}" fill="${color}" stroke="${isDark ? '#000000' : '#ffffff'}" stroke-width="0.5" />`
+      );
+      
+      if (node.name) {
+        // Escape label text for XML safety
+        const safeLabel = node.name
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&apos;');
+          
+        svgElements.push(
+          `<text x="${cx}" y="${cy + r + 4}" font-family="sans-serif" font-size="4" fill="${textColor}" text-anchor="middle">${safeLabel}</text>`
+        );
+      }
+    }
+  });
+
+  const svgString = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" style="background-color: ${bgColor};">
+  ${svgElements.join('\n  ')}
+</svg>`;
+
+  // Output as Blob and trigger download
+  const blob = new Blob([svgString], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'graph-export.svg';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
# PR Description: Graph Export Overhaul & Offline Support
 
closes #993 

### SVG Export Overhaul & Fixes

- **Node Parity**: SVG node radius logic to exactly match the website's `nScale` sizing formula (based on total node counts).
- **Typography Parity**:  dynamically scaled `font-size` based on the node radius, utilizing the `Inter` font family.
- **Directional Arrows**: Added a dynamic `<defs>` block that generates `<marker>` arrowhead elements for every unique link color and appends `marker-end` to directed edges in the SVG.
- **Flowchart SVG**: For Mermaid mode, since we *do* render a real `<svg>` in the DOM (`FlowchartSVG.tsx`), we clone the `outerHTML` to perfectly preserve grid backgrounds, dimensions, and styling.

###  Interactive HTML Export Rewrite

- **Classic Engine Clone**: wrote the exporter to use `d3-force` + `<canvas>`. Replicated the exact physics parameters (`velocityDecay`, `alphaDecay`, `forceCollide`) and adaptive canvas drawing routines to clone the site.
- **Flowchart Engine Clone**: Wrote a vanilla JS tree layout algorithm replicating `FlowchartSVG.tsx`. The containment tree builds from `CONTAINS` links, features clickable expand/collapse buttons (`+/-`), properly maps dashed cross-links, and uses D3 for pan/zoom.
- **Offline D3 Bundling**: The HTML exporter now uses an internal `fetchD3()` helper to grab the d3 library and inline it inside the HTML `<script>` tags, guaranteeing that exports (Classic & Flowchart) will fully render and function offline.

###  UI / Layout Bug Fixes
- **Orphan Nodes Layout**: Previously, the HTML exporter stacked all 200+ external/orphan modules into a single massive vertical column. We ported the `FlowchartSVG` logic to filter out orphans by default, formatting them into a neat 2-column grid when toggled on.
- **"Show External" Button Overlap**: The orphan toggle was moved out of the SVG coordinate system and placed into a fixed HTML `<button>` overlay at the `bottom-right` corner, resolving overlap issues with the legend.
- **Simulation Button State**: Added an effect to `CodeGraphViewer.tsx` to automatically call `setSimulationReady(false)` when `filteredData` changes, fixing a bug where the SVG export button wouldn't disable correctly during layout resets.


##  Files Modified / Added
- `website/src/lib/svg-exporter.ts`
- `website/src/lib/html-exporter.ts`
- `website/src/components/FlowchartSVG.tsx`
- `website/src/components/CodeGraphViewer.tsx`
- `website/src/lib/supabase-client.ts`
