### PR TITLE
Refactor cgcignore to natively support wildcards without pathspec

### DIFF
--- a/src/codegraphcontext/core/cgcignore.py
+++ b/src/codegraphcontext/core/cgcignore.py
@@ -1,7 +1,8 @@
 # src/codegraphcontext/core/cgcignore.py
 from pathlib import Path
 from typing import Iterable, Optional, Tuple
-from pathspec import PathSpec
+import re
+from ..utils.debug_log import warning_logger
 
 
 def _resolve_explicit_path(ignore_root: Path, explicit_path: Optional[str]) -> Optional[Path]:
@@ -85,12 +86,134 @@ def read_cgcignore_patterns(path: Path, default_patterns: list[str]) -> list[str
     # User patterns first so explicit repo rules take precedence.
     return user_patterns + list(default_patterns)
 
+class CGCIgnoreMatcher:
+    def __init__(self, patterns: list[str], root_dir: Path):
+        self.root_dir = root_dir
+        self.rules = self._compile_patterns(patterns)
+        
+    def _translate_segment(self, seg: str) -> str:
+        """Translates a single gitwildmatch segment into regex, completely avoiding fnmatch."""
+        i, n = 0, len(seg)
+        res = ""
+        while i < n:
+            c = seg[i]
+            i += 1
+            if c == '*':
+                res += '[^/]*'
+            elif c == '?':
+                res += '[^/]'
+            elif c == '\\':
+                # Handle gitignore escape sequence (e.g. \! matches a literal !)
+                if i < n:
+                    res += re.escape(seg[i])
+                    i += 1
+                else:
+                    res += re.escape('\\')
+            elif c == '[':
+                j = i
+                if j < n and seg[j] == '!':
+                    j += 1
+                if j < n and seg[j] == ']':
+                    j += 1
+                while j < n and seg[j] != ']':
+                    j += 1
+                if j >= n:
+                    res += '\\['
+                else:
+                    stuff = seg[i:j].replace('\\', '\\\\')
+                    i = j + 1
+                    if stuff[0] == '!':
+                        stuff = '^' + stuff[1:]
+                    elif stuff[0] == '^':
+                        stuff = '\\' + stuff
+                    res += '[' + stuff + ']'
+            else:
+                res += re.escape(c)
+        return res
+
+    def _compile_patterns(self, patterns: list[str]) -> list[Tuple[bool, re.Pattern]]:
+        rules = []
+        for raw_pat in patterns:
+            pat = raw_pat.strip()
+            if not pat or pat.startswith('#'):
+                continue
+            
+            is_negation = pat.startswith('!')
+            if is_negation:
+                pat = pat[1:]
+                
+            is_dir_only = pat.endswith('/')
+            if is_dir_only:
+                pat = pat[:-1]
+
+            is_root_anchored = '/' in pat
+            if pat.startswith('/'):
+                pat = pat[1:]
+
+            segments = pat.split('**')
+            translated_segments = []
+            for seg in segments:
+                if seg:
+                    translated_segments.append(self._translate_segment(seg))
+                else:
+                    translated_segments.append('')
+            
+            regex_str = '.*'.join(translated_segments)
+            
+            if is_root_anchored:
+                regex_str = r'\A' + regex_str
+            else:
+                regex_str = r'(?:.*/)?' + regex_str
+                
+            if is_dir_only:
+                # Must match a directory (so it must have trailing slash, or children)
+                regex_str = regex_str + r'(?:/.*)\Z'
+            else:
+                regex_str = regex_str + r'(?:/.*)?\Z'
+                
+            try:
+                compiled = re.compile(regex_str, re.DOTALL)
+                rules.append((is_negation, compiled))
+            except re.error as e:
+                warning_logger(f"Failed to compile .cgcignore pattern '{raw_pat}': {e}")
+                continue
+                
+        return rules
+        
+    def match_file(self, file_path) -> bool:
+        """Returns True if the file should be ignored.
+        
+        Note on directory-only patterns (e.g. `build/`):
+        Since we match on the path string, a directory-only pattern requires a 
+        trailing slash in the input to be matched accurately. If the caller checks
+        a directory without appending a trailing slash (e.g. `match_file("build")`), 
+        it will not match `build/` because we cannot distinguish it from a file named `build`.
+        Callers (like `safe_walk`) should append `/` to directory paths before calling this.
+        """
+        try:
+            if isinstance(file_path, Path) and file_path.is_absolute():
+                rel_path = str(file_path.relative_to(self.root_dir)).replace("\\", "/")
+            else:
+                rel_path = str(file_path).replace("\\", "/")
+        except ValueError:
+            # If not relative to root, just use absolute
+            rel_path = str(file_path).replace("\\", "/")
+            
+        rel_path = rel_path.lstrip('/')
+        
+        ignored = False
+        for is_neg, rule in self.rules:
+            if rule.search(rel_path):
+                ignored = not is_neg
+                
+        return ignored
+
 def build_ignore_spec(
     ignore_root: Path,
     default_patterns: list[str],
     explicit_path: Optional[str] = None,
-) -> Tuple[PathSpec, Optional[Path]]:
-    """Build PathSpec using merged default + user .cgcignore patterns.
+) -> Tuple[CGCIgnoreMatcher, Optional[Path]]:
+    """Build CGCIgnoreMatcher using merged default + user .cgcignore patterns.
 
     Returns the compiled spec and the discovered/created .cgcignore path.
     """
@@ -116,4 +239,4 @@ def build_ignore_spec(
         )
 
     all_patterns = merged_user_patterns + list(default_patterns)
-    return PathSpec.from_lines("gitwildmatch", all_patterns), local_cgcignore_path
+    return CGCIgnoreMatcher(all_patterns, ignore_root), local_cgcignore_path


### PR DESCRIPTION
This PR removes our dependency on the pathspec library and implements a custom regex-based ignore matcher for .cgcignore files. 

closes #1098 

What changed
Dropped pathspec: We are now compiling user rules directly into regex for fast matching during file system walks.
Built a custom wildcard translator: Python's built-in fnmatch turned out to be way too fragile and version-dependent for our needs.  wrote a bespoke _translate_segment function from scratch that parses *, ?, character classes like [!a-z], and escape sequences without relying on any black box libraries.

Fixed directory-only patterns: Rules with trailing slashes (like build/) will now correctly ignore the directory itself and its children, but won't accidentally ignore a random file named build.

Proper negation ordering: Negation patterns (the ones starting with !) are now processed sequentially. This means a later positive rule can correctly re-ignore something that an earlier negation rule un-ignored, exactly how git handles it.

Root anchoring: Patterns that contain a slash somewhere in the middle are now properly anchored to the root directory during regex compilation.

runned a test :
<img width="833" height="47" alt="image" src="https://github.com/user-attachments/assets/ecacc1c9-e627-45dc-98b0-45ed9f61e5bf" />
<img width="658" height="181" alt="image" src="https://github.com/user-attachments/assets/666761b9-758c-4779-a14b-47b8d7d93a4e" />
  @Shashankss1205 review this 