### PR TITLE
fix(status-bar): resolve arbitrary alignment priority conflict (#1118)

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -226,6 +226,17 @@
           "type": "string",
           "default": "{}",
           "description": "JSON map of tool name to max result count, e.g. {\"find_code\": 20}."
+        },
+        "cgc.statusBarAlignment": {
+          "type": "string",
+          "default": "right",
+          "enum": ["left", "right"],
+          "description": "Which side of the VS Code status bar the CGC item appears on. Change this if the item conflicts with another extension."
+        },
+        "cgc.statusBarPriority": {
+          "type": "number",
+          "default": 1000,
+          "description": "Priority of the CGC status bar item. Higher values place the item further left within its alignment group. Adjust this to resolve layout conflicts with other extensions (issue #1118)."
         }
       }
     }

--- a/extensions/vscode/src/views/statusBarItem.ts
+++ b/extensions/vscode/src/views/statusBarItem.ts
@@ -5,6 +5,18 @@ import { cgcEvents } from "../mcp/eventBus";
 type StatusState = "online" | "offline" | "indexing";
 
 /**
+ * Default priority for the CGC status bar item.
+ *
+ * VS Code renders Right-aligned items in descending priority order
+ * (higher number = further left / more prominent). Pinning this to
+ * a named constant avoids the "arbitrary priority" problem described
+ * in issue #1118 and makes it easy for contributors to see—and
+ * override via settings—exactly where CGC sits relative to other
+ * extensions.
+ */
+const DEFAULT_STATUS_BAR_PRIORITY = 1000;
+
+/**
  * Persistent status bar item showing CGC health.
  *
  *  Green  = indexed + MCP online
@@ -20,10 +32,23 @@ export class CgcStatusBarItem implements vscode.Disposable {
   private spinTimer?: NodeJS.Timeout;
 
   constructor(private readonly client: CgcMcpClient) {
-    this.item = vscode.window.createStatusBarItem(
-      vscode.StatusBarAlignment.Right,
-      1000
+    // Read user-configured alignment and priority so the item's
+    // position is explicit and stable across VS Code versions and
+    // other extensions (fixes issue #1118).
+    const cfg = vscode.workspace.getConfiguration("cgc");
+
+    const alignmentSetting = cfg.get<string>("statusBarAlignment", "right");
+    const alignment =
+      alignmentSetting === "left"
+        ? vscode.StatusBarAlignment.Left
+        : vscode.StatusBarAlignment.Right;
+
+    const priority = cfg.get<number>(
+      "statusBarPriority",
+      DEFAULT_STATUS_BAR_PRIORITY
     );
+
+    this.item = vscode.window.createStatusBarItem(alignment, priority);
     this.item.command = "cgc.openDashboard";
     this.item.tooltip = "CodeGraphContext — click to open dashboard";
     this._subscribeEvents();


### PR DESCRIPTION
## Summary
Fixes #1118 — the CGC status bar item had a hardcoded alignment and priority, which caused unpredictable layout conflicts with other extensions.

## Changes
- `statusBarItem.ts`: Reads `cgc.statusBarAlignment` and `cgc.statusBarPriority` from workspace config instead of hardcoding values. Extracted magic number into `DEFAULT_STATUS_BAR_PRIORITY` constant.
- `package.json`: Declares the two new settings with descriptions, defaults, and valid enum values so they appear in the VS Code Settings UI.

## Behavior
- **No breaking change** — defaults are identical to the original hardcoded values (`right`, `1000`)
- Users who experience layout conflicts can now open Settings → search `cgc statusBar` and adjust without editing source code

## Testing
- [x] Extension loads, CGC icon appears in status bar as before
- [x] Changing `cgc.statusBarPriority` to a lower value moves the icon further right
- [x] Changing `cgc.statusBarAlignment` to `left` moves the icon to the left side of the bar
- [x] Status transitions (online → indexing → offline) still render correctly

## Files Modified
- `extensions/vscode/src/views/statusBarItem.ts`
- `extensions/vscode/package.json`