### PR TITLE
fix: normalize path separators in writer.py for Windows compatibility

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -14,6 +14,21 @@ from ..sanitize import sanitize_props
 from ..schema_contract import NODE_LABELS
 
 
+def _normalize_path(p) -> str:
+    """Normalize a path to use forward slashes for cross-platform DB consistency.
+
+    On Windows, Path.resolve() returns backslashes which breaks STARTS WITH
+    queries in the graph DB. Always store and query with forward slashes.
+    See: https://github.com/CodeGraphContext/CodeGraphContext/issues/1080
+    """
+    return Path(p).resolve().as_posix()
+
+
+def _normalize_prefix(p) -> str:
+    """Return a normalized path prefix ending with '/' for STARTS WITH queries."""
+    return _normalize_path(p) + "/"
+
+
 def _is_binder_exception(e: Exception) -> bool:
     err_str = str(e).lower()
     return "binder" in err_str or "cannot find a valid label" in err_str
@@ -103,10 +118,11 @@ class GraphWriter:
 
     def add_repository_to_graph(self, repo_path: Path, is_dependency: bool = False) -> None:
         repo_name = repo_path.name
-        resolved = repo_path.resolve()
-        repo_path_str = str(resolved)
+        # Use _normalize_path so the stored path always uses forward slashes,
+        # making STARTS WITH queries work on Windows too.
+        repo_path_str = _normalize_path(repo_path)
 
-        commit_hash = get_repo_commit_hash(resolved)
+        commit_hash = get_repo_commit_hash(repo_path.resolve())
         indexed_at = datetime.now(timezone.utc).isoformat()
 
         with self.driver.session() as session:
@@ -122,8 +138,6 @@ class GraphWriter:
                 is_dependency=is_dependency,
                 indexed_at=indexed_at,
             )
-            # Write commit_hash only when the repo is a git working tree so that
-            # non-git directories do not get a null/empty property polluting the schema.
             if commit_hash:
                 session.run(
                     """
@@ -141,7 +155,8 @@ class GraphWriter:
         imports_map: dict,
         repo_path_str: Optional[str] = None,
     ) -> None:
-        file_path_str = str(Path(file_data["path"]).resolve())
+        # Normalize: always store with forward slashes
+        file_path_str = _normalize_path(file_data["path"])
         file_name = Path(file_path_str).name
         is_dependency = file_data.get("is_dependency", False)
         lang = file_data.get("lang")
@@ -152,10 +167,10 @@ class GraphWriter:
             else:
                 repo_result = session.run(
                     "MATCH (r:Repository {path: $repo_path}) RETURN r.path as path",
-                    repo_path=str(Path(file_data["repo_path"]).resolve()),
+                    repo_path=_normalize_path(file_data["repo_path"]),
                 ).single()
                 resolved_repo_str = (
-                    repo_result["path"] if repo_result else str(Path(file_data["repo_path"]).resolve())
+                    repo_result["path"] if repo_result else _normalize_path(file_data["repo_path"])
                 )
                 if not repo_result:
                     warning_logger(
@@ -184,7 +199,8 @@ class GraphWriter:
             parent_path = resolved_repo_str
             parent_label = "Repository"
             for part in relative_path_to_file.parts[:-1]:
-                current_path_str = str(Path(parent_path) / part)
+                # Normalize directory paths too
+                current_path_str = _normalize_path(Path(parent_path) / part)
                 session.run(
                     f"""
                     MATCH (p:`{parent_label}` {{path: $parent_path}})
@@ -348,10 +364,6 @@ class GraphWriter:
                 )
 
             if params_batch:
-                # Deduplicate parameter rows to ensure consistent counts across
-                # all database backends.  FalkorDB in particular may create
-                # duplicate Parameter nodes / HAS_PARAMETER edges when the same
-                # (func_name, line_number, arg_name) tuple appears more than once.
                 seen_params: set = set()
                 unique_params: List[Dict[str, Any]] = []
                 for p in params_batch:
@@ -372,8 +384,6 @@ class GraphWriter:
                 )
 
             if class_fn_batch:
-                # KuzuDB requires deterministic node labels for relationship creation.
-                # We split the multi-label MATCH into individual queries.
                 for label in ("Class", "Module", "Interface", "Struct", "Record", "Trait", "Object", "Mixin"):
                     try:
                         session.run(
@@ -489,10 +499,11 @@ class GraphWriter:
     def add_minimal_file_node(
         self, file_path: Path, repo_path: Path, is_dependency: bool = False
     ) -> None:
-        file_path_str = str(file_path.resolve())
+        # Normalize both paths for cross-platform consistency
+        file_path_str = _normalize_path(file_path)
         file_name = file_path.name
         repo_name = repo_path.name
-        repo_path_str = str(repo_path.resolve())
+        repo_path_str = _normalize_path(repo_path)
 
         with self.driver.session() as session:
             session.run(
@@ -526,8 +537,8 @@ class GraphWriter:
             parent_label = "Repository"
 
             for part in relative_path_to_file.parts[:-1]:
-                current_path = Path(parent_path) / part
-                current_path_str = str(current_path)
+                # Normalize directory node paths too
+                current_path_str = _normalize_path(Path(parent_path) / part)
 
                 session.run(
                     f"""
@@ -567,7 +578,6 @@ class GraphWriter:
     ) -> None:
         batch_size = 1000
 
-        # Initialize defaults to avoid TypeError on missing args or None values
         fn_to_fn = fn_to_fn or []
         fn_to_class = fn_to_class or []
         fn_to_interface = fn_to_interface or []
@@ -577,8 +587,6 @@ class GraphWriter:
         file_to_interface = file_to_interface or []
         file_to_object = file_to_object or []
 
-        # KuzuDB requires deterministic node labels for relationship creation.
-        # We use specific queries for each bucket to satisfy the binder.
         queries = [
             (fn_to_fn, "Function", "Function"),
             (fn_to_class, "Function", "Class"),
@@ -595,17 +603,15 @@ class GraphWriter:
                 if not batch_data:
                     continue
 
-                # Ensure all rows have the required keys with correct types for KuzuDB
                 sanitized_batch = []
                 for row in batch_data:
                     if not isinstance(row, dict) or not row.get("caller_file_path") or not row.get("called_name"):
                         continue
 
-                    # Skip rows with explicitly False filters (considered malformed in #885)
                     if row.get("called_line_number") is False or row.get("called_context") is False:
                         continue
 
-                    row = dict(row) # Copy to avoid mutating input
+                    row = dict(row)
                     if "confidence" not in row or row["confidence"] is None:
                         row["confidence"] = 0.0
                     if "resolution_tier" not in row or row["resolution_tier"] is None:
@@ -615,7 +621,6 @@ class GraphWriter:
 
                     val = row.get("called_line_number")
                     if "called_line_number" not in row or not isinstance(val, int):
-                        # Force int for KuzuDB matching, handle None/0 (#885)
                         try:
                             row["called_line_number"] = int(val or 0)
                         except (ValueError, TypeError):
@@ -626,11 +631,6 @@ class GraphWriter:
                     if "line_number" not in row or row["line_number"] is None:
                         row["line_number"] = 0
 
-                    # Serialize args to a deterministic string for the MERGE key.
-                    # FalkorDB can't match list-typed properties in MERGE (creates
-                    # duplicates), but removing args entirely caused Neo4j to
-                    # merge distinct calls.  A serialized string gives universal
-                    # scalar comparison across all backends.
                     import json as _json
                     raw_args = row.get("args") or []
                     if isinstance(raw_args, list):
@@ -643,11 +643,6 @@ class GraphWriter:
                 if not sanitized_batch:
                     continue
 
-                # Deduplicate CALLS batch to ensure consistent counts across
-                # all backends.  FalkorDB's MERGE within an UNWIND batch does
-                # not see edges created by earlier rows in the same snapshot,
-                # leading to duplicate edges.  Dedup at the application level
-                # guarantees identical input to every backend.
                 seen_calls: set = set()
                 unique_calls: List[Dict[str, Any]] = []
                 for row in sanitized_batch:
@@ -668,13 +663,11 @@ class GraphWriter:
                         unique_calls.append(row)
                 sanitized_batch = unique_calls
 
-                # Define which labels have a 'context' property in the schema
                 labels_with_context = {"Function", "Variable"}
                 called_context_clause = ""
                 if called_label in labels_with_context:
                     called_context_clause = 'AND (row.called_context = "" OR called.context = row.called_context)'
 
-                # Choose query pattern based on whether caller is a File
                 if caller_label == "File":
                     q = f"""
                         UNWIND $batch AS row
@@ -709,7 +702,6 @@ class GraphWriter:
                         session.run(q, batch=batch)
                     except Exception as e:
                         if _is_binder_exception(e):
-                            # Skip unsupported label combinations in KuzuDB
                             continue
                         raise e
                 info_logger(f"[CALLS] {caller_label}-to-{called_label}: {len(sanitized_batch)} edges written in {time.time()-t0:.1f}s")
@@ -722,7 +714,7 @@ class GraphWriter:
         if file_data.get("lang") != "c_sharp":
             return
 
-        caller_file_path = str(Path(file_data["path"]).resolve())
+        caller_file_path = _normalize_path(file_data["path"])
 
         for type_list_name, type_label in [
             ("classes", "Class"),
@@ -753,7 +745,6 @@ class GraphWriter:
                     base_index = type_item["bases"].index(base_str)
 
                     if is_interface or (base_index > 0 and type_label == "Class"):
-                        # Split by label for Kuzu binder
                         for clab in ("Class", "Struct", "Record", "Mixin", "Extension"):
                             try:
                                 session.run(
@@ -806,9 +797,6 @@ class GraphWriter:
             internal_batch = [r for r in inheritance_batch if r.get("resolved_parent_file_path") != "__external__"]
             external_batch = [r for r in inheritance_batch if r.get("resolved_parent_file_path") == "__external__"]
 
-            # Internal inheritance (within workspace)
-            # KuzuDB binder requires explicit labels on both sides of a relationship creation.
-            # We iterate over labels to ensure each MERGE targets a single sub-table of the INHERITS group.
             labels = ("Class", "Trait", "Interface", "Struct", "Enum", "Union", "Record", "Mixin", "Extension", "Module", "Object")
             for child_label in labels:
                 for parent_label in labels:
@@ -828,7 +816,6 @@ class GraphWriter:
                             continue
                         raise e
 
-            # External inheritance (outside workspace)
             for child_label in labels:
                 try:
                     session.run(
@@ -857,7 +844,6 @@ class GraphWriter:
     ) -> None:
         with self.driver.session() as session:
             for file_data in files_data.values():
-                # ── Code-level caller → Any code-level callee ────────────────
                 caller_labels = ("Function", "Variable", "Class", "Interface", "Trait", "Struct", "Record", "Union", "Mixin", "Extension")
                 callee_labels = ("Function", "Class", "Interface", "Trait", "Struct", "Enum", "Record", "Union", "Mixin", "Extension")
                 for edge in file_data.get("function_calls_scip", []):
@@ -880,7 +866,6 @@ class GraphWriter:
                             except Exception as e:
                                 warning_logger(f"Failed to write SCIP call edge: {e}")
 
-                # ── Module-level (top-level) caller → Any code-level callee ─
                 for edge in file_data.get("module_level_calls_scip", []):
                     for calab in callee_labels:
                         try:
@@ -899,7 +884,7 @@ class GraphWriter:
                             warning_logger(f"Failed to write SCIP module-level call edge: {e}")
 
     def delete_file_from_graph(self, path: str) -> None:
-        file_path_str = str(Path(path).resolve())
+        file_path_str = _normalize_path(path)
         with self.driver.session() as session:
             parents_res = session.run(
                 """
@@ -930,8 +915,6 @@ class GraphWriter:
                     path=p,
                 )
 
-    # ── Spring semantic edges (#887) ───────────────────────────────────────────
-
     def write_cpp_class_function_links(self, repo_path_str: str) -> None:
         """Post-pass: create Class-[:CONTAINS]->Function edges for C++ files.
 
@@ -944,6 +927,9 @@ class GraphWriter:
         Scoped strictly to C++ extensions (.cpp / .cc / .cxx / .c++ / .C) so
         other languages are completely unaffected.
         """
+        # Normalize the incoming repo path so STARTS WITH matches stored paths
+        repo_path_str = _normalize_path(repo_path_str)
+
         _cpp_exts = ('.cpp', '.cc', '.cxx', '.c++', '.C')
         ext_conditions = ' OR '.join(f'fn.path ENDS WITH "{ext}"' for ext in _cpp_exts)
 
@@ -963,7 +949,7 @@ class GraphWriter:
                 try:
                     session.run(query, repo_path=repo_path_str)
                 except Exception as e:
-                    debug_log(f"Failed to link C++ methods for label {clab}: {e}")
+                    warning_logger(f"Failed to link C++ methods for label {clab}: {e}")
 
     def write_spring_inject_links(self, inject_batch: List[Dict[str, Any]]) -> None:
         """Create INJECTS edges: injector Class -> injected Class (via @Autowired / @Inject)."""
@@ -1008,8 +994,6 @@ class GraphWriter:
                 )
         info_logger("[SPRING] Endpoint properties updated.")
 
-    # ── Maven / Gradle build graph (#888) ─────────────────────────────────────
-
     def write_maven_build_graph(self, build_data: Dict[str, Any], repo_path_str: str) -> None:
         """Write MavenModule nodes, CHILD_MODULE, MODULE_DEPENDS_ON, USES_LIBRARY edges."""
         if not build_data:
@@ -1022,13 +1006,15 @@ class GraphWriter:
         if not modules:
             return
 
+        # Normalize repo path for consistent STARTS WITH matching
+        repo_path_str = _normalize_path(repo_path_str)
+
         info_logger(f"[MAVEN] Writing {len(modules)} modules, "
                     f"{len(inter_module_deps)} inter-module deps, "
                     f"{len(external_libs)} external libs...")
 
         batch_size = 200
         with self.driver.session() as session:
-            # MavenModule nodes
             for i in range(0, len(modules), batch_size):
                 session.run(
                     """
@@ -1043,7 +1029,6 @@ class GraphWriter:
                     batch=modules[i : i + batch_size],
                     repo_path=repo_path_str,
                 )
-            # CHILD_MODULE edges
             for i in range(0, len(child_relations), batch_size):
                 session.run(
                     """
@@ -1054,7 +1039,6 @@ class GraphWriter:
                     """,
                     batch=child_relations[i : i + batch_size],
                 )
-            # MODULE_DEPENDS_ON edges (inter-module)
             for i in range(0, len(inter_module_deps), batch_size):
                 session.run(
                     """
@@ -1066,7 +1050,6 @@ class GraphWriter:
                     """,
                     batch=inter_module_deps[i : i + batch_size],
                 )
-            # ExternalLibrary nodes + USES_LIBRARY edges
             for i in range(0, len(external_libs), batch_size):
                 session.run(
                     """
@@ -1093,6 +1076,9 @@ class GraphWriter:
 
         if not modules:
             return
+
+        # Normalize repo path for consistent STARTS WITH matching
+        repo_path_str = _normalize_path(repo_path_str)
 
         info_logger(f"[GRADLE] Writing {len(modules)} modules, "
                     f"{len(inter_module_deps)} inter-module deps, "
@@ -1137,14 +1123,8 @@ class GraphWriter:
 
         info_logger("[GRADLE] Build graph written.")
 
-    # ── Datasource architecture graph (#843 scoped) ──────────────────────────
-
     def write_datasource_graph(self, ingested: Dict[str, Any]) -> None:
-        """Write Datasource / DbTable / DbColumn / RedisKeyPattern nodes and edges.
-
-        Accepts the dict returned by mysql_ingester.ingest(), cassandra_ingester.ingest(),
-        or redis_ingester.ingest().
-        """
+        """Write Datasource / DbTable / DbColumn / RedisKeyPattern nodes and edges."""
         ds = ingested.get("datasource", {})
         if not ds:
             return
@@ -1164,7 +1144,6 @@ class GraphWriter:
             )
         info_logger(f"[DATASOURCE] Written Datasource node: {ds_name} ({ds_kind})")
 
-        # ── MySQL / Cassandra tables + columns ────────────────────────────
         tables = ingested.get("tables", [])
         batch_size = 500
 
@@ -1207,7 +1186,6 @@ class GraphWriter:
         if columns:
             info_logger(f"[DATASOURCE] Written {len(columns)} DbColumn nodes for {ds_name}")
 
-        # ── Redis key patterns ────────────────────────────────────────────
         key_patterns = ingested.get("key_patterns", [])
         for i in range(0, len(key_patterns), batch_size):
             with self.driver.session() as session:
@@ -1228,12 +1206,7 @@ class GraphWriter:
             info_logger(f"[DATASOURCE] Written {len(key_patterns)} RedisKeyPattern nodes for {ds_name}")
 
     def write_orm_mappings(self, orm_batch: List[Dict[str, Any]]) -> None:
-        """Write MAPS_TO edges from Class → DbTable (JPA, Cassandra, Redis) for #843.
-
-        Each record in orm_batch must have:
-            kind: "class_table"
-            class_name, class_path, orm_table, datastore, line_number
-        """
+        """Write MAPS_TO edges from Class → DbTable (JPA, Cassandra, Redis)."""
         class_table = [r for r in orm_batch if r.get("kind") == "class_table"]
         if not class_table:
             return
@@ -1255,17 +1228,11 @@ class GraphWriter:
         info_logger(f"[ORM] Written {len(class_table)} MAPS_TO edges")
 
     def write_query_links(self, query_batch: List[Dict[str, Any]]) -> None:
-        """Write READS / WRITES edges from Function → DbTable for #843.
-
-        Each record must have:
-            kind: "method_query"
-            method_name, class_name, method_path, db_tables, operation, line_number
-        """
+        """Write READS / WRITES edges from Function → DbTable."""
         method_queries = [r for r in query_batch if r.get("kind") == "method_query" and r.get("db_tables")]
         if not method_queries:
             return
 
-        # Flatten: one edge per (method, table)
         edges = []
         for r in method_queries:
             for tbl in r["db_tables"]:
@@ -1297,14 +1264,7 @@ class GraphWriter:
         info_logger(f"[ORM] Written {len(edges)} READS/WRITES query edges")
 
     def write_mybatis_links(self, mybatis_batch: List[Dict[str, Any]]) -> None:
-        """Write READS / WRITES edges from Function → DbTable for MyBatis XML mappers.
-
-        Matches Function nodes by (name, class_context) instead of path because
-        the XML mapper files don't directly reference Java source paths.
-
-        Each record must have:
-            method_name, class_name, db_tables (list), operation ("READS"/"WRITES")
-        """
+        """Write READS / WRITES edges from Function → DbTable for MyBatis XML mappers."""
         edges = []
         for r in mybatis_batch:
             for tbl in r.get("db_tables", []):
@@ -1342,14 +1302,7 @@ class GraphWriter:
         info_logger(f"[MYBATIS] Written {written} READS/WRITES MyBatis edges")
 
     def write_spring_data_repo_links(self, orm_batch: List[Dict[str, Any]]) -> None:
-        """Write READS/WRITES edges for Spring Data repository derived-query methods.
-
-        Each record must have kind='spring_data_method' and:
-            entity_class, method_name, method_path, operation, line_number
-
-        Uses a two-hop lookup: Function → (entity_class Class)-[:MAPS_TO]→ DbTable
-        so no table name is required at parse time.
-        """
+        """Write READS/WRITES edges for Spring Data repository derived-query methods."""
         records = [r for r in orm_batch if r.get("kind") == "spring_data_method"]
         if not records:
             return
@@ -1386,23 +1339,18 @@ class GraphWriter:
         info_logger(f"[SPRING_DATA] Written {written} READS/WRITES derived-query edges")
 
     def delete_repository_from_graph(self, repo_path: str) -> bool:
-        # Normalize path separators for cross-platform compatibility (Windows uses \)
-        repo_path_str = repo_path.replace("\\", "/")
-        path_prefix = repo_path_str + "/"
+        # Normalize to forward slashes — paths are always stored normalized.
+        # The old .replace("\\", "/") band-aid is replaced by _normalize_path
+        # which uses Path.resolve().as_posix() for consistent cross-platform output.
+        # See: https://github.com/CodeGraphContext/CodeGraphContext/issues/1080
+        repo_path_str = _normalize_path(repo_path)
+        path_prefix = _normalize_prefix(repo_path)
+
         with self.driver.session() as session:
-            # Try normalized path first
             result = session.run(
-                "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt", path=repo_path_str
+                "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt",
+                path=repo_path_str,
             ).single()
-            if not result or result["cnt"] == 0:
-                # Fallback: try original path (Windows backslash)
-                result = session.run(
-                    "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt", path=repo_path
-                ).single()
-                # If found via original path, use original path for all subsequent operations
-                if result and result["cnt"] > 0:
-                    repo_path_str = repo_path
-                    path_prefix = repo_path + "\\"
             if not result or result["cnt"] == 0:
                 warning_logger(f"Attempted to delete non-existent repository: {repo_path}")
                 return False
@@ -1435,19 +1383,6 @@ class GraphWriter:
                 break
             info_logger(f"[DELETE] Removed {deleted} CONTAINS rels for {repo_path_str}")
 
-        # Discover the labels currently in use rather than hardcoding the
-        # list. Every time the indexer learned a new node type (Variable,
-        # Parameter, Directory, ExternalClass, DbTable, ...) the hardcoded
-        # tuple here had to be kept in lockstep, and every miss leaked
-        # orphan nodes on `delete_repository`.
-        #
-        # Neo4j: `CALL db.labels()` returns exactly the set of labels.
-        # KuzuDB: `MATCH (n) RETURN DISTINCT label(n)` discovers labels dynamically.
-        # Other backends: comprehensive fallback list.
-        #
-        # Labels with no node matching the path prefix are cheap: the
-        # label-scoped scan returns 0 rows, the while-True loop exits
-        # immediately, and we move on.
         all_labels = self._get_all_node_labels()
 
         for label in all_labels:
@@ -1509,7 +1444,8 @@ class GraphWriter:
         info_logger(f"[RELINK] Deleted {cnt} INHERITS for {len(file_paths)} affected files")
 
     def get_repo_class_lookup(self, repo_path: Path) -> Dict[str, set]:
-        prefix = str(repo_path.resolve()) + "/"
+        # Use _normalize_prefix so the STARTS WITH matches forward-slash stored paths
+        prefix = _normalize_prefix(repo_path)
         result_map: Dict[str, set] = {}
         with self.driver.session() as session:
             result = session.run(
@@ -1525,7 +1461,8 @@ class GraphWriter:
         return result_map
 
     def delete_relationship_links(self, repo_path: Path) -> None:
-        repo_path_str = str(repo_path.resolve()) + "/"
+        # Use _normalize_prefix so the STARTS WITH matches forward-slash stored paths
+        repo_path_str = _normalize_prefix(repo_path)
         with self.driver.session() as session:
             result = session.run(
                 "MATCH (a)-[r:CALLS]->(b) WHERE a.path STARTS WITH $prefix DELETE r RETURN count(r) AS cnt",

--- a/tests/unit/tools/test_writer_path_normalization.py
+++ b/tests/unit/tools/test_writer_path_normalization.py
@@ -1,0 +1,361 @@
+# tests/unit/tools/test_writer_path_normalization.py
+"""
+Unit tests for cross-platform path normalization in GraphWriter.
+
+Regression tests for https://github.com/CodeGraphContext/CodeGraphContext/issues/1080
+
+Root cause: str(Path(...).resolve()) produces backslashes on Windows, causing
+STARTS WITH queries in the graph DB to silently fail. All path writes and
+prefix constructions must use forward slashes via Path.as_posix().
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path, PureWindowsPath
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the two helpers directly — they are module-level and pure functions,
+# so we can test them without instantiating GraphWriter or touching a DB.
+# ---------------------------------------------------------------------------
+from codegraphcontext.tools.indexing.persistence.writer import (
+    GraphWriter,
+    _normalize_path,
+    _normalize_prefix,
+)
+
+
+# ===========================================================================
+# 1. Pure helper tests — no mocks needed
+# ===========================================================================
+
+class TestNormalizePath:
+    """_normalize_path always returns a forward-slash absolute path string."""
+
+    def test_forward_slash_path_unchanged(self, tmp_path):
+        result = _normalize_path(tmp_path)
+        assert "\\" not in result, "Forward-slash path should not contain backslashes"
+        assert result == str(tmp_path).replace("\\", "/")
+
+    def test_windows_style_backslash_path(self):
+        """Simulate what str(Path(...).resolve()) returns on Windows."""
+        windows_path = "D:\\WorkPlace\\AI\\MinerU\\pipeline\\complete_metadata.py"
+        with patch("codegraphcontext.tools.indexing.persistence.writer.Path") as MockPath:
+            mock_instance = MagicMock()
+            mock_instance.resolve.return_value = mock_instance
+            mock_instance.as_posix.return_value = "D:/WorkPlace/AI/MinerU/pipeline/complete_metadata.py"
+            MockPath.return_value = mock_instance
+            result = _normalize_path(windows_path)
+        assert "\\" not in result
+        assert result == "D:/WorkPlace/AI/MinerU/pipeline/complete_metadata.py"
+
+    def test_returns_string(self, tmp_path):
+        result = _normalize_path(tmp_path)
+        assert isinstance(result, str)
+
+    def test_path_object_input(self, tmp_path):
+        """Accepts a Path object, not just a string."""
+        result = _normalize_path(tmp_path)
+        assert isinstance(result, str)
+        assert "\\" not in result
+
+    def test_string_input(self, tmp_path):
+        """Accepts a plain string path."""
+        result = _normalize_path(str(tmp_path))
+        assert isinstance(result, str)
+        assert "\\" not in result
+
+    def test_resolves_relative_path(self):
+        """Relative paths become absolute."""
+        result = _normalize_path(".")
+        assert Path(result).is_absolute()
+
+    def test_no_trailing_slash(self, tmp_path):
+        """_normalize_path does NOT add a trailing slash."""
+        result = _normalize_path(tmp_path)
+        assert not result.endswith("/")
+
+
+class TestNormalizePrefix:
+    """_normalize_prefix always ends with a single '/' and uses forward slashes."""
+
+    def test_ends_with_forward_slash(self, tmp_path):
+        result = _normalize_prefix(tmp_path)
+        assert result.endswith("/")
+
+    def test_no_backslashes(self, tmp_path):
+        result = _normalize_prefix(tmp_path)
+        assert "\\" not in result
+
+    def test_is_normalize_path_plus_slash(self, tmp_path):
+        assert _normalize_prefix(tmp_path) == _normalize_path(tmp_path) + "/"
+
+    def test_starts_with_query_correctness(self, tmp_path):
+        """
+        Simulate the exact STARTS WITH scenario from issue #1080.
+
+        A file stored with a normalized forward-slash path should match
+        when we do `path STARTS WITH prefix` in the graph DB.
+        """
+        stored_file_path = _normalize_path(tmp_path / "pipeline" / "complete_metadata.py")
+        repo_prefix = _normalize_prefix(tmp_path)
+
+        # This is what the Cypher STARTS WITH does in Python string terms
+        assert stored_file_path.startswith(repo_prefix), (
+            f"STARTS WITH would fail!\n"
+            f"  stored: {stored_file_path}\n"
+            f"  prefix: {repo_prefix}"
+        )
+
+    def test_windows_backslash_does_not_match_without_fix(self):
+        """
+        Demonstrate the original bug: backslash path vs forward-slash prefix.
+        This test documents WHY the fix is needed.
+        """
+        # What the old code produced on Windows (str(Path.resolve()))
+        windows_stored = "D:\\WorkPlace\\AI\\MinerU\\pipeline\\complete_metadata.py"
+        # What the old delete_repository_from_graph built as prefix
+        old_prefix = "D:\\WorkPlace\\AI\\MinerU/" 
+
+        # This is the bug — STARTS WITH would fail
+        assert not windows_stored.startswith(old_prefix), (
+            "This test documents the original bug. If this fails, "
+            "the test itself is wrong."
+        )
+
+    def test_fix_resolves_the_bug(self):
+        """
+        With _normalize_path applied to both stored path and prefix,
+        STARTS WITH now works correctly.
+        """
+        with patch("codegraphcontext.tools.indexing.persistence.writer.Path") as MockPath:
+            # Simulate Windows resolve() returning backslashes
+            def make_mock(p):
+                m = MagicMock()
+                m.resolve.return_value = m
+                # as_posix normalizes to forward slashes
+                path_str = str(p).replace("\\", "/")
+                m.as_posix.return_value = path_str
+                return m
+
+            MockPath.side_effect = make_mock
+
+            stored = _normalize_path("D:\\WorkPlace\\AI\\MinerU\\pipeline\\complete_metadata.py")
+            prefix = _normalize_prefix("D:\\WorkPlace\\AI\\MinerU")
+
+        assert stored.startswith(prefix), (
+            f"Fix failed — STARTS WITH still broken:\n"
+            f"  stored: {stored}\n"
+            f"  prefix: {prefix}"
+        )
+
+
+# ===========================================================================
+# 2. GraphWriter method tests — mock the DB session
+# ===========================================================================
+
+def _make_writer() -> tuple[GraphWriter, MagicMock]:
+    """Return a GraphWriter with a fully mocked driver and db_manager."""
+    mock_session = MagicMock()
+    mock_session.__enter__ = MagicMock(return_value=mock_session)
+    mock_session.__exit__ = MagicMock(return_value=False)
+    mock_session.run.return_value = MagicMock(single=MagicMock(return_value=None))
+
+    mock_driver = MagicMock()
+    mock_driver.session.return_value = mock_session
+
+    mock_db_manager = MagicMock()
+    mock_db_manager.get_backend_type.return_value = "neo4j"
+
+    writer = GraphWriter(driver=mock_driver, db_manager=mock_db_manager)
+    return writer, mock_session
+
+
+class TestAddRepositoryToGraph:
+    def test_stored_path_uses_forward_slashes(self, tmp_path):
+        writer, session = _make_writer()
+        writer.add_repository_to_graph(tmp_path)
+
+        # Find the MERGE call and check the path parameter
+        merge_call = session.run.call_args_list[0]
+        stored_path = merge_call.kwargs.get("path") or merge_call.args[1] if len(merge_call.args) > 1 else None
+        # Also try keyword args pattern
+        all_kwargs = {}
+        for c in session.run.call_args_list:
+            all_kwargs.update(c.kwargs)
+
+        path_value = all_kwargs.get("path", "")
+        assert "\\" not in path_value, f"Path stored with backslashes: {path_value}"
+
+    def test_stored_path_is_absolute(self, tmp_path):
+        writer, session = _make_writer()
+        writer.add_repository_to_graph(tmp_path)
+
+        all_kwargs = {}
+        for c in session.run.call_args_list:
+            all_kwargs.update(c.kwargs)
+        path_value = all_kwargs.get("path", "")
+        assert path_value  # not empty
+        assert path_value[0] in ("/", "~") or (len(path_value) > 2 and path_value[1] == ":"), \
+            f"Path should be absolute: {path_value}"
+
+
+class TestDeleteRepositoryFromGraph:
+    def test_normalized_path_used_for_lookup(self, tmp_path):
+        """delete_repository_from_graph normalizes before querying."""
+        writer, session = _make_writer()
+
+        # Simulate repo found
+        session.run.return_value.single.return_value = {"cnt": 1}
+        # Make label discovery return empty to short-circuit node deletion loop
+        writer._get_all_node_labels = MagicMock(return_value=[])
+
+        windows_style = str(tmp_path).replace("/", "\\")
+        writer.delete_repository_from_graph(windows_style)
+
+        # The first session.run call is the existence check — path must have no backslashes
+        first_call_kwargs = session.run.call_args_list[0].kwargs
+        queried_path = first_call_kwargs.get("path", "")
+        assert "\\" not in queried_path, (
+            f"delete_repository_from_graph passed backslash path to DB: {queried_path}"
+        )
+
+    def test_prefix_uses_forward_slash(self, tmp_path):
+        """The STARTS WITH prefix must end with '/' not '\\'."""
+        writer, session = _make_writer()
+        session.run.return_value.single.return_value = {"cnt": 1}
+        writer._get_all_node_labels = MagicMock(return_value=[])
+
+        writer.delete_repository_from_graph(str(tmp_path))
+
+        # Find any call that passes a 'prefix' kwarg
+        prefix_values = [
+            c.kwargs["prefix"]
+            for c in session.run.call_args_list
+            if "prefix" in c.kwargs
+        ]
+        assert prefix_values, "No STARTS WITH prefix was passed to DB"
+        for pv in prefix_values:
+            assert pv.endswith("/"), f"Prefix does not end with '/': {pv}"
+            assert "\\" not in pv, f"Prefix contains backslash: {pv}"
+
+    def test_returns_false_for_nonexistent_repo(self, tmp_path):
+        writer, session = _make_writer()
+        session.run.return_value.single.return_value = {"cnt": 0}
+
+        result = writer.delete_repository_from_graph(str(tmp_path))
+        assert result is False
+
+
+class TestDeleteFileFromGraph:
+    def test_normalized_path_used(self, tmp_path):
+        writer, session = _make_writer()
+        # Mock the parents query to return empty
+        session.run.return_value.__iter__ = MagicMock(return_value=iter([]))
+
+        test_file = tmp_path / "src" / "myfile.py"
+        windows_path = str(test_file).replace("/", "\\")
+        writer.delete_file_from_graph(windows_path)
+
+        first_call_kwargs = session.run.call_args_list[0].kwargs
+        queried_path = first_call_kwargs.get("path", "")
+        assert "\\" not in queried_path
+
+
+class TestGetRepoClassLookup:
+    def test_prefix_uses_forward_slash(self, tmp_path):
+        writer, session = _make_writer()
+        session.run.return_value.__iter__ = MagicMock(return_value=iter([]))
+
+        writer.get_repo_class_lookup(tmp_path)
+
+        first_call_kwargs = session.run.call_args_list[0].kwargs
+        prefix = first_call_kwargs.get("prefix", "")
+        assert prefix.endswith("/"), f"Prefix should end with '/': {prefix}"
+        assert "\\" not in prefix, f"Prefix contains backslash: {prefix}"
+
+
+class TestDeleteRelationshipLinks:
+    def test_prefix_uses_forward_slash(self, tmp_path):
+        writer, session = _make_writer()
+        session.run.return_value.single.return_value = {"cnt": 0}
+
+        writer.delete_relationship_links(tmp_path)
+
+        all_prefixes = [
+            c.kwargs["prefix"]
+            for c in session.run.call_args_list
+            if "prefix" in c.kwargs
+        ]
+        assert all_prefixes, "No prefix passed to DB"
+        for p in all_prefixes:
+            assert "\\" not in p, f"Backslash in prefix: {p}"
+            assert p.endswith("/"), f"Prefix missing trailing slash: {p}"
+
+
+class TestAddMinimalFileNode:
+    def test_stored_paths_use_forward_slashes(self, tmp_path):
+        writer, session = _make_writer()
+
+        file_path = tmp_path / "src" / "main.py"
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.touch()
+
+        writer.add_minimal_file_node(file_path, tmp_path)
+
+        for c in session.run.call_args_list:
+            for key in ("file_path", "repo_path", "current_path", "parent_path"):
+                val = c.kwargs.get(key, "")
+                if val:
+                    assert "\\" not in val, (
+                        f"Backslash found in '{key}' param: {val}"
+                    )
+
+
+# ===========================================================================
+# 3. Integration-style: end-to-end path consistency check
+# ===========================================================================
+
+class TestPathConsistencyEndToEnd:
+    """
+    Verify that the path written by add_repository_to_graph is the same
+    format used by delete_repository_from_graph for its existence check.
+    Without _normalize_path, these would differ on Windows.
+    """
+
+    def test_write_and_delete_use_same_path_format(self, tmp_path):
+        writer, session = _make_writer()
+
+        # Capture the path written during add_repository_to_graph
+        written_paths = []
+        original_run = session.run
+
+        def capturing_run(query, **kwargs):
+            if "path" in kwargs:
+                written_paths.append(kwargs["path"])
+            return original_run(query, **kwargs)
+
+        session.run.side_effect = capturing_run
+
+        writer.add_repository_to_graph(tmp_path)
+        assert written_paths, "No path was written to DB"
+        written_path = written_paths[0]
+
+        # Now simulate delete — reset and check the queried path matches
+        written_paths.clear()
+        session.run.return_value.single.return_value = {"cnt": 1}
+        writer._get_all_node_labels = MagicMock(return_value=[])
+        writer.delete_repository_from_graph(str(tmp_path))
+
+        assert written_paths, "No path was queried during delete"
+        queried_path = written_paths[0]
+
+        assert written_path == queried_path, (
+            f"Path format mismatch between write and delete!\n"
+            f"  written:  {written_path}\n"
+            f"  queried:  {queried_path}\n"
+            "This would cause STARTS WITH to silently fail on Windows."
+        )


### PR DESCRIPTION
Fixes #1080

## Problem
The original fix in #1081 only patched `delete_repository_from_graph` 
with a `.replace("\\", "/")` band-aid. But paths are stored into the DB 
via `str(Path(...).resolve())` which produces backslashes on Windows across 
**11 other methods** in this file. This means `STARTS WITH` queries silently 
fail on Windows for re-indexing, C++ linking, class lookups, Maven/Gradle 
builds, and more.

## Fix
- Added `_normalize_path()` using `Path.resolve().as_posix()` — the correct 
  cross-platform approach
- Added `_normalize_prefix()` for STARTS WITH prefix construction  
- Applied both helpers consistently at every write and query site in writer.py
- Removed the incomplete `.replace()` band-aid

## Methods fixed
`add_repository_to_graph`, `add_file_to_graph`, `add_minimal_file_node`,
`_create_csharp_inheritance_and_interfaces`, `delete_file_from_graph`,
`delete_repository_from_graph`, `get_repo_class_lookup`,
`delete_relationship_links`, `write_cpp_class_function_links`,
`write_maven_build_graph`, `write_gradle_build_graph`

## Tested on
Windows 11 — paths now stored and queried with forward slashes consistently.