### PR TITLE
fix: improve SCIP fallback warning message

### DIFF
--- a/src/codegraphcontext/tools/scip_indexer.py
+++ b/src/codegraphcontext/tools/scip_indexer.py
@@ -251,7 +251,11 @@ class ScipIndexer:
                 error_logger(f"Docker SCIP indexing failed: {e}")
 
         if not binary:
-            warning_logger(f"SCIP indexer for '{lang}' not found locally or in Docker. Install with: {install_hint}")
+    warning_logger(
+        f"SCIP indexer for '{lang}' is not installed or not available in PATH. "
+        f"Falling back to Tree-sitter parsing. "
+        f"To enable SCIP indexing, install it using: {install_hint}"
+    )
         return None
 
     def _get_binary(self, lang: str) -> Tuple[Optional[str], str, str, Optional[str]]:


### PR DESCRIPTION
## Description

Improved the warning message shown when the SCIP indexer binary is unavailable.

### Changes made

* Added a clearer warning explaining that:

  * the SCIP binary is missing or not available in PATH
  * CGC is falling back to Tree-sitter parsing
  * package-level import resolution may be limited without SCIP
  * users can install SCIP using the provided install command

### Related Issue

Closes #1096 
