### PR TITLE
test: add unit tests for JavaScript and TypeScript parsers (fixes #1022)

### DIFF
--- a/tests/unit/parsers/test_javascript_parser.py
+++ b/tests/unit/parsers/test_javascript_parser.py
@@ -1,0 +1,108 @@
+﻿from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.tools.languages.javascript import JavascriptTreeSitterParser, pre_scan_javascript
+from codegraphcontext.tools.tree_sitter_parser import TreeSitterParser
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+@pytest.fixture(scope="module")
+def js_parser():
+    manager = get_tree_sitter_manager()
+    if not manager.is_language_available("javascript"):
+        pytest.skip("JavaScript tree-sitter grammar is not available in this environment")
+
+    wrapper = MagicMock()
+    wrapper.language_name = "javascript"
+    wrapper.language = manager.get_language_safe("javascript")
+    wrapper.parser = manager.create_parser("javascript")
+    return JavascriptTreeSitterParser(wrapper)
+
+
+def test_tree_sitter_dispatches_javascript_parser():
+    parser = TreeSitterParser("javascript")
+    assert isinstance(parser.language_specific_parser, JavascriptTreeSitterParser)
+
+
+def test_parse_javascript_functions_and_classes(js_parser, temp_test_dir):
+    code = """
+import { readFile } from 'fs';
+import path from 'path';
+
+class Animal {
+    constructor(name) {
+        this.name = name;
+    }
+
+    speak() {
+        console.log(this.name);
+    }
+}
+
+function greet(name) {
+    return 'Hello, ' + name;
+}
+
+const add = (a, b) => {
+    return a + b;
+};
+"""
+    f = temp_test_dir / "sample.js"
+    f.write_text(code)
+
+    result = js_parser.parse(f)
+
+    assert result["lang"] == "javascript"
+
+    function_names = {fn["name"] for fn in result["functions"]}
+    assert "greet" in function_names
+    assert "add" in function_names
+
+    class_names = {cls["name"] for cls in result["classes"]}
+    assert "Animal" in class_names
+
+    import_names = {imp["name"] for imp in result["imports"]}
+    assert "fs" in import_names or "path" in import_names
+
+
+def test_parse_javascript_function_calls(js_parser, temp_test_dir):
+    code = """
+function main() {
+    const result = greet('world');
+    console.log(result);
+}
+
+function greet(name) {
+    return 'Hello, ' + name;
+}
+"""
+    f = temp_test_dir / "calls.js"
+    f.write_text(code)
+
+    result = js_parser.parse(f)
+
+    call_names = {call["name"] for call in result["function_calls"]}
+    assert "greet" in call_names or "log" in call_names
+
+
+def test_pre_scan_javascript_indexes_functions(temp_test_dir):
+    code = """
+function helper() {}
+
+function main() {
+    helper();
+}
+"""
+    f = temp_test_dir / "scanner.js"
+    f.write_text(code)
+
+    manager = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "javascript"
+    wrapper.language = manager.get_language_safe("javascript")
+    wrapper.parser = manager.create_parser("javascript")
+
+    imports_map = pre_scan_javascript([f], wrapper)
+
+    assert "helper" in imports_map or "main" in imports_map

--- a/tests/unit/parsers/test_typescript_parser.py
+++ b/tests/unit/parsers/test_typescript_parser.py
@@ -1,0 +1,115 @@
+﻿from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.tools.languages.typescript import TypescriptTreeSitterParser, pre_scan_typescript
+from codegraphcontext.tools.tree_sitter_parser import TreeSitterParser
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+@pytest.fixture(scope="module")
+def ts_parser():
+    manager = get_tree_sitter_manager()
+    if not manager.is_language_available("typescript"):
+        pytest.skip("TypeScript tree-sitter grammar is not available in this environment")
+
+    wrapper = MagicMock()
+    wrapper.language_name = "typescript"
+    wrapper.language = manager.get_language_safe("typescript")
+    wrapper.parser = manager.create_parser("typescript")
+    return TypescriptTreeSitterParser(wrapper)
+
+
+def test_tree_sitter_dispatches_typescript_parser():
+    parser = TreeSitterParser("typescript")
+    assert isinstance(parser.language_specific_parser, TypescriptTreeSitterParser)
+
+
+def test_parse_typescript_functions_and_classes(ts_parser, temp_test_dir):
+    code = """
+import { readFile } from 'fs';
+import path from 'path';
+
+interface Animal {
+    name: string;
+    speak(): void;
+}
+
+class Dog implements Animal {
+    name: string;
+
+    constructor(name: string) {
+        this.name = name;
+    }
+
+    speak(): void {
+        console.log(this.name);
+    }
+}
+
+function greet(name: string): string {
+    return 'Hello, ' + name;
+}
+
+const add = (a: number, b: number): number => {
+    return a + b;
+};
+"""
+    f = temp_test_dir / "sample.ts"
+    f.write_text(code)
+
+    result = ts_parser.parse(f)
+
+    assert result["lang"] == "typescript"
+
+    function_names = {fn["name"] for fn in result["functions"]}
+    assert "greet" in function_names
+    assert "add" in function_names
+
+    class_names = {cls["name"] for cls in result["classes"]}
+    assert "Dog" in class_names
+
+    import_names = {imp["name"] for imp in result["imports"]}
+    assert "fs" in import_names or "path" in import_names
+
+
+def test_parse_typescript_function_calls(ts_parser, temp_test_dir):
+    code = """
+function main(): void {
+    const result = greet('world');
+    console.log(result);
+}
+
+function greet(name: string): string {
+    return 'Hello, ' + name;
+}
+"""
+    f = temp_test_dir / "calls.ts"
+    f.write_text(code)
+
+    result = ts_parser.parse(f)
+
+    call_names = {call["name"] for call in result["function_calls"]}
+    assert "greet" in call_names or "log" in call_names
+
+
+def test_pre_scan_typescript_indexes_functions(temp_test_dir):
+    code = """
+function helper(): void {}
+
+function main(): void {
+    helper();
+}
+"""
+    f = temp_test_dir / "scanner.ts"
+    f.write_text(code)
+
+    manager = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "typescript"
+    wrapper.language = manager.get_language_safe("typescript")
+    wrapper.parser = manager.create_parser("typescript")
+
+    imports_map = pre_scan_typescript([f], wrapper)
+
+    assert "helper" in imports_map or "main" in imports_map


### PR DESCRIPTION
Closes #1022

Added unit tests for JavaScript and TypeScript parser support, which were the only two languages missing test coverage among the 22 supported languages.

**Changes:**
- `tests/unit/parsers/test_javascript_parser.py` - tests for `JavascriptTreeSitterParser` and `pre_scan_javascript`, covering function detection, class detection, import detection, function calls, and pre-scan indexing
- `tests/unit/parsers/test_typescript_parser.py` - same coverage for `TypescriptTreeSitterParser` and `pre_scan_typescript`, including TypeScript-specific features like type annotations and interfaces

All 8 new tests pass locally.