### PR TITLE
fix(cli): propagate database query exceptions in CLI output (#1097)

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -415,6 +415,49 @@ def delete_helper(repo_path: str, context: Optional[str] = None):
     finally:
         db_manager.close_driver()
 
+def _print_query_exception(e: Exception, query: str) -> None:
+    """
+    Pretty-print a database query exception, surfacing the raw driver
+    error message so Cypher syntax problems are clearly visible.
+    """
+    import traceback
+
+    error_type = type(e).__name__
+    error_module = type(e).__module__ or ""
+
+    # Neo4j: CypherSyntaxError and other ClientError subclasses carry
+    # a .message and .code attribute with the full server-side detail.
+    if "neo4j" in error_module:
+        code = getattr(e, "code", None)
+        msg = getattr(e, "message", None) or str(e)
+        console.print(f"[bold red]Query Error ({error_type}):[/bold red]")
+        if code:
+            console.print(f"  [yellow]Code:[/yellow] {code}")
+        console.print(f"  [yellow]Message:[/yellow] {msg}")
+
+    # FalkorDB: ResponseError / exceptions in falkordb or redis packages
+    elif "falkordb" in error_module or "redis" in error_module:
+        console.print(f"[bold red]Query Error ({error_type}):[/bold red]")
+        console.print(f"  [yellow]Database message:[/yellow] {e}")
+
+    # KuzuDB: RuntimeError from the kuzu extension
+    # KuzuDB: RuntimeError from the kuzu extension or database_kuzu wrapper
+    elif "kuzu" in error_module or (
+        error_type == "RuntimeError" and "Parser exception" in str(e)
+    ):
+        console.print(f"[bold red]Query Error ({error_type}):[/bold red]")
+        console.print(f"  [yellow]Database message:[/yellow] {e}")
+
+    else:
+        # Fallback: unknown backend — print type + message + traceback
+        console.print(f"[bold red]An error occurred while executing query ({error_type}):[/bold red]")
+        console.print(f"  [yellow]Message:[/yellow] {e}")
+        console.print("[dim]--- Traceback ---[/dim]")
+        console.print(f"[dim]{traceback.format_exc()}[/dim]")
+
+    console.print(f"\n[dim]Failed query:[/dim]")
+    console.print(f"[dim]  {query}[/dim]")
+
 
 def cypher_helper(query: str, context: Optional[str] = None):
     """Executes a read-only Cypher query."""
@@ -440,7 +483,7 @@ def cypher_helper(query: str, context: Optional[str] = None):
             records = [record.data() for record in result]
             console.print(json.dumps(records, indent=2))
     except Exception as e:
-        console.print(f"[bold red]An error occurred while executing query:[/bold red] {e}")
+        _print_query_exception(e, query)
         db_manager.close_driver()
         raise typer.Exit(code=1)
     finally:
@@ -466,7 +509,7 @@ def cypher_helper_visual(query: str, context: Optional[str] = None):
     try:
         visualize_cypher_results(query)
     except Exception as e:
-        console.print(f"[bold red]An error occurred while executing query:[/bold red] {e}")
+        _print_query_exception(e, query)
         db_manager.close_driver()
         raise typer.Exit(code=1)
     finally:

--- a/tests/unit/cli/test_query_exception_propagation.py
+++ b/tests/unit/cli/test_query_exception_propagation.py
@@ -1,0 +1,174 @@
+"""Tests for issue #1097: cgc query propagates raw database exceptions."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import pytest
+import typer
+from codegraphcontext.cli import cli_helpers
+
+
+def _services():
+    db_manager = MagicMock()
+    db_manager.get_backend_type = lambda: "kuzudb"
+    ctx = SimpleNamespace(mode="global")
+    return db_manager, MagicMock(), MagicMock(), ctx
+
+
+# ---------------------------------------------------------------------------
+# _print_query_exception unit tests
+# ---------------------------------------------------------------------------
+
+class TestPrintQueryException:
+    """Verify _print_query_exception surfaces the right message per backend."""
+
+    def test_kuzu_parser_error_no_traceback(self, capsys):
+        """KuzuDB RuntimeError with 'Parser exception' should print cleanly."""
+        e = RuntimeError(
+            "Parser exception: Invalid input <MATCH (n:Bad RETURN>: "
+            "expected rule oC_SingleQuery (line: 1, offset: 21)"
+        )
+        cli_helpers._print_query_exception(e, "MATCH (n:Bad RETURN n")
+        captured = cli_helpers.console.file  # rich Console, check via output below
+
+    def test_kuzu_parser_error_shows_message(self, capsys):
+        """Output must contain the raw parser exception text."""
+        e = RuntimeError("Parser exception: Invalid input <MATCH")
+        from io import StringIO
+        from rich.console import Console
+        buf = StringIO()
+        original = cli_helpers.console
+        cli_helpers.console = Console(file=buf, highlight=False)
+        try:
+            cli_helpers._print_query_exception(e, "MATCH (n RETURN n")
+        finally:
+            cli_helpers.console = original
+        output = buf.getvalue()
+        assert "Parser exception" in output
+        assert "MATCH (n RETURN n" in output
+        assert "Traceback" not in output
+
+    def test_neo4j_error_shows_code_and_message(self):
+        """Neo4j exceptions should show .code and .message attributes."""
+        from io import StringIO
+        from rich.console import Console
+
+        FakeNeo4jError = type(
+            "CypherSyntaxError",
+            (Exception,),
+            {"__module__": "neo4j.exceptions"},
+        )
+
+        e = FakeNeo4jError("Neo4j error")
+        e.code = "Neo.ClientError.Statement.SyntaxError"
+        e.message = "Invalid input 'RETURN': expected..."
+
+        buf = StringIO()
+        original = cli_helpers.console
+        cli_helpers.console = Console(file=buf, highlight=False)
+        try:
+            cli_helpers._print_query_exception(e, "MATCH RETURN n")
+        finally:
+            cli_helpers.console = original
+
+        output = buf.getvalue()
+        assert "Neo.ClientError.Statement.SyntaxError" in output
+        assert "Invalid input 'RETURN'" in output
+
+    def test_falkordb_error_shows_message(self):
+        """FalkorDB exceptions should show the database message."""
+        from io import StringIO
+        from rich.console import Console
+
+        FakeFalkorError = type(
+            "ResponseError",
+            (Exception,),
+            {"__module__": "falkordb.exceptions"},
+        )
+
+        e = FakeFalkorError("ERR query syntax error")
+
+        buf = StringIO()
+        original = cli_helpers.console
+        cli_helpers.console = Console(file=buf, highlight=False)
+        try:
+            cli_helpers._print_query_exception(e, "MATCH (n RETURN n")
+        finally:
+            cli_helpers.console = original
+
+        output = buf.getvalue()
+        assert "ERR query syntax error" in output
+
+
+# ---------------------------------------------------------------------------
+# cypher_helper integration tests
+# ---------------------------------------------------------------------------
+
+class TestCypherHelperExceptionPropagation:
+    """Verify cypher_helper calls _print_query_exception on failure."""
+
+    def test_exits_nonzero_on_query_error(self, tmp_path):
+        """cypher_helper must exit with code 1 when query raises."""
+        services = _services()
+        session_mock = MagicMock()
+        session_mock.__enter__ = MagicMock(return_value=session_mock)
+        session_mock.__exit__ = MagicMock(return_value=False)
+        session_mock.run.side_effect = RuntimeError(
+            "Parser exception: Invalid input"
+        )
+        services[0].get_driver.return_value.session.return_value = session_mock
+
+        with (
+            patch.object(cli_helpers, "_initialize_services", return_value=services),
+            patch.object(cli_helpers, "_print_query_exception") as mock_print_exc,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            cli_helpers.cypher_helper("MATCH (n RETURN n")
+
+        assert exc_info.value.exit_code == 1
+        mock_print_exc.assert_called_once()
+        call_args = mock_print_exc.call_args
+        assert "MATCH (n RETURN n" in call_args[0]
+
+    def test_print_query_exception_called_with_correct_query(self, tmp_path):
+        """_print_query_exception must receive the original query string."""
+        services = _services()
+        session_mock = MagicMock()
+        session_mock.__enter__ = MagicMock(return_value=session_mock)
+        session_mock.__exit__ = MagicMock(return_value=False)
+        bad_query = "MATCH (n:Broken RETURN n"
+        session_mock.run.side_effect = RuntimeError("Parser exception")
+        services[0].get_driver.return_value.session.return_value = session_mock
+
+        with (
+            patch.object(cli_helpers, "_initialize_services", return_value=services),
+            patch.object(cli_helpers, "_print_query_exception") as mock_print_exc,
+            pytest.raises(typer.Exit),
+        ):
+            cli_helpers.cypher_helper(bad_query)
+
+        assert mock_print_exc.call_args[0][1] == bad_query
+
+
+# ---------------------------------------------------------------------------
+# cypher_helper_visual integration tests
+# ---------------------------------------------------------------------------
+
+class TestCypherHelperVisualExceptionPropagation:
+    """Verify cypher_helper_visual also calls _print_query_exception."""
+
+    def test_visual_exits_nonzero_on_query_error(self, tmp_path):
+        services = _services()
+
+        with (
+            patch.object(cli_helpers, "_initialize_services", return_value=services),
+            patch(
+                "codegraphcontext.cli.visualizer.visualize_cypher_results",
+                 side_effect=RuntimeError("Parser exception: bad query"),
+            ),
+            patch.object(cli_helpers, "_print_query_exception") as mock_print_exc,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            cli_helpers.cypher_helper_visual("MATCH (n RETURN n")
+
+        assert exc_info.value.exit_code == 1
+        mock_print_exc.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes #1097 by surfacing backend-specific database query errors instead of displaying a generic exception message.

### Changes

* Added `_print_query_exception()` helper to format query exceptions by backend.
* Updated `cypher_helper()` to use the new exception handler.
* Updated `cypher_helper_visual()` to use the new exception handler.
* Added support for displaying Neo4j, FalkorDB, and KuzuDB query/compiler error messages.
* Added unit tests covering:

  * Neo4j query errors
  * FalkorDB query errors
  * KuzuDB parser errors
  * `cypher_helper` exception propagation
  * `cypher_helper_visual` exception propagation

### Verification

Manually tested with an invalid Cypher query and confirmed that the underlying database parser/compiler error is displayed instead of a generic error message.

All added tests pass successfully.