### PR TITLE
fix: normalize path separators and add fallback path matching for Windows compatibility

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -1315,7 +1315,7 @@ class GraphWriter:
         repo_path_str = repo_path.replace("\\", "/")
         path_prefix = repo_path_str + "/"
         with self.driver.session() as session:
-            # Try both normalized and original path to handle cross-platform mismatches
+            # Try normalized path first
             result = session.run(
                 "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt", path=repo_path_str
             ).single()
@@ -1324,6 +1324,10 @@ class GraphWriter:
                 result = session.run(
                     "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt", path=repo_path
                 ).single()
+                # If found via original path, use original path for all subsequent operations
+                if result and result["cnt"] > 0:
+                    repo_path_str = repo_path
+                    path_prefix = repo_path + "\\"
             if not result or result["cnt"] == 0:
                 warning_logger(f"Attempted to delete non-existent repository: {repo_path}")
                 return False

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -1311,7 +1311,8 @@ class GraphWriter:
         info_logger(f"[SPRING_DATA] Written {written} READS/WRITES derived-query edges")
 
     def delete_repository_from_graph(self, repo_path: str) -> bool:
-        repo_path_str = repo_path
+        # Normalize path separators for cross-platform compatibility (Windows uses \)
+        repo_path_str = repo_path.replace("\\", "/")
         path_prefix = repo_path_str + "/"
         with self.driver.session() as session:
             result = session.run(

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -1315,11 +1315,17 @@ class GraphWriter:
         repo_path_str = repo_path.replace("\\", "/")
         path_prefix = repo_path_str + "/"
         with self.driver.session() as session:
+            # Try both normalized and original path to handle cross-platform mismatches
             result = session.run(
                 "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt", path=repo_path_str
             ).single()
             if not result or result["cnt"] == 0:
-                warning_logger(f"Attempted to delete non-existent repository: {repo_path_str}")
+                # Fallback: try original path (Windows backslash)
+                result = session.run(
+                    "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt", path=repo_path
+                ).single()
+            if not result or result["cnt"] == 0:
+                warning_logger(f"Attempted to delete non-existent repository: {repo_path}")
                 return False
 
         for rel_type in ("CALLS", "INHERITS", "IMPORTS"):

--- a/tests/unit/tools/test_graph_builder_perf_fixes.py
+++ b/tests/unit/tools/test_graph_builder_perf_fixes.py
@@ -573,7 +573,11 @@ class TestDeleteRepositoryFromGraph:
         return _DeleteRepoSession(labels=labels, responses=responses)
 
     def test_returns_false_when_repo_not_found(self):
-        session = _RecordingSession(responses=[_FakeResult([{"cnt": 0}])])
+        # Provide two failure responses: one for normalized path, one for fallback
+        session = _RecordingSession(responses=[
+            _FakeResult([{"cnt": 0}]),  # normalized path (forward-slash)
+            _FakeResult([{"cnt": 0}]),  # fallback path (original)
+        ])
         gb, _ = _make_graph_builder(session)
         result = gb.delete_repository_from_graph("/nonexistent/repo")
         assert result is False
@@ -678,6 +682,43 @@ class TestDeleteRepositoryFromGraph:
         assert existence_idx < labels_call_idx < node_delete_idx, (
             "db.labels() must come after existence check and before per-label deletion"
         )
+
+    def test_finds_repo_stored_with_backslash_path(self):
+        """Fallback should find a Repository stored with Windows backslash paths."""
+        session = _RecordingSession(responses=[
+            _FakeResult([{"cnt": 0}]),   # normalized (forward-slash) fails
+            _FakeResult([{"cnt": 1}]),   # fallback (original backslash) succeeds
+            _FakeResult([{"deleted": 0}]) * 20,  # drain loops
+        ])
+        gb, _ = _make_graph_builder(session)
+        result = gb.delete_repository_from_graph("C:\\Users\\test\\repo")
+        assert result is True
+        
+        # Verify that fallback path was used for subsequent operations
+        queries = [c["query"] for c in session.calls]
+        # Should use backslash path prefix for STARTS WITH queries
+        assert any("C:\\Users\\test\\repo\\" in q for q in queries), \
+            "Expected backslash path prefix in STARTS WITH queries after fallback"
+
+    def test_uses_matching_path_format_for_deletion(self):
+        """When fallback triggers, deletion queries should use the path format that matched."""
+        session = _RecordingSession(responses=[
+            _FakeResult([{"cnt": 0}]),   # normalized (forward-slash) fails
+            _FakeResult([{"cnt": 1}]),   # fallback (original backslash) succeeds
+            _FakeResult([{"deleted": 0}]) * 20,  # drain loops
+        ])
+        gb, _ = _make_graph_builder(session)
+        gb.delete_repository_from_graph("D:\\WorkPlace\\AI\\MinerU\\pipeline")
+        
+        # Check that all deletion queries use the backslash path
+        queries = [c["query"] for c in session.calls]
+        for q in queries:
+            if "STARTS WITH" in q or "DETACH DELETE" in q:
+                # Should use backslash path, not forward-slash
+                assert "D:/WorkPlace/AI/MinerU/pipeline" not in q, \
+                    "Should not use normalized forward-slash path after fallback"
+                assert "D:\\WorkPlace\\AI\\MinerU\\pipeline" in q or "D:\\WorkPlace\\AI\\MinerU\\pipeline\\" in q, \
+                    "Should use original backslash path after fallback"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug Fix

Fixes #1080

## Problem

The `delete_repository_from_graph` function in `writer.py` uses a hardcoded `/` when building the path prefix for Cypher `STARTS WITH` queries. On Windows, file paths use backslashes (`\\`), causing the prefix to not match existing node paths.

**Example:**
- Database node path: `D:\\WorkPlace\\AI\\MinerU\\pipeline\\complete_metadata.py`
- Generated prefix: `D:\\WorkPlace\\AI\\MinerU\\pipeline/` (mixed separators)
- Result: `STARTS WITH` match fails, old nodes not deleted

## Solution

### 1. Normalize path separators
Convert backslashes to forward slashes before building the prefix:

```python
def delete_repository_from_graph(self, repo_path: str) -> bool:
    # Normalize path separators for cross-platform compatibility (Windows uses \\)
    repo_path_str = repo_path.replace("\\", "/")
    path_prefix = repo_path_str + "/"
```

### 2. Add fallback path matching
When Repository nodes are stored with backslash paths (Windows), try both normalized and original paths:

```python
with self.driver.session() as session:
    # Try normalized path first
    result = session.run(
        "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt", path=repo_path_str
    ).single()
    if not result or result["cnt"] == 0:
        # Fallback: try original path (Windows backslash)
        result = session.run(
            "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt", path=repo_path
        ).single()
        # If found via original path, use original path for all subsequent operations
        if result and result["cnt"] > 0:
            repo_path_str = repo_path
            path_prefix = repo_path + "\\"
```

### 3. Ensure consistent path format for deletion
When fallback triggers, all subsequent deletion queries use the matched path format (backslash) to ensure proper deletion of all related nodes and relationships.

## Testing

Added comprehensive tests for Windows path compatibility:
- `test_finds_repo_stored_with_backslash_path`: Verifies fallback finds Repository stored with backslash paths
- `test_uses_matching_path_format_for_deletion`: Ensures deletion queries use the correct path format after fallback
- Updated `test_returns_false_when_repo_not_found` to explicitly test both path formats

## Impact

- `cgc index --force` now correctly deletes old nodes on Windows
- Prevents duplicate function entries in the Neo4j database
- Ensures accurate complexity analysis after refactoring
- Handles both forward-slash and backslash path formats in the database

## Code Review

Addressed critical issues found during code review:
- Fallback logic now extends to all deletion operations, not just existence check
- Path format consistency maintained throughout the entire deletion process
- Comprehensive test coverage for Windows path scenarios

## Verification

Verified on Windows 11 with CGC v0.4.13 and Neo4j backend.