### PR TITLE
fix(writer): purge all repo-scoped labels via db.labels() in delete_repository_from_graph

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -1349,8 +1349,23 @@ class GraphWriter:
                 break
             info_logger(f"[DELETE] Removed {deleted} CONTAINS rels for {repo_path_str}")
 
-        for label in ("Function", "Class", "Interface", "Trait", "Struct", "Enum", "Variable", "Macro", "Union", "Record", "Property", "File", "Module", "Mixin", "Extension", "Object", "Parameter", "Directory", "Repository", "ExternalClass", "DbTable"):
+        # Discover the labels currently in use rather than hardcoding the
+        # list. Every time the indexer learned a new node type (Variable,
+        # Parameter, Directory, ExternalClass, DbTable, ...) the hardcoded
+        # tuple here had to be kept in lockstep, and every miss leaked
+        # orphan nodes on `delete_repository`. `CALL db.labels()` returns
+        # exactly the set of labels that have at least one node in the
+        # current database -- per-label DETACH DELETE with the same path
+        # prefix is then label-agnostic and self-maintaining.
+        #
+        # Labels with no node matching the path prefix are cheap: the
+        # label-scoped scan returns 0 rows, the while-True loop exits
+        # immediately, and we move on.
+        with self.driver.session() as session:
+            label_records = session.run("CALL db.labels() YIELD label RETURN label")
+            all_labels = sorted({record["label"] for record in label_records})
 
+        for label in all_labels:
             while True:
                 with self.driver.session() as session:
                     result = session.run(

--- a/tests/unit/tools/test_graph_builder_perf_fixes.py
+++ b/tests/unit/tools/test_graph_builder_perf_fixes.py
@@ -526,11 +526,41 @@ class TestAddFileToGraph:
 # 4. delete_repository_from_graph (Changes 9a/9b/9c)
 # ---------------------------------------------------------------------------
 
+class _DeleteRepoSession(_RecordingSession):
+    """RecordingSession that intercepts `CALL db.labels()` queries and
+    returns a fixed label list without consuming a slot in the responses
+    queue, so positional fixtures stay focused on deletion counts and
+    aren't disturbed by the new label-discovery query in the implementation."""
+
+    def __init__(self, labels, responses=None):
+        super().__init__(responses=responses)
+        self._labels = list(labels)
+
+    def run(self, query: str, **kwargs):
+        self.calls.append({"query": query, "kwargs": kwargs})
+        if "db.labels()" in query:
+            return _FakeResult([{"label": lbl} for lbl in self._labels])
+        if self._call_idx < len(self._responses):
+            result = self._responses[self._call_idx]
+        else:
+            result = _FakeResult()
+        self._call_idx += 1
+        return result
+
+
 class TestDeleteRepositoryFromGraph:
     """Tests for delete_repository_from_graph (batched, rels-first, orphan purge)."""
 
-    def _make_repo_exists_session(self, extra_responses=None):
+    # Default set of labels returned by the mocked `CALL db.labels()` --
+    # covers the labels the existing assertions still expect to see in
+    # node-deletion queries (Function, Class, File) while including one
+    # previously-leaking label (Variable) so the test reflects the bug
+    # this PR is closing.
+    _DEFAULT_DB_LABELS = ["Class", "File", "Function", "Variable"]
+
+    def _make_repo_exists_session(self, extra_responses=None, db_labels=None):
         """Session that reports the repo exists (cnt=1), then zero-counts to stop loops."""
+        labels = db_labels if db_labels is not None else self._DEFAULT_DB_LABELS
         responses = [
             _FakeResult([{"cnt": 1}]),  # repo existence check
         ]
@@ -540,7 +570,7 @@ class TestDeleteRepositoryFromGraph:
         else:
             # Enough zeros to drain all the while-True loops
             responses.extend([_FakeResult([{"deleted": 0}])] * 20)
-        return _RecordingSession(responses=responses)
+        return _DeleteRepoSession(labels=labels, responses=responses)
 
     def test_returns_false_when_repo_not_found(self):
         session = _RecordingSession(responses=[_FakeResult([{"cnt": 0}])])
@@ -593,6 +623,61 @@ class TestDeleteRepositoryFromGraph:
 
         queries = [c["query"] for c in session.calls]
         assert any("Repository" in q and ("DELETE" in q or "DETACH DELETE" in q) for q in queries)
+
+    def test_purges_labels_discovered_dynamically(self):
+        """Should DETACH DELETE every label that `CALL db.labels()` reports,
+        not a hardcoded subset -- otherwise nodes from any newly-added
+        indexer label leak as orphans on `delete_repository`.
+
+        Regression test for: pre-fix, the function iterated a fixed tuple
+        of (Function, Class, Interface, ..., DbTable). When the indexer
+        learned a new label, every `delete_repository` call against that
+        repo would leave the new label's nodes behind. The fix uses
+        `CALL db.labels()` so the per-label cleanup loop is self-
+        maintaining.
+        """
+        # Mock db.labels() returning a label that doesn't exist in any
+        # hardcoded list anywhere in this codebase -- proves the loop
+        # responds to whatever the running Neo4j actually contains.
+        session = self._make_repo_exists_session(
+            db_labels=["Function", "Class", "File", "SomeFutureLabelTheIndexerMightAdd"]
+        )
+        gb, _ = _make_graph_builder(session)
+        gb.delete_repository_from_graph("/my/repo")
+
+        queries = [c["query"] for c in session.calls]
+        assert any(
+            "SomeFutureLabelTheIndexerMightAdd" in q and "DETACH DELETE" in q
+            for q in queries
+        ), (
+            "Expected a DETACH DELETE query targeting every label returned by "
+            "`CALL db.labels()`, including labels not in any hardcoded list."
+        )
+
+    def test_calls_db_labels_after_existence_check(self):
+        """Label discovery should happen exactly once, after the repo
+        existence check passes, before any per-label deletion loops."""
+        session = self._make_repo_exists_session()
+        gb, _ = _make_graph_builder(session)
+        gb.delete_repository_from_graph("/my/repo")
+
+        queries = [c["query"] for c in session.calls]
+        labels_call_idx = next(
+            (i for i, q in enumerate(queries) if "db.labels()" in q), None
+        )
+        existence_idx = next(
+            (i for i, q in enumerate(queries) if "MATCH (r:Repository {path: $path})" in q and "count(r)" in q),
+            None,
+        )
+        node_delete_idx = next(
+            (i for i, q in enumerate(queries) if "DETACH DELETE n" in q), None
+        )
+        assert labels_call_idx is not None, "Expected exactly one `CALL db.labels()` query"
+        assert existence_idx is not None, "Expected the repo existence check"
+        assert node_delete_idx is not None, "Expected at least one DETACH DELETE for nodes"
+        assert existence_idx < labels_call_idx < node_delete_idx, (
+            "db.labels() must come after existence check and before per-label deletion"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`GraphWriter.delete_repository_from_graph` iterates a **hardcoded tuple** of node labels and DETACH-DELETEs only those. Every time the indexer learns a new node type, the tuple has to be updated in lockstep, and every miss leaks orphan nodes that can never be reached by the user-facing tools.

In a recent production environment running CGC `v0.4.7`, calling `delete_repository` on six indexed repositories cleanly removed every `Repository`, `File`, `Function` and `Class` node — but left behind **~43,000 orphan `Variable`** + **~17,000 orphan `Parameter`** + **~100 orphan `Directory`** nodes from those repos. These are invisible to `list_indexed_repositories`, `find_code`, `get_repository_stats`, `analyze_code_relationships`, and `generate_report` (all of which anchor on Repository / File / Function / Class), so the leak grows silently. There is no way to reclaim the space from the MCP surface either — `execute_cypher_query` correctly blocks write Cypher for safety, so an operator has to drop into a `cypher-shell` session against the Neo4j pod to manually `DETACH DELETE` the orphans.

`main` has since grown the tuple to 21 labels (`Function, Class, Interface, Trait, Struct, Enum, Variable, Macro, Union, Record, Property, File, Module, Mixin, Extension, Object, Parameter, Directory, Repository, ExternalClass, DbTable`), which closes the specific leak above, but doesn't fix the underlying fragility — the next indexer that adds a label will leak again, and there's no test that catches it.

## Fix

Replace the hardcoded label tuple with `CALL db.labels()` discovery:

```python
with self.driver.session() as session:
    label_records = session.run("CALL db.labels() YIELD label RETURN label")
    all_labels = sorted({record["label"] for record in label_records})

for label in all_labels:
    while True:
        ...  # same batched DETACH DELETE as before
```

Per-label DETACH DELETE with the path-prefix filter is now **label-agnostic and self-maintaining**:
- Any future node type the indexer adds is purged automatically with no source-code change.
- Labels with no matching node return zero in one query and the loop exits — extra labels are essentially free.
- Behaviour is otherwise identical: relationship deletion still happens first, batched `LIMIT 10000` still applies, the final standalone `Repository` node deletion is unchanged.

## Tests

- Updates `TestDeleteRepositoryFromGraph._make_repo_exists_session` to use a new `_DeleteRepoSession` subclass that intercepts the `CALL db.labels()` query inline, so the existing positional response queue stays focused on deletion counts and isn't disturbed by the new discovery query.
- Adds `test_purges_labels_discovered_dynamically` — the regression test. Mocks `db.labels()` to return a label name (`SomeFutureLabelTheIndexerMightAdd`) that doesn't appear in any hardcoded list anywhere in the codebase, and asserts a `DETACH DELETE` is issued against it. Pre-fix, this would have caught the `Variable` / `Parameter` / `Directory` leak from earlier versions.
- Adds `test_calls_db_labels_after_existence_check` — pins the ordering invariant (existence check → `db.labels()` → per-label deletion) so a future refactor can't accidentally fire the labels call too early or too late.

All 6 pre-existing `TestDeleteRepositoryFromGraph` tests + the 2 new tests pass locally. The other 41 tests in `test_graph_builder_perf_fixes.py` are unaffected.

## How to reproduce the original leak (on `main`, against a fresh CGC install)

1. `cgc index` a few small repos with `Variable` / `Parameter` / `Directory` nodes (any python project will do).
2. `delete_repository` each of them via the MCP `delete_repository` tool.
3. `list_indexed_repositories` is now empty.
4. `execute_cypher_query` with `MATCH (n:Variable) RETURN count(n)` — but wait, you can't, write Cypher is blocked. So:
5. Drop into a `cypher-shell` against the running Neo4j and run `MATCH (n) RETURN labels(n) AS lbl, count(*) ORDER BY count(*) DESC` — you'll see the orphan counts.

On `main` you'd need to add a brand-new label to the indexer to reproduce; this PR makes that scenario harmless by construction.