### PR TITLE
feat(cli): add Zed editor support to setup wizard

### DIFF
--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -107,7 +107,7 @@ def mcp_setup():
     Configure MCP Client (IDE/CLI Integration).
     
     Sets up CodeGraphContext integration with your IDE or CLI tool:
-    - VS Code, Cursor, Windsurf
+    - VS Code, Cursor, Windsurf, Zed
     - Claude Desktop, Gemini CLI
     - Cline, RooCode, Amazon Q Developer, Goose
     - OpenCode (prints stdio config + link to vendor docs)
@@ -124,7 +124,7 @@ def mcp_start():
     Start the CodeGraphContext MCP server.
     
     Starts the server which listens for JSON-RPC requests from stdin.
-    This is used by IDE integrations (VS Code, Cursor, etc.).
+    This is used by IDE integrations (VS Code, Cursor, Zed, etc.).
     """
     console.print("[bold green]Starting CodeGraphContext Server...[/bold green]")
     _load_credentials()

--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -256,7 +256,7 @@ def _configure_ide(mcp_config):
     questions = [
         {
             "type": "confirm",
-            "message": "Automatically configure your IDE/CLI (VS Code, Cursor, Windsurf, Claude, Gemini, Cline, RooCode, ChatGPT Codex, Amazon Q Developer, Aider, Kiro, Goose, Antigravity, OpenCode)?",
+            "message": "Automatically configure your IDE/CLI (VS Code, Cursor, Windsurf, Zed, Claude, Gemini, Cline, RooCode, ChatGPT Codex, Amazon Q Developer, Aider, Kiro, Goose, Antigravity, OpenCode)?",
             "name": "configure_ide",
             "default": True,
         }
@@ -270,7 +270,7 @@ def _configure_ide(mcp_config):
         {
             "type": "list",
             "message": "Choose your IDE/CLI to configure:",
-            "choices": ["VS Code", "Cursor", "Windsurf", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "RooCode", "Amazon Q Developer", "JetBrainsAI", "Aider", "Kiro", "Goose", "Antigravity", "OpenCode", "None of the above"],
+            "choices": ["VS Code", "Cursor", "Windsurf", "Zed", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "RooCode", "Amazon Q Developer", "JetBrainsAI", "Aider", "Kiro", "Goose", "Antigravity", "OpenCode", "None of the above"],
             "name": "ide_choice",
         }
     ]
@@ -289,7 +289,7 @@ def _configure_ide(mcp_config):
         )
         return
 
-    if ide_choice in ["VS Code", "Cursor", "Windsurf", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "RooCode", "Amazon Q Developer", "JetBrainsAI", "Aider", "Kiro", "Goose", "Antigravity"]:
+    if ide_choice in ["VS Code", "Cursor", "Windsurf", "Zed", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "RooCode", "Amazon Q Developer", "JetBrainsAI", "Aider", "Kiro", "Goose", "Antigravity"]:
         console.print(f"\n[bold cyan]Configuring for {ide_choice}...[/bold cyan]")
 
         if ide_choice == "Amazon Q Developer":
@@ -319,6 +319,10 @@ def _configure_ide(mcp_config):
                 Path.home() / "Library" / "Application Support" / "windsurf" / "settings.json",
                 Path.home() / "AppData" / "Roaming" / "windsurf" / "settings.json",
                 Path.home() / ".config" / "Windsurf" / "User" / "settings.json",
+            ],
+            "Zed": [
+                Path.home() / ".config" / "zed" / "settings.json",
+                Path.home() / "AppData" / "Roaming" / "Zed" / "settings.json"
             ],
             "Claude code": [
                 Path.home() / ".claude.json"
@@ -398,10 +402,14 @@ def _configure_ide(mcp_config):
             console.print(f"[red]Error: Configuration file at {target_path} is not a valid JSON object.[/red]")
             return
 
-        if "mcpServers" not in settings:
-            settings["mcpServers"] = {}
-        
-        settings["mcpServers"].update(mcp_config["mcpServers"])
+        if ide_choice == "Zed":
+            if "context_servers" not in settings:
+                settings["context_servers"] = {}
+            settings["context_servers"].update(mcp_config["mcpServers"])
+        else:
+            if "mcpServers" not in settings:
+                settings["mcpServers"] = {}
+            settings["mcpServers"].update(mcp_config["mcpServers"])
 
         try:
             with open(target_path, "w") as f:


### PR DESCRIPTION
Added support for configuring Zed editor to the CLI setup wizard. Zed uses `context_servers` instead of `mcpServers` in its settings JSON. Included paths for macOS/Linux and Windows for Zed's configuration settings.

---
*PR created automatically by Jules for task [1567282857441521683](https://jules.google.com/task/1567282857441521683) started by @Shashankss1205*