### PR TITLE
Add SCIP support for .hh C++ header files

### DIFF
--- a/src/codegraphcontext/tools/scip_indexer.py
+++ b/src/codegraphcontext/tools/scip_indexer.py
@@ -68,6 +68,7 @@ EXTENSION_TO_SCIP: Dict[str, Tuple[str, str, str, str]] = {
     ".dart":  ("dart",       "scip_dart",       "dart pub global activate scip_dart", "dart:stable"),
     ".cpp":   ("cpp",        "scip-clang",      "brew install llvm", "sourcegraph/scip-clang:sha-1704d3d"),
     ".hpp":   ("cpp",        "scip-clang",      "brew install llvm", "sourcegraph/scip-clang:sha-1704d3d"),
+    ".hh":    ("cpp",        "scip-clang",      "brew install llvm", "sourcegraph/scip-clang:sha-1704d3d"),
     ".c":     ("c",          "scip-clang",      "brew install llvm", "sourcegraph/scip-clang:sha-1704d3d"),
     ".h":     ("cpp",        "scip-clang",      "brew install llvm", "sourcegraph/scip-clang:sha-1704d3d"),
     ".cs":    ("csharp",     "scip-dotnet",     "dotnet tool install -g Microsoft.CodeAnalysis.ScipDotnet", "sourcegraph/scip-dotnet"),


### PR DESCRIPTION
## Summary

Adds support for `.hh` C++ header files in the SCIP indexer by registering the extension in `EXTENSION_TO_SCIP`.

## Changes

* Added `.hh` extension mapping to the C++ SCIP configuration in `scip_indexer.py`

## Why

`.hh` files are already recognized throughout the codebase in several C++ parsing and indexing paths, but they were not registered in the SCIP extension mapping. As a result, SCIP indexing for `.hh` files was unavailable.

This change brings SCIP support in line with the existing `.h` and `.hpp` handling.

Fixes #643