### PR TITLE
fix: limit AST recursion depth to 20 in Python parser (#1095)

### DIFF
--- a/src/codegraphcontext/tools/languages/python.py
+++ b/src/codegraphcontext/tools/languages/python.py
@@ -77,11 +77,17 @@ class PythonTreeSitterParser:
 
     def _get_parent_context(self, node, types=('function_definition', 'class_definition')):
         curr = node.parent
+        depth = 0
+        MAX_DEPTH = 20
         while curr:
+            if depth >= MAX_DEPTH:
+                warning_logger(f"[AST] _get_parent_context exceeded max depth ({MAX_DEPTH}) - stopping traversal.")
+                break
             if curr.type in types:
                 name_node = curr.child_by_field_name('name')
                 return self._get_node_text(name_node) if name_node else None, curr.type, curr.start_point[0] + 1
             curr = curr.parent
+            depth += 1
         return None, None, None
 
     def _calculate_complexity(self, node):
@@ -92,13 +98,16 @@ class PythonTreeSitterParser:
         }
         count = 1
         
-        def traverse(n):
+        def traverse(n, depth=0):
             nonlocal count
+            if depth >= 20:
+                warning_logger(f"[AST] _calculate_complexity exceeded max depth (20) - stopping traversal.")
+                return
             if n.type in complexity_nodes:
                 count += 1
             for child in n.children:
-                traverse(child)
-        
+                traverse(child, depth + 1)
+
         traverse(node)
         return count
 

--- a/tests/unit/parsers/test_python_parser.py
+++ b/tests/unit/parsers/test_python_parser.py
@@ -108,3 +108,38 @@ class Greeter:
         # Depending on implementation, methods might be in 'functions' with parent info
         # or inside 'classes'.
         # Let's assume they are captured.
+
+    def test_ast_recursion_depth_limit_parent_context(self, parser, tmp_path):
+        """_get_parent_context must not recurse beyond MAX_DEPTH on deeply nested functions."""
+        # Build a deeply nested function (25 levels) — exceeds the MAX_DEPTH of 20
+        indent = ""
+        code = ""
+        for i in range(25):
+            code += f"{indent}def level_{i}():\n"
+            indent += "    "
+        code += f"{indent}pass\n"
+
+        f = tmp_path / "deep_nesting.py"
+        f.write_text(code)
+
+        # Should not raise RecursionError — depth guard must kick in at 20
+        result = parser.parse(str(f))
+        assert "functions" in result
+
+    def test_ast_recursion_depth_limit_complexity(self, parser, tmp_path):
+        """_calculate_complexity must not crash on deeply nested if-statements."""
+        indent = ""
+        code = "def deeply_nested():\n"
+        indent = "    "
+        for i in range(25):
+            code += f"{indent}if True:\n"
+            indent += "    "
+        code += f"{indent}pass\n"
+
+        f = tmp_path / "deep_complexity.py"
+        f.write_text(code)
+
+        # Should not raise RecursionError — traverse depth guard must kick in
+        result = parser.parse(str(f))
+        assert "functions" in result
+        assert result["functions"][0]["name"] == "deeply_nested"


### PR DESCRIPTION
## Problem
Deeply nested, autogenerated, or cyclical Python source files trigger 
Python's recursion limit in the AST parsing loop, causing the parser 
pipeline to crash.

## Fix
- Added a `MAX_DEPTH = 20` guard in `_get_parent_context` to stop 
  traversing parent nodes beyond 20 levels
- Added a `depth` counter in `_calculate_complexity`'s `traverse` 
  function to skip AST branches beyond 20 levels deep
- Both guards log a warning via `warning_logger` when the limit is hit

## Tests
Added 2 new tests in `tests/unit/parsers/test_python_parser.py`:
- `test_ast_recursion_depth_limit_parent_context` — 25-level nested functions
- `test_ast_recursion_depth_limit_complexity` — 25-level nested if-statements

All 5 tests passing locally.

Closes #1095