### PR TITLE
feat(cli): add git hook sync commands

### DIFF
--- a/src/codegraphcontext/cli/hook_manager.py
+++ b/src/codegraphcontext/cli/hook_manager.py
@@ -1,0 +1,220 @@
+"""Git hook management for keeping CGC indexes in sync."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import stat
+import subprocess
+
+
+MANAGED_MARKER = "# CGC_MANAGED_HOOK"
+HOOK_NAMES = ("post-commit", "post-checkout")
+GITATTRIBUTES_ENTRY = "*.cgc merge=cgc-bundle"
+
+
+class HookError(RuntimeError):
+    """Raised when hook installation cannot proceed safely."""
+
+
+@dataclass(frozen=True)
+class GitRepository:
+    root: Path
+    git_dir: Path
+
+
+@dataclass(frozen=True)
+class HookStatus:
+    repo_root: Path
+    git_dir: Path
+    installed_hooks: tuple[str, ...]
+    unmanaged_hooks: tuple[str, ...]
+    has_merge_driver: bool
+    has_gitattributes_entry: bool
+
+    @property
+    def installed(self) -> bool:
+        return (
+            bool(self.installed_hooks)
+            and self.has_merge_driver
+            and self.has_gitattributes_entry
+        )
+
+
+def find_git_repository(start: Path | str | None = None) -> GitRepository:
+    """Find the nearest Git repository root and git directory."""
+    current = Path(start or Path.cwd()).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in (current, *current.parents):
+        git_path = candidate / ".git"
+        if git_path.is_dir():
+            return GitRepository(root=candidate, git_dir=git_path)
+        if git_path.is_file():
+            target = _read_worktree_gitdir(git_path)
+            return GitRepository(root=candidate, git_dir=target)
+
+    raise HookError("No Git repository found from the current directory.")
+
+
+def install_hooks(start: Path | str | None = None, *, force: bool = False) -> HookStatus:
+    repo = find_git_repository(start)
+    hooks_dir = repo.git_dir / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    script = _hook_script(repo.root)
+    for hook_name in HOOK_NAMES:
+        hook_path = hooks_dir / hook_name
+        if hook_path.exists() and not _is_managed_hook(hook_path) and not force:
+            raise HookError(
+                f"{hook_name} already exists and is not managed by CGC. "
+                "Re-run with --force to replace it."
+            )
+        hook_path.write_text(script, encoding="utf-8")
+        mode = hook_path.stat().st_mode
+        hook_path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    _ensure_gitattributes(repo.root)
+    _configure_merge_driver(repo.root)
+    return get_hook_status(repo.root)
+
+
+def uninstall_hooks(start: Path | str | None = None) -> HookStatus:
+    repo = find_git_repository(start)
+    hooks_dir = repo.git_dir / "hooks"
+
+    for hook_name in HOOK_NAMES:
+        hook_path = hooks_dir / hook_name
+        if hook_path.exists() and _is_managed_hook(hook_path):
+            hook_path.unlink()
+
+    _remove_gitattributes_entry(repo.root)
+    _unset_git_config(repo.root, "merge.cgc-bundle.name")
+    _unset_git_config(repo.root, "merge.cgc-bundle.driver")
+    return get_hook_status(repo.root)
+
+
+def get_hook_status(start: Path | str | None = None) -> HookStatus:
+    repo = find_git_repository(start)
+    hooks_dir = repo.git_dir / "hooks"
+    installed_hooks: list[str] = []
+    unmanaged_hooks: list[str] = []
+
+    for hook_name in HOOK_NAMES:
+        hook_path = hooks_dir / hook_name
+        if not hook_path.exists():
+            continue
+        if _is_managed_hook(hook_path):
+            installed_hooks.append(hook_name)
+        else:
+            unmanaged_hooks.append(hook_name)
+
+    return HookStatus(
+        repo_root=repo.root,
+        git_dir=repo.git_dir,
+        installed_hooks=tuple(installed_hooks),
+        unmanaged_hooks=tuple(unmanaged_hooks),
+        has_merge_driver=_has_git_config(repo.root, "merge.cgc-bundle.driver"),
+        has_gitattributes_entry=_has_gitattributes_entry(repo.root),
+    )
+
+
+def _read_worktree_gitdir(git_file: Path) -> Path:
+    content = git_file.read_text(encoding="utf-8").strip()
+    prefix = "gitdir:"
+    if not content.lower().startswith(prefix):
+        raise HookError(f"Unsupported .git file format at {git_file}")
+
+    raw_path = content[len(prefix):].strip()
+    git_dir = Path(raw_path)
+    if not git_dir.is_absolute():
+        git_dir = (git_file.parent / git_dir).resolve()
+    return git_dir
+
+
+def _hook_script(repo_root: Path) -> str:
+    repo_root_value = _sh_quote(str(repo_root))
+    return (
+        "#!/bin/sh\n"
+        f"{MANAGED_MARKER}: CodeGraphContext auto-update hook\n"
+        f"CGC_REPO_ROOT={repo_root_value}\n"
+        "if command -v cgc >/dev/null 2>&1; then\n"
+        '  cgc update "$CGC_REPO_ROOT" --quiet\n'
+        "else\n"
+        '  python -m codegraphcontext update "$CGC_REPO_ROOT" --quiet\n'
+        "fi\n"
+    )
+
+
+def _sh_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def _is_managed_hook(path: Path) -> bool:
+    try:
+        return MANAGED_MARKER in path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+
+
+def _ensure_gitattributes(repo_root: Path) -> None:
+    path = repo_root / ".gitattributes"
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    lines = existing.splitlines()
+    if any(line.strip() == GITATTRIBUTES_ENTRY for line in lines):
+        return
+
+    prefix = existing
+    if prefix and not prefix.endswith("\n"):
+        prefix += "\n"
+    path.write_text(f"{prefix}{GITATTRIBUTES_ENTRY}\n", encoding="utf-8")
+
+
+def _remove_gitattributes_entry(repo_root: Path) -> None:
+    path = repo_root / ".gitattributes"
+    if not path.exists():
+        return
+
+    lines = [
+        line
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() != GITATTRIBUTES_ENTRY
+    ]
+    if lines:
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    else:
+        path.unlink()
+
+
+def _has_gitattributes_entry(repo_root: Path) -> bool:
+    path = repo_root / ".gitattributes"
+    if not path.exists():
+        return False
+    return any(
+        line.strip() == GITATTRIBUTES_ENTRY
+        for line in path.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def _configure_merge_driver(repo_root: Path) -> None:
+    _git_config(repo_root, "merge.cgc-bundle.name", "CodeGraphContext bundle merge driver")
+    _git_config(repo_root, "merge.cgc-bundle.driver", "cgc bundle merge %O %A %B")
+
+
+def _git_config(repo_root: Path, key: str, value: str) -> None:
+    subprocess.run(["git", "-C", str(repo_root), "config", key, value], check=True)
+
+
+def _unset_git_config(repo_root: Path, key: str) -> None:
+    subprocess.run(["git", "-C", str(repo_root), "config", "--unset-all", key], check=False)
+
+
+def _has_git_config(repo_root: Path, key: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "config", "--get", key],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -34,6 +34,7 @@ from .cli_helpers import (
     cypher_helper_visual,
     visualize_helper,
     reindex_helper,
+    update_helper,
     clean_helper,
     stats_helper,
     _initialize_services,
@@ -42,6 +43,7 @@ from .cli_helpers import (
     list_watching_helper,
     setup_scip_helper,
 )
+from .hook_manager import HookError, get_hook_status, install_hooks, uninstall_hooks
 
 # Set the log level for the noisy neo4j, asyncio, and urllib3 loggers to keep the output clean.
 # Get the log level from config, defaulting to WARNING
@@ -767,6 +769,71 @@ def bundle_load(
         console.print("[dim]Use 'cgc registry list' to see available bundles[/dim]")
         raise typer.Exit(code=1)
 
+# ============================================================================
+# HOOK COMMAND GROUP - Git integration
+# ============================================================================
+
+hook_app = typer.Typer(help="Install Git hooks that keep the CGC graph in sync")
+app.add_typer(hook_app, name="hook")
+
+
+@hook_app.command("install")
+def hook_install(
+    path: str = typer.Argument(".", help="Path inside the Git repository"),
+    force: bool = typer.Option(False, "--force", "-f", help="Replace existing non-CGC hook files"),
+):
+    """
+    Install CGC-managed Git hooks in the nearest repository.
+
+    The installed hooks run `cgc update <repo> --quiet` after commits and
+    checkouts. Existing non-CGC hooks are preserved unless --force is used.
+    """
+    try:
+        status = install_hooks(path, force=force)
+    except HookError as exc:
+        console.print(f"[bold red]Hook install failed:[/bold red] {exc}")
+        raise typer.Exit(code=1)
+
+    console.print(f"[green]✓[/green] Installed CGC hooks in [bold]{status.repo_root}[/bold]")
+    console.print(f"[dim]Git directory: {status.git_dir}[/dim]")
+
+
+@hook_app.command("uninstall")
+def hook_uninstall(
+    path: str = typer.Argument(".", help="Path inside the Git repository"),
+):
+    """Remove CGC-managed Git hooks and local merge-driver config."""
+    try:
+        status = uninstall_hooks(path)
+    except HookError as exc:
+        console.print(f"[bold red]Hook uninstall failed:[/bold red] {exc}")
+        raise typer.Exit(code=1)
+
+    console.print(f"[green]✓[/green] Removed CGC hooks from [bold]{status.repo_root}[/bold]")
+
+
+@hook_app.command("status")
+def hook_status(
+    path: str = typer.Argument(".", help="Path inside the Git repository"),
+):
+    """Show whether CGC-managed Git hooks are installed."""
+    try:
+        status = get_hook_status(path)
+    except HookError as exc:
+        console.print(f"[bold red]Hook status failed:[/bold red] {exc}")
+        raise typer.Exit(code=1)
+
+    table = Table(title="CGC Git Hook Status", show_header=True, header_style="bold magenta")
+    table.add_column("Check", style="cyan")
+    table.add_column("Status")
+    table.add_row("Repository", str(status.repo_root))
+    table.add_row("Git directory", str(status.git_dir))
+    table.add_row("Managed hooks", ", ".join(status.installed_hooks) or "none")
+    table.add_row("Unmanaged hooks", ", ".join(status.unmanaged_hooks) or "none")
+    table.add_row("Merge driver", "installed" if status.has_merge_driver else "missing")
+    table.add_row(".gitattributes", "installed" if status.has_gitattributes_entry else "missing")
+    console.print(table)
+
 # Shortcut commands at root level
 @app.command("export", rich_help_panel="Bundle Shortcuts")
 def export_shortcut(
@@ -1139,6 +1206,23 @@ def index(
         reindex_helper(path, context)
     else:
         index_helper(path, context)
+
+@app.command()
+def update(
+    path: Optional[str] = typer.Argument(None, help="Path to refresh. Defaults to current directory."),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Reduce output when running from automation"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use (overrides mode/default)"),
+):
+    """
+    Refresh an existing repository index.
+
+    This command is intentionally small and hook-friendly; Git hooks installed
+    with `cgc hook install` call it after commits and checkouts.
+    """
+    _load_credentials()
+    if path is None:
+        path = str(Path.cwd())
+    update_helper(path, context)
 
 @app.command()
 def clean(

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -61,6 +61,7 @@ def _inventory_from_main_source() -> dict[str, set[str]]:
         "neo4j": set(),
         "config": set(),
         "bundle": set(),
+        "hook": set(),
         "registry": set(),
         "find": set(),
         "analyze": set(),
@@ -241,6 +242,7 @@ def cli_test_stubs(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_main, "run_neo4j_setup_wizard", lambda *_args, **_kwargs: None)
 
     monkeypatch.setattr(cli_main, "index_helper", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_main, "update_helper", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(cli_main, "setup_scip_helper", lambda *_args, **_kwargs: None)
     
     import uvicorn
@@ -305,6 +307,32 @@ def cli_test_stubs(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "codegraphcontext.core.cgc_bundle", bundle_module)
 
     monkeypatch.setattr(cli_main, "_write_datasource_graph", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_main,
+        "install_hooks",
+        lambda *_args, **_kwargs: types.SimpleNamespace(
+            repo_root=tmp_path, git_dir=tmp_path / ".git"
+        ),
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "uninstall_hooks",
+        lambda *_args, **_kwargs: types.SimpleNamespace(
+            repo_root=tmp_path, git_dir=tmp_path / ".git"
+        ),
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "get_hook_status",
+        lambda *_args, **_kwargs: types.SimpleNamespace(
+            repo_root=tmp_path,
+            git_dir=tmp_path / ".git",
+            installed_hooks=("post-commit",),
+            unmanaged_hooks=(),
+            has_merge_driver=True,
+            has_gitattributes_entry=True,
+        ),
+    )
 
     datasource_pkg = types.ModuleType("codegraphcontext.tools.datasources")
     monkeypatch.setitem(sys.modules, "codegraphcontext.tools.datasources", datasource_pkg)
@@ -353,11 +381,12 @@ def _matrix_command_set(entries: list[list[str]]) -> set[tuple[str, str]]:
 def test_cli_inventory_grouped_from_source():
     inventory = _inventory_from_main_source()
 
-    assert {"root", "mcp", "neo4j", "config", "bundle", "registry", "find", "analyze"}.issubset(set(inventory.keys()))
+    assert {"root", "mcp", "neo4j", "config", "bundle", "hook", "registry", "find", "analyze"}.issubset(set(inventory.keys()))
     assert inventory["mcp"] == {"setup", "start", "tools"}
     assert inventory["neo4j"] == {"setup"}
     assert inventory["config"] == {"show", "set", "reset", "db"}
     assert inventory["bundle"] == {"export", "import", "load"}
+    assert inventory["hook"] == {"install", "uninstall", "status"}
     assert inventory["registry"] == {"list", "search", "download", "request"}
     assert inventory["find"] == {"name", "pattern", "type", "variable", "content", "decorator", "argument"}
     assert inventory["analyze"] == {
@@ -396,6 +425,9 @@ def test_all_canonical_cli_commands_run_with_kuzudb(kuzudb_env, cli_test_stubs):
         ["bundle", "export", bundle_export],
         ["bundle", "import", bundle_file],
         ["bundle", "load", bundle_file],
+        ["hook", "install"],
+        ["hook", "uninstall"],
+        ["hook", "status"],
         ["registry", "list"],
         ["registry", "search", "numpy"],
         ["registry", "download", "numpy"],
@@ -404,6 +436,7 @@ def test_all_canonical_cli_commands_run_with_kuzudb(kuzudb_env, cli_test_stubs):
         ["setup-scip"],
         ["api", "start"],
         ["index", "."],
+        ["update", "."],
         ["clean"],
         ["stats"],
         ["delete", "."],

--- a/tests/unit/cli/test_hook_manager.py
+++ b/tests/unit/cli/test_hook_manager.py
@@ -1,0 +1,102 @@
+import os
+import stat
+import subprocess
+
+import pytest
+
+from codegraphcontext.cli.hook_manager import (
+    GITATTRIBUTES_ENTRY,
+    HookError,
+    find_git_repository,
+    get_hook_status,
+    install_hooks,
+    uninstall_hooks,
+)
+
+
+def _init_repo(path):
+    path.mkdir(parents=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, stdout=subprocess.DEVNULL)
+    return path
+
+
+def test_find_git_repository_from_nested_directory(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    nested = repo / "src" / "pkg"
+    nested.mkdir(parents=True)
+
+    found = find_git_repository(nested)
+
+    assert found.root == repo
+    assert found.git_dir == repo / ".git"
+
+
+def test_install_hooks_writes_managed_hooks_and_merge_driver(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+
+    status = install_hooks(repo)
+
+    assert status.installed
+    assert set(status.installed_hooks) == {"post-commit", "post-checkout"}
+    for hook_name in status.installed_hooks:
+        hook = repo / ".git" / "hooks" / hook_name
+        text = hook.read_text(encoding="utf-8")
+        assert "CGC_MANAGED_HOOK" in text
+        assert "cgc update" in text
+        assert os.access(hook, os.X_OK)
+
+    assert (repo / ".gitattributes").read_text(encoding="utf-8").strip() == GITATTRIBUTES_ENTRY
+    driver = subprocess.run(
+        ["git", "-C", str(repo), "config", "--get", "merge.cgc-bundle.driver"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+    assert driver == "cgc bundle merge %O %A %B"
+
+
+def test_install_hooks_refuses_unmanaged_existing_hook_without_force(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    hook = repo / ".git" / "hooks" / "post-commit"
+    hook.write_text("#!/bin/sh\necho existing\n", encoding="utf-8")
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    with pytest.raises(HookError, match="not managed by CGC"):
+        install_hooks(repo)
+
+
+def test_install_hooks_force_replaces_existing_hook(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    hook = repo / ".git" / "hooks" / "post-commit"
+    hook.write_text("#!/bin/sh\necho existing\n", encoding="utf-8")
+
+    install_hooks(repo, force=True)
+
+    assert "CGC_MANAGED_HOOK" in hook.read_text(encoding="utf-8")
+
+
+def test_uninstall_removes_only_cgc_managed_artifacts(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    install_hooks(repo)
+
+    unmanaged = repo / ".git" / "hooks" / "pre-commit"
+    unmanaged.write_text("#!/bin/sh\necho keep\n", encoding="utf-8")
+
+    status = uninstall_hooks(repo)
+
+    assert not status.installed_hooks
+    assert unmanaged.exists()
+    assert not (repo / ".git" / "hooks" / "post-commit").exists()
+    assert not (repo / ".git" / "hooks" / "post-checkout").exists()
+    assert not (repo / ".gitattributes").exists()
+    assert not get_hook_status(repo).has_merge_driver
+
+
+def test_gitattributes_update_is_idempotent(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+
+    install_hooks(repo)
+    install_hooks(repo)
+
+    lines = (repo / ".gitattributes").read_text(encoding="utf-8").splitlines()
+    assert lines.count(GITATTRIBUTES_ENTRY) == 1


### PR DESCRIPTION
## Summary
- add `cgc hook install`, `cgc hook status`, and `cgc hook uninstall` commands for Git hook integration
- install managed `post-commit` and `post-checkout` hooks that call `cgc update <repo> --quiet`
- configure the local `*.cgc` merge driver and keep install/uninstall idempotent and safe around unmanaged hooks
- cover the new hook manager and CLI command matrix in tests

## Validation
- `PYTHONPATH=src uv run --python 3.12 --with pytest python -m pytest tests/unit/cli/test_hook_manager.py -q`
- `PYTHONPATH=src uv run --python 3.12 --with pytest python -m pytest tests/integration/cli/test_cli_commands.py -k 'inventory or canonical' -q`
- `PYTHONPATH=src uv run --python 3.12 python -m py_compile src/codegraphcontext/cli/hook_manager.py src/codegraphcontext/cli/main.py`
- `git diff --check`

Closes #886
