### PR TITLE
fix: use UTF-8 for config file IO

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -234,7 +234,7 @@ def load_config() -> Dict[str, str]:
     # Load global config
     if CONFIG_FILE.exists():
         try:
-            with open(CONFIG_FILE, "r") as f:
+            with open(CONFIG_FILE, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if line and not line.startswith("#") and "=" in line:
@@ -247,7 +247,7 @@ def load_config() -> Dict[str, str]:
     local_env = find_local_env()
     if local_env and local_env.exists():
         try:
-            with open(local_env, "r") as f:
+            with open(local_env, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if line and not line.startswith("#") and "=" in line:
@@ -321,7 +321,7 @@ def save_config(config: Dict[str, str], preserve_db_credentials: bool = True):
     if preserve_db_credentials and CONFIG_FILE.exists():
         # Load existing credentials from file to preserve them
         try:
-            with open(CONFIG_FILE, "r") as f:
+            with open(CONFIG_FILE, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if line and not line.startswith("#") and "=" in line:
@@ -342,7 +342,7 @@ def save_config(config: Dict[str, str], preserve_db_credentials: bool = True):
                 credentials_to_write[key] = config[key]
     
     try:
-        with open(CONFIG_FILE, "w") as f:
+        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
             f.write("# CodeGraphContext Configuration\n")
             f.write(f"# Location: {CONFIG_FILE}\n\n")
             
@@ -696,7 +696,7 @@ def load_context_config() -> ContextConfig:
         return cfg
 
     try:
-        with open(CONTEXT_CONFIG_FILE, "r") as f:
+        with open(CONTEXT_CONFIG_FILE, "r", encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
 
         contexts: Dict[str, ContextInfo] = {}
@@ -746,7 +746,7 @@ def save_context_config(cfg: ContextConfig) -> None:
     }
 
     try:
-        with open(CONTEXT_CONFIG_FILE, "w") as f:
+        with open(CONTEXT_CONFIG_FILE, "w", encoding="utf-8") as f:
             yaml.dump(raw, f, default_flow_style=False, sort_keys=False)
     except Exception as e:
         console.print(f"[red]Error saving config.yaml: {e}[/red]")
@@ -838,7 +838,7 @@ def resolve_context(
         local_db = "falkordb"
         if local_yaml.exists():
             try:
-                with open(local_yaml) as f:
+                with open(local_yaml, encoding="utf-8") as f:
                     local_raw = yaml.safe_load(f) or {}
                 local_db = local_raw.get("database", "falkordb")
             except Exception:
@@ -1053,7 +1053,7 @@ def discover_child_contexts(
                 local_yaml = candidate / "config.yaml"
                 if local_yaml.exists():
                     try:
-                        with open(local_yaml) as f:
+                        with open(local_yaml, encoding="utf-8") as f:
                             raw = yaml.safe_load(f) or {}
                         local_db = raw.get("database", "falkordb")
                     except Exception:
@@ -1082,7 +1082,7 @@ def _load_workspace_mappings() -> Dict[str, Dict[str, str]]:
     if not CONTEXT_CONFIG_FILE.exists():
         return {}
     try:
-        with open(CONTEXT_CONFIG_FILE, "r") as f:
+        with open(CONTEXT_CONFIG_FILE, "r", encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
         return raw.get("workspace_mappings", {}) or {}
     except Exception:
@@ -1096,13 +1096,13 @@ def _save_workspace_mappings(mappings: Dict[str, Dict[str, str]]) -> None:
     raw: Dict[str, Any] = {}
     if CONTEXT_CONFIG_FILE.exists():
         try:
-            with open(CONTEXT_CONFIG_FILE, "r") as f:
+            with open(CONTEXT_CONFIG_FILE, "r", encoding="utf-8") as f:
                 raw = yaml.safe_load(f) or {}
         except Exception:
             raw = {}
     raw["workspace_mappings"] = mappings
     try:
-        with open(CONTEXT_CONFIG_FILE, "w") as f:
+        with open(CONTEXT_CONFIG_FILE, "w", encoding="utf-8") as f:
             yaml.dump(raw, f, default_flow_style=False, sort_keys=False)
     except Exception as e:
         console.print(f"[red]Error saving workspace mappings: {e}[/red]")
@@ -1124,7 +1124,7 @@ def save_workspace_mapping(cwd: Path, context_path: Path) -> None:
     local_yaml = context_path / "config.yaml"
     if local_yaml.exists():
         try:
-            with open(local_yaml) as f:
+            with open(local_yaml, encoding="utf-8") as f:
                 raw = yaml.safe_load(f) or {}
             local_db = raw.get("database", "falkordb")
         except Exception:

--- a/tests/unit/cli/test_config_manager_encoding.py
+++ b/tests/unit/cli/test_config_manager_encoding.py
@@ -1,0 +1,48 @@
+import builtins
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.cli import config_manager
+
+
+def _require_utf8_open_for(paths, monkeypatch):
+    original_open = builtins.open
+    tracked = {Path(path) for path in paths}
+
+    def open_spy(file, mode="r", *args, **kwargs):
+        if Path(file) in tracked and any(flag in mode for flag in ("r", "w")):
+            assert kwargs.get("encoding") == "utf-8"
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", open_spy)
+
+
+def test_env_config_files_are_opened_with_utf8(tmp_path, monkeypatch):
+    global_config = tmp_path / ".env"
+    local_config = tmp_path / "local.env"
+    global_config.write_text("# em dash: —\nDEFAULT_DATABASE=falkordb\n", encoding="utf-8")
+    local_config.write_text("# cjk: 日本語\nSKIP_EXTERNAL_RESOLUTION=false\n", encoding="utf-8")
+
+    monkeypatch.setattr(config_manager, "CONFIG_FILE", global_config)
+    monkeypatch.setattr(config_manager, "find_local_env", lambda: local_config)
+    _require_utf8_open_for([global_config, local_config], monkeypatch)
+
+    loaded = config_manager.load_config()
+
+    assert loaded["DEFAULT_DATABASE"] == "falkordb"
+    assert loaded["SKIP_EXTERNAL_RESOLUTION"] == "false"
+
+
+def test_context_config_files_are_opened_with_utf8(tmp_path, monkeypatch):
+    context_config = tmp_path / "config.yaml"
+
+    monkeypatch.setattr(config_manager, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config_manager, "CONTEXT_CONFIG_FILE", context_config)
+    monkeypatch.setattr(config_manager, "_LEGACY_CONTEXT_CONFIG_FILE", tmp_path / "cgc_config.yaml")
+    _require_utf8_open_for([context_config], monkeypatch)
+
+    config_manager.save_context_config(config_manager.ContextConfig(default_context="global"))
+    loaded = config_manager.load_context_config()
+
+    assert loaded.default_context == "global"


### PR DESCRIPTION
## Summary\n- add explicit UTF-8 encoding to config/env/YAML file reads and writes in config_manager.py\n- cover global/local env loading and context config persistence with focused regression tests\n- prevents Windows CJK locale defaults from failing on UTF-8 comments in config files\n\nFixes #1068\n\n## Validation\n- python3 -m py_compile src/codegraphcontext/cli/config_manager.py tests/unit/cli/test_config_manager_encoding.py\n- PYTHONPATH=src python3 -m pytest tests/unit/cli/test_config_manager_encoding.py -q\n- git diff --check