### PR TITLE
fix: persist selected website theme

### DIFF
--- a/website/src/components/ThemeProvider.tsx
+++ b/website/src/components/ThemeProvider.tsx
@@ -5,5 +5,16 @@ import { ThemeProvider as NextThemesProvider } from "next-themes"
 import { type ThemeProviderProps } from "next-themes/dist/types"
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+  const storedTheme =
+    typeof window !== "undefined" ? window.localStorage.getItem("theme") : null
+  const defaultTheme =
+    storedTheme === "light" || storedTheme === "dark"
+      ? storedTheme
+      : props.defaultTheme
+
+  return (
+    <NextThemesProvider {...props} defaultTheme={defaultTheme}>
+      {children}
+    </NextThemesProvider>
+  )
 }


### PR DESCRIPTION
## Description

Reads the saved next-themes value from localStorage during ThemeProvider initialization so a selected light or dark theme is used instead of always falling back to the hard-coded dark default on reload.

## Related Issues

Resolves #1110

## Verification

- npm run build passed
- npx eslint src/components/ThemeProvider.tsx passed
- npm run lint fails on existing repo-wide lint errors unrelated to this change