### PR TITLE
fix(config): restrict .env resolution to current directory (#1099)

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -302,24 +302,17 @@ def find_local_env() -> Optional[Path]:
         return None
 
     current = Path.cwd()
-    
-    # Search up to 5 levels up
-    for _ in range(5):
-        # 1. Prefer .codegraphcontext/.env if it exists
-        cgc_env = current / ".codegraphcontext" / ".env"
-        if cgc_env.exists() and cgc_env != CONFIG_FILE:
-            return cgc_env
-            
-        # 2. Fall back to root project .env
-        env_file = current / ".env"
-        if env_file.exists() and env_file != CONFIG_FILE:
-            return env_file
-        
-        # Stop at root
-        if current.parent == current:
-            break
-        current = current.parent
-    
+
+    # Prefer .codegraphcontext/.env in the current directory
+    cgc_env = current / ".codegraphcontext" / ".env"
+    if cgc_env.exists() and cgc_env != CONFIG_FILE:
+        return cgc_env
+
+    # Fall back to .env in the current directory
+    env_file = current / ".env"
+    if env_file.exists() and env_file != CONFIG_FILE:
+        return env_file
+
     return None
 
 

--- a/tests/unit/cli/test_config_manager_encoding.py
+++ b/tests/unit/cli/test_config_manager_encoding.py
@@ -46,3 +46,29 @@ def test_context_config_files_are_opened_with_utf8(tmp_path, monkeypatch):
     loaded = config_manager.load_context_config()
 
     assert loaded.default_context == "global"
+
+def test_find_local_env_does_not_traverse_parent_directories(tmp_path, monkeypatch):
+    """
+    .env files in parent directories should not be discovered.
+    """
+    parent_env = tmp_path / ".env"
+    parent_env.write_text("TEST=value", encoding="utf-8")
+
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+
+    monkeypatch.chdir(child_dir)
+
+    result = config_manager.find_local_env()
+
+    assert result is None
+
+def test_find_local_env_finds_env_in_current_directory(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("TEST=value", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    result = config_manager.find_local_env()
+
+    assert result == env_file


### PR DESCRIPTION
## Summary

Fixes #1099 by preventing `.env` resolution from traversing parent directories.

### Changes

* Updated `find_local_env()` to search only within the current working directory.
* Removed upward parent-directory traversal when locating `.env` files.
* Preserved support for:

  * `.codegraphcontext/.env`
  * `.env`
    in the current working directory.

### Tests

Added tests verifying that:

* `.env` files in parent directories are not discovered.
* `.env` files in the current working directory are still discovered.

### Verification

All related config manager tests pass successfully (`4 passed`).
