### PR TITLE
Fix C# SCIP indexer install hint in `cgc setup-scip`

### DIFF
--- a/src/codegraphcontext/tools/scip_indexer.py
+++ b/src/codegraphcontext/tools/scip_indexer.py
@@ -28,7 +28,7 @@ Supported SCIP indexers and their install commands:
   rust       → cargo install scip-rust (or rustup component add rust-analyzer)
   java       → https://github.com/sourcegraph/scip-java
   c / c++    → scip-clang (JSON compilation database: compile_commands.json)
-  csharp     → scip-dotnet (dotnet tool install -g Microsoft.CodeAnalysis.ScipDotnet)
+  csharp     → scip-dotnet (dotnet tool install --global scip-dotnet)
 
 JavaScript indexing notes:
   - Pure JS projects (no tsconfig.json): scip-typescript index --infer-tsconfig
@@ -71,7 +71,7 @@ EXTENSION_TO_SCIP: Dict[str, Tuple[str, str, str, str]] = {
     ".hh":    ("cpp",        "scip-clang",      "brew install llvm", "sourcegraph/scip-clang:sha-1704d3d"),
     ".c":     ("c",          "scip-clang",      "brew install llvm", "sourcegraph/scip-clang:sha-1704d3d"),
     ".h":     ("cpp",        "scip-clang",      "brew install llvm", "sourcegraph/scip-clang:sha-1704d3d"),
-    ".cs":    ("csharp",     "scip-dotnet",     "dotnet tool install -g Microsoft.CodeAnalysis.ScipDotnet", "sourcegraph/scip-dotnet"),
+    ".cs":    ("csharp",     "scip-dotnet",     "dotnet tool install --global scip-dotnet", "sourcegraph/scip-dotnet"),
     ".php":   ("php",        "scip-php",        "composer global require davidrjenni/scip-php", "davidrjenni/scip-php"),
     ".rb":    ("ruby",       "scip-ruby",       "gem install scip-ruby", ""),
     ".swift": ("swift",      "scip-swift",      "brew install scip-swift", ""),


### PR DESCRIPTION
Fixes issue #1072.

The install hint shown by `cgc setup-scip` for the C# SCIP indexer incorrectly referenced `Microsoft.CodeAnalysis.ScipDotnet`. The correct NuGet package published by Sourcegraph is `scip-dotnet`. This updates both the `.cs` entry string and the module docstring to correctly say `dotnet tool install --global scip-dotnet`.

---
*PR created automatically by Jules for task [11488852876114103084](https://jules.google.com/task/11488852876114103084) started by @Shashankss1205*