### PR TITLE
docs: Add OpenCode setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ codegraphcontext find pattern "Auth" --viz
     *   RooCode
     *   Amazon Q Developer
     *   Kiro
+    *   OpenCode
 
     Upon successful configuration, `codegraphcontext mcp setup` will generate and place the necessary configuration files:
     *   It creates an `mcp.json` file in your current directory for reference.

--- a/docs/docs/getting-started/mcp-setup.md
+++ b/docs/docs/getting-started/mcp-setup.md
@@ -63,6 +63,19 @@ Cursor supports local MCP servers via direct process execution:
 
 ---
 
+### OpenCode
+
+OpenCode manages MCP in its own UI. Follow the vendor's guide at [OpenCode MCP servers](https://opencode.ai/docs/ko/mcp-servers/#_top) to register a stdio server.
+
+Use the following configuration details:
+- **Type**: `stdio`
+- **Command**: `cgc`
+- **Arguments**: `mcp start`
+
+*Note: Ensure your database credentials and configurations match what `cgc mcp setup` generated (usually in `~/.codegraphcontext/.env`).*
+
+---
+
 ### VS Code (via Continue extension)
 
 If you use VS Code with the [Continue.dev](https://continue.dev) plugin:


### PR DESCRIPTION
This PR adds OpenCode to the list of supported IDE integrations in the README and adds an OpenCode setup guide in the MCP setup documentation, addressing the request to provide a guide for installing the MCP server in OpenCode.

---
*PR created automatically by Jules for task [15107012567200015667](https://jules.google.com/task/15107012567200015667) started by @Shashankss1205*