### PR TITLE
fix(index): respect cgcignore during SCIP indexing

### DIFF
--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -943,6 +943,7 @@ class GraphBuilder:
             self.parsers.keys(),
             self.get_parser,
             scip_indexer,
+            cgcignore_path,
         )
 
     def _name_from_symbol(self, symbol: str) -> str:

--- a/src/codegraphcontext/tools/indexing/scip_pipeline.py
+++ b/src/codegraphcontext/tools/indexing/scip_pipeline.py
@@ -9,9 +9,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+from ...core.cgcignore import build_ignore_spec
 from ...core.jobs import JobManager, JobStatus
 from ...utils.debug_log import debug_log, error_logger, info_logger, warning_logger
 from ...utils.path_ignore import file_path_has_ignore_dir_segment
+from .constants import DEFAULT_IGNORE_PATTERNS
 from .persistence.writer import GraphWriter
 from .pre_scan import pre_scan_for_imports
 from .resolution.inheritance import build_inheritance_and_csharp_files
@@ -37,6 +39,7 @@ async def run_scip_index_async(
     parsers_keys: Any,
     get_parser: Callable[[str], Any],
     scip_indexer_mod: Any,
+    cgcignore_path: Optional[str] = None,
 ) -> None:
     """Run SCIP CLI, write graph, supplement with Tree-sitter, write SCIP CALLS edges."""
     ScipIndexer = scip_indexer_mod.ScipIndexer
@@ -48,6 +51,33 @@ async def run_scip_index_async(
     repo_root = path if path.is_dir() else path.parent.resolve()
     writer.add_repository_to_graph(repo_root, is_dependency)
     repo_name = repo_root.name
+    index_root = path.resolve() if path.is_dir() else path.parent.resolve()
+
+    ignore_spec = None
+    try:
+        ignore_spec, resolved_cgcignore = build_ignore_spec(
+            ignore_root=index_root,
+            default_patterns=DEFAULT_IGNORE_PATTERNS,
+            explicit_path=cgcignore_path,
+        )
+        if resolved_cgcignore:
+            debug_log(
+                f"SCIP using .cgcignore at {resolved_cgcignore} "
+                f"(filtering relative to {index_root})"
+            )
+    except OSError as e:
+        warning_logger(f"Could not load/create .cgcignore for SCIP indexing: {e}")
+
+    def should_skip_file(file_path: Path) -> bool:
+        if file_path.is_file() and file_path_has_ignore_dir_segment(file_path, index_root):
+            return True
+        if not ignore_spec:
+            return False
+        try:
+            rel_path = file_path.relative_to(index_root).as_posix()
+        except ValueError:
+            return False
+        return ignore_spec.match_file(rel_path)
 
     try:
         with tempfile.TemporaryDirectory(prefix="cgc_scip_") as tmpdir:
@@ -66,6 +96,12 @@ async def run_scip_index_async(
             raise RuntimeError("SCIP parse returned empty result")
 
         files_data = scip_data.get("files", {})
+        if ignore_spec:
+            files_data = {
+                abs_path_str: file_data
+                for abs_path_str, file_data in files_data.items()
+                if not should_skip_file(Path(abs_path_str))
+            }
         file_paths = [Path(p) for p in files_data.keys() if Path(p).exists()]
 
         imports_map = pre_scan_for_imports(file_paths, parsers_keys, get_parser)
@@ -74,10 +110,9 @@ async def run_scip_index_async(
             job_manager.update_job(job_id, total_files=len(files_data))
 
         processed = 0
-        index_root = path.resolve() if path.is_dir() else path.parent.resolve()
         for abs_path_str, file_data in files_data.items():
             file_path = Path(abs_path_str)
-            if file_path.is_file() and file_path_has_ignore_dir_segment(file_path, index_root):
+            if should_skip_file(file_path):
                 continue
             file_data["repo_path"] = str(index_root)
             if job_id:
@@ -149,7 +184,7 @@ async def run_scip_index_async(
         from .discovery import discover_files_to_index
         supplementary_files, _ = discover_files_to_index(
             index_root,
-            cgcignore_path=None,
+            cgcignore_path=cgcignore_path,
             supported_extensions=set(parsers_keys),
         )
         for repo_file in supplementary_files:

--- a/tests/unit/tools/test_scip_pipeline_cgcignore.py
+++ b/tests/unit/tools/test_scip_pipeline_cgcignore.py
@@ -1,0 +1,102 @@
+"""Tests for .cgcignore handling in the SCIP indexing pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codegraphcontext.tools.indexing.scip_pipeline import run_scip_index_async
+
+
+class _FakeScipIndexer:
+    def run(self, _project_path: Path, _lang: str, output_dir: Path) -> Path:
+        scip_file = output_dir / "index.scip"
+        scip_file.write_bytes(b"fake")
+        return scip_file
+
+
+class _FakeScipIndexParser:
+    files_data: dict[str, dict]
+
+    def parse(self, _index_scip_path: Path, _project_path: Path) -> dict:
+        return {"files": self.files_data}
+
+
+class _FakeParser:
+    def parse(self, path: Path, _is_dependency: bool, index_source: bool = False) -> dict:
+        return {
+            "path": str(path),
+            "functions": [],
+            "classes": [],
+            "imports": [],
+            "variables": [],
+            "function_calls_scip": [],
+            "module_level_calls_scip": [],
+        }
+
+
+@pytest.mark.asyncio
+async def test_scip_pipeline_respects_root_directory_cgcignore_pattern(tmp_path: Path):
+    repo = tmp_path / "repo"
+    src_dir = repo / "src"
+    ignored_dir = repo / "Binaries"
+    src_dir.mkdir(parents=True)
+    ignored_dir.mkdir()
+
+    tracked_file = src_dir / "app.py"
+    ignored_file = ignored_dir / "generated.py"
+    tracked_file.write_text("print('tracked')\n", encoding="utf-8")
+    ignored_file.write_text("print('ignored')\n", encoding="utf-8")
+    (repo / ".cgcignore").write_text("Binaries/\n", encoding="utf-8")
+
+    fake_parser_mod = SimpleNamespace(
+        ScipIndexer=_FakeScipIndexer,
+        ScipIndexParser=_FakeScipIndexParser,
+    )
+    _FakeScipIndexParser.files_data = {
+        str(tracked_file.resolve()): {
+            "path": str(tracked_file.resolve()),
+            "functions": [],
+            "classes": [],
+            "imports": [],
+            "function_calls_scip": [],
+            "module_level_calls_scip": [],
+        },
+        str(ignored_file.resolve()): {
+            "path": str(ignored_file.resolve()),
+            "functions": [],
+            "classes": [],
+            "imports": [],
+            "function_calls_scip": [],
+            "module_level_calls_scip": [],
+        },
+    }
+
+    writer = MagicMock()
+    job_manager = MagicMock()
+
+    with patch(
+        "codegraphcontext.tools.indexing.scip_pipeline.pre_scan_for_imports",
+        return_value={},
+    ):
+        await run_scip_index_async(
+            repo,
+            is_dependency=False,
+            job_id=None,
+            lang="python",
+            writer=writer,
+            job_manager=job_manager,
+            parsers_keys={".py"},
+            get_parser=lambda _suffix: _FakeParser(),
+            scip_indexer_mod=fake_parser_mod,
+        )
+
+    indexed_paths = [
+        call.args[0]["path"]
+        for call in writer.add_file_to_graph.call_args_list
+    ]
+    assert str(tracked_file.resolve()) in indexed_paths
+    assert str(ignored_file.resolve()) not in indexed_paths


### PR DESCRIPTION
## Summary
- carry the active .cgcignore path into the SCIP indexing pipeline
- filter SCIP-returned files against the same .cgcignore/default ignore spec before pre-scan and graph writes
- pass the ignore path into the Tree-sitter supplementary pass so ignored folders are not reintroduced
- add a regression test for a root-level `Binaries/` directory pattern

Closes #917

## Validation
- `PYTHONPATH=src uv run --python 3.12 --with pytest --with pytest-asyncio python -m pytest tests/unit/tools/test_scip_pipeline_cgcignore.py tests/unit/core/test_cgcignore_core.py -q`
- `PYTHONPATH=src uv run --python 3.12 --with pytest --with pytest-asyncio python -m pytest tests/unit/tools/test_scip_pipeline_cgcignore.py tests/unit/tools/test_scip_indexer_c_family.py -q`
- `PYTHONPATH=src uv run --python 3.12 python -m py_compile src/codegraphcontext/tools/indexing/scip_pipeline.py src/codegraphcontext/tools/graph_builder.py`
- `git diff --check`