### PR TITLE
Fix: Remove is_file() guard from SCIP pipeline ignore check

### DIFF
--- a/src/codegraphcontext/tools/indexing/scip_pipeline.py
+++ b/src/codegraphcontext/tools/indexing/scip_pipeline.py
@@ -77,7 +77,7 @@ async def run_scip_index_async(
         index_root = path.resolve() if path.is_dir() else path.parent.resolve()
         for abs_path_str, file_data in files_data.items():
             file_path = Path(abs_path_str)
-            if file_path.is_file() and file_path_has_ignore_dir_segment(file_path, index_root):
+            if file_path_has_ignore_dir_segment(file_path, index_root):
                 continue
             file_data["repo_path"] = str(index_root)
             if job_id:


### PR DESCRIPTION
When indexing a project with SCIP enabled, generated files inside directories like `.NET` `obj/` are sometimes written to the graph even if they are excluded in `.cgcignore`. This occurs because the ignore logic in the `run_scip_index_async` function previously relied on `file_path.is_file()`.

Since ephemeral generated files may be deleted before the SCIP index output is parsed, `is_file()` returned `False` and bypassed the `file_path_has_ignore_dir_segment` check completely.

This commit removes the `is_file()` check, allowing the ignore logic to evaluate the path itself regardless of whether the file still exists on disk.

Fixes #1073

---
*PR created automatically by Jules for task [8931532181013429087](https://jules.google.com/task/8931532181013429087) started by @Shashankss1205*