### PR TITLE
Refactor Neo4j adapter ingestion loops to use managed transactions

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/utils.py
+++ b/src/codegraphcontext/tools/indexing/persistence/utils.py
@@ -1,0 +1,46 @@
+"""Utility functions for database transactions and backend detection."""
+
+from typing import Any
+
+
+def get_backend_type(driver: Any, db_manager: Any = None) -> str:
+    """Determine the database backend type dynamically."""
+    if db_manager is not None and hasattr(db_manager, "get_backend_type"):
+        return getattr(db_manager, "get_backend_type", None)()
+    return getattr(driver, "get_backend_type", lambda: "neo4j")()
+
+
+def execute_write_operation(driver: Any, backend: str, work_fn: callable) -> Any:
+    """Execute a database write operation with full transaction and retry support.
+    
+    For Neo4j/Nornic, utilizes managed transactions (execute_write or write_transaction)
+    to automatically retry on transient errors and group all operations in a single block.
+    For other backends (e.g. KuzuDB, FalkorDB), passes through the standard session.
+    """
+    if backend in ("neo4j", "nornic"):
+        with driver.session() as session:
+            # Prefer execute_write (Neo4j driver 5+), fallback to write_transaction (<5)
+            if hasattr(session, "execute_write"):
+                return session.execute_write(work_fn)
+            elif hasattr(session, "write_transaction"):
+                return session.write_transaction(work_fn)
+            else:
+                return work_fn(session)
+    else:
+        with driver.session() as session:
+            return work_fn(session)
+
+
+def execute_read_operation(driver: Any, backend: str, work_fn: callable) -> Any:
+    """Execute a database read operation utilizing managed read transactions where supported."""
+    if backend in ("neo4j", "nornic"):
+        with driver.session() as session:
+            if hasattr(session, "execute_read"):
+                return session.execute_read(work_fn)
+            elif hasattr(session, "read_transaction"):
+                return session.read_transaction(work_fn)
+            else:
+                return work_fn(session)
+    else:
+        with driver.session() as session:
+            return work_fn(session)

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -12,6 +12,7 @@ from ....utils.debug_log import info_logger, warning_logger
 from ....utils.git_utils import get_repo_commit_hash
 from ..sanitize import sanitize_props
 from ..schema_contract import NODE_LABELS
+from .utils import get_backend_type, execute_write_operation, execute_read_operation
 
 
 def _normalize_path(p) -> str:
@@ -58,17 +59,14 @@ class GraphWriter:
         plus supplementary labels on failure.
         """
         # Prefer db_manager.get_backend_type(); fall back to driver, then neo4j
-        backend = (
-            getattr(self._db_manager, "get_backend_type", None)
-            or getattr(self.driver, "get_backend_type", None)
-            or (lambda: "neo4j")
-        )()
+        backend = get_backend_type(self.driver, self._db_manager)
 
         if backend in ("kuzudb", "ladybugdb"):
             # NOTE: Full node scan required because SHOW TABLES is unavailable
             # in KuzuDB ≤ 0.11. Acceptable for delete_repository (low-frequency).
             try:
-                with self.driver.session() as session:
+                backend = get_backend_type(self.driver, self._db_manager)
+                def _work(session):
                     result = session.run(
                         "MATCH (n) RETURN DISTINCT label(n) AS lbl"
                     )
@@ -77,6 +75,7 @@ class GraphWriter:
                     )
                     if labels:
                         return labels
+                return execute_read_operation(self.driver, backend, _work)
             except Exception as e:
                 info_logger(
                     f"[DELETE] label discovery failed for {backend} "
@@ -85,11 +84,13 @@ class GraphWriter:
 
         elif backend in ("neo4j", "nornic"):
             try:
-                with self.driver.session() as session:
+                backend = get_backend_type(self.driver, self._db_manager)
+                def _work(session):
                     label_records = session.run(
                         "CALL db.labels() YIELD label RETURN label"
                     )
                     return sorted({record["label"] for record in label_records})
+                return execute_read_operation(self.driver, backend, _work)
             except Exception as e:
                 info_logger(
                     f"[DELETE] CALL db.labels() failed for {backend} "
@@ -98,9 +99,11 @@ class GraphWriter:
 
         elif backend in ("falkordb", "falkordb-remote"):
             try:
-                with self.driver.session() as session:
+                backend = get_backend_type(self.driver, self._db_manager)
+                def _work(session):
                     label_records = session.run("CALL db.labels()")
                     return sorted({record["label"] for record in label_records})
+                return execute_read_operation(self.driver, backend, _work)
             except Exception as e:
                 info_logger(
                     f"[DELETE] CALL db.labels() failed for {backend} "
@@ -125,7 +128,8 @@ class GraphWriter:
         commit_hash = get_repo_commit_hash(repo_path.resolve())
         indexed_at = datetime.now(timezone.utc).isoformat()
 
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             session.run(
                 """
                 MERGE (r:Repository {path: $path})
@@ -148,6 +152,7 @@ class GraphWriter:
                     commit_hash=commit_hash,
                 )
 
+        execute_write_operation(self.driver, backend, _work)
     def add_file_to_graph(
         self,
         file_data: Dict[str, Any],
@@ -161,7 +166,8 @@ class GraphWriter:
         is_dependency = file_data.get("is_dependency", False)
         lang = file_data.get("lang")
 
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             if repo_path_str:
                 resolved_repo_str = repo_path_str
             else:
@@ -496,6 +502,7 @@ class GraphWriter:
                     file_path=file_path_str,
                 )
 
+        execute_write_operation(self.driver, backend, _work)
     def add_minimal_file_node(
         self, file_path: Path, repo_path: Path, is_dependency: bool = False
     ) -> None:
@@ -505,7 +512,8 @@ class GraphWriter:
         repo_name = repo_path.name
         repo_path_str = _normalize_path(repo_path)
 
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             session.run(
                 """
                 MERGE (r:Repository {path: $repo_path})
@@ -565,6 +573,7 @@ class GraphWriter:
                 file_path=file_path_str,
             )
 
+        execute_write_operation(self.driver, backend, _work)
     def write_function_call_groups(
         self,
         fn_to_fn: List[Dict] = None,
@@ -598,7 +607,8 @@ class GraphWriter:
             (file_to_object, "File", "Object"),
         ]
 
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             for batch_data, caller_label, called_label in queries:
                 if not batch_data:
                     continue
@@ -706,6 +716,7 @@ class GraphWriter:
                         raise e
                 info_logger(f"[CALLS] {caller_label}-to-{called_label}: {len(sanitized_batch)} edges written in {time.time()-t0:.1f}s")
 
+        execute_write_operation(self.driver, backend, _work)
         info_logger("[CALLS] All relationships processed.")
 
     def _create_csharp_inheritance_and_interfaces(
@@ -793,7 +804,8 @@ class GraphWriter:
             f"[INHERITS] Resolving inheritance links across {len(inheritance_batch)} files..."
         )
         batch_size = 500
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             internal_batch = [r for r in inheritance_batch if r.get("resolved_parent_file_path") != "__external__"]
             external_batch = [r for r in inheritance_batch if r.get("resolved_parent_file_path") == "__external__"]
 
@@ -837,12 +849,14 @@ class GraphWriter:
             for file_data in csharp_files:
                 self._create_csharp_inheritance_and_interfaces(session, file_data, imports_map)
 
+        execute_write_operation(self.driver, backend, _work)
         info_logger(f"[INHERITS] Complete: {len(inheritance_batch)} inheritance links processed.")
 
     def write_scip_call_edges(
         self, files_data: Dict[str, Any], name_from_symbol: Callable[[str], str]
     ) -> None:
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             for file_data in files_data.values():
                 caller_labels = ("Function", "Variable", "Class", "Interface", "Trait", "Struct", "Record", "Union", "Mixin", "Extension")
                 callee_labels = ("Function", "Class", "Interface", "Trait", "Struct", "Enum", "Record", "Union", "Mixin", "Extension")
@@ -883,9 +897,11 @@ class GraphWriter:
                         except Exception as e:
                             warning_logger(f"Failed to write SCIP module-level call edge: {e}")
 
+        execute_write_operation(self.driver, backend, _work)
     def delete_file_from_graph(self, path: str) -> None:
         file_path_str = _normalize_path(path)
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             parents_res = session.run(
                 """
                 MATCH (f:File {path: $path})<-[:CONTAINS*]-(d:Directory)
@@ -915,6 +931,7 @@ class GraphWriter:
                     path=p,
                 )
 
+        execute_write_operation(self.driver, backend, _work)
     def write_cpp_class_function_links(self, repo_path_str: str) -> None:
         """Post-pass: create Class-[:CONTAINS]->Function edges for C++ files.
 
@@ -934,7 +951,8 @@ class GraphWriter:
         ext_conditions = ' OR '.join(f'fn.path ENDS WITH "{ext}"' for ext in _cpp_exts)
 
         container_labels = ("Class", "Struct", "Module")
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             for clab in container_labels:
                 query = f"""
                     MATCH (fn:Function)
@@ -951,13 +969,15 @@ class GraphWriter:
                 except Exception as e:
                     warning_logger(f"Failed to link C++ methods for label {clab}: {e}")
 
+        execute_write_operation(self.driver, backend, _work)
     def write_spring_inject_links(self, inject_batch: List[Dict[str, Any]]) -> None:
         """Create INJECTS edges: injector Class -> injected Class (via @Autowired / @Inject)."""
         if not inject_batch:
             return
         info_logger(f"[SPRING] Writing {len(inject_batch)} INJECTS edges...")
         batch_size = 500
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             for i in range(0, len(inject_batch), batch_size):
                 batch = inject_batch[i : i + batch_size]
                 session.run(
@@ -972,6 +992,7 @@ class GraphWriter:
                     """,
                     batch=batch,
                 )
+        execute_write_operation(self.driver, backend, _work)
         info_logger(f"[SPRING] INJECTS edges written.")
 
     def write_spring_endpoint_properties(self, endpoint_batch: List[Dict[str, Any]]) -> None:
@@ -980,7 +1001,8 @@ class GraphWriter:
             return
         info_logger(f"[SPRING] Updating {len(endpoint_batch)} endpoint function properties...")
         batch_size = 500
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             for i in range(0, len(endpoint_batch), batch_size):
                 batch = endpoint_batch[i : i + batch_size]
                 session.run(
@@ -992,6 +1014,7 @@ class GraphWriter:
                     """,
                     batch=batch,
                 )
+        execute_write_operation(self.driver, backend, _work)
         info_logger("[SPRING] Endpoint properties updated.")
 
     def write_maven_build_graph(self, build_data: Dict[str, Any], repo_path_str: str) -> None:
@@ -1014,7 +1037,8 @@ class GraphWriter:
                     f"{len(external_libs)} external libs...")
 
         batch_size = 200
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             for i in range(0, len(modules), batch_size):
                 session.run(
                     """
@@ -1064,6 +1088,7 @@ class GraphWriter:
                     batch=external_libs[i : i + batch_size],
                 )
 
+        execute_write_operation(self.driver, backend, _work)
         info_logger("[MAVEN] Build graph written.")
 
     def write_gradle_build_graph(self, build_data: Dict[str, Any], repo_path_str: str) -> None:
@@ -1085,7 +1110,8 @@ class GraphWriter:
                     f"{len(external_libs)} external libs...")
 
         batch_size = 200
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             for i in range(0, len(modules), batch_size):
                 session.run(
                     """
@@ -1121,6 +1147,7 @@ class GraphWriter:
                     batch=external_libs[i : i + batch_size],
                 )
 
+        execute_write_operation(self.driver, backend, _work)
         info_logger("[GRADLE] Build graph written.")
 
     def write_datasource_graph(self, ingested: Dict[str, Any]) -> None:
@@ -1131,7 +1158,8 @@ class GraphWriter:
         ds_name = ds["name"]
         ds_kind = ds.get("kind", "unknown")
 
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             session.run(
                 """
                 MERGE (d:Datasource {name: $name})
@@ -1142,13 +1170,11 @@ class GraphWriter:
                 host=ds.get("host", ""),
                 env=ds.get("env", ""),
             )
-        info_logger(f"[DATASOURCE] Written Datasource node: {ds_name} ({ds_kind})")
 
-        tables = ingested.get("tables", [])
-        batch_size = 500
+            tables = ingested.get("tables", [])
+            batch_size = 500
 
-        for i in range(0, len(tables), batch_size):
-            with self.driver.session() as session:
+            for i in range(0, len(tables), batch_size):
                 session.run(
                     """
                     UNWIND $batch AS t
@@ -1163,12 +1189,9 @@ class GraphWriter:
                     """,
                     batch=tables[i : i + batch_size],
                 )
-        if tables:
-            info_logger(f"[DATASOURCE] Written {len(tables)} DbTable nodes for {ds_name}")
 
-        columns = ingested.get("columns", [])
-        for i in range(0, len(columns), batch_size):
-            with self.driver.session() as session:
+            columns = ingested.get("columns", [])
+            for i in range(0, len(columns), batch_size):
                 session.run(
                     """
                     UNWIND $batch AS c
@@ -1183,12 +1206,9 @@ class GraphWriter:
                     """,
                     batch=columns[i : i + batch_size],
                 )
-        if columns:
-            info_logger(f"[DATASOURCE] Written {len(columns)} DbColumn nodes for {ds_name}")
 
-        key_patterns = ingested.get("key_patterns", [])
-        for i in range(0, len(key_patterns), batch_size):
-            with self.driver.session() as session:
+            key_patterns = ingested.get("key_patterns", [])
+            for i in range(0, len(key_patterns), batch_size):
                 session.run(
                     """
                     UNWIND $batch AS kp
@@ -1202,8 +1222,18 @@ class GraphWriter:
                     """,
                     batch=key_patterns[i : i + batch_size],
                 )
-        if key_patterns:
-            info_logger(f"[DATASOURCE] Written {len(key_patterns)} RedisKeyPattern nodes for {ds_name}")
+            
+            return len(tables), len(columns), len(key_patterns)
+
+        tables_len, columns_len, key_patterns_len = execute_write_operation(self.driver, backend, _work)
+        
+        info_logger(f"[DATASOURCE] Written Datasource node: {ds_name} ({ds_kind})")
+        if tables_len:
+            info_logger(f"[DATASOURCE] Written {tables_len} DbTable nodes for {ds_name}")
+        if columns_len:
+            info_logger(f"[DATASOURCE] Written {columns_len} DbColumn nodes for {ds_name}")
+        if key_patterns_len:
+            info_logger(f"[DATASOURCE] Written {key_patterns_len} RedisKeyPattern nodes for {ds_name}")
 
     def write_orm_mappings(self, orm_batch: List[Dict[str, Any]]) -> None:
         """Write MAPS_TO edges from Class → DbTable (JPA, Cassandra, Redis)."""
@@ -1212,8 +1242,9 @@ class GraphWriter:
             return
 
         batch_size = 500
-        for i in range(0, len(class_table), batch_size):
-            with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
+            for i in range(0, len(class_table), batch_size):
                 session.run(
                     """
                     UNWIND $batch AS m
@@ -1225,6 +1256,7 @@ class GraphWriter:
                     """,
                     batch=class_table[i : i + batch_size],
                 )
+        execute_write_operation(self.driver, backend, _work)
         info_logger(f"[ORM] Written {len(class_table)} MAPS_TO edges")
 
     def write_query_links(self, query_batch: List[Dict[str, Any]]) -> None:
@@ -1246,10 +1278,11 @@ class GraphWriter:
                 })
 
         batch_size = 500
-        for op in ("READS", "WRITES"):
-            op_edges = [e for e in edges if e["operation"] == op]
-            for i in range(0, len(op_edges), batch_size):
-                with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
+            for op in ("READS", "WRITES"):
+                op_edges = [e for e in edges if e["operation"] == op]
+                for i in range(0, len(op_edges), batch_size):
                     session.run(
                         f"""
                         UNWIND $batch AS q
@@ -1261,6 +1294,7 @@ class GraphWriter:
                         """,
                         batch=op_edges[i : i + batch_size],
                     )
+        execute_write_operation(self.driver, backend, _work)
         info_logger(f"[ORM] Written {len(edges)} READS/WRITES query edges")
 
     def write_mybatis_links(self, mybatis_batch: List[Dict[str, Any]]) -> None:
@@ -1279,13 +1313,14 @@ class GraphWriter:
             return
 
         batch_size = 500
-        written = 0
-        for op in ("READS", "WRITES"):
-            op_edges = [e for e in edges if e["operation"] == op]
-            if not op_edges:
-                continue
-            for i in range(0, len(op_edges), batch_size):
-                with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
+            local_written = 0
+            for op in ("READS", "WRITES"):
+                op_edges = [e for e in edges if e["operation"] == op]
+                if not op_edges:
+                    continue
+                for i in range(0, len(op_edges), batch_size):
                     session.run(
                         f"""
                         UNWIND $batch AS q
@@ -1298,7 +1333,9 @@ class GraphWriter:
                         """,
                         batch=op_edges[i : i + batch_size],
                     )
-                written += len(op_edges[i : i + batch_size])
+                    local_written += len(op_edges[i : i + batch_size])
+            return local_written
+        written = execute_write_operation(self.driver, backend, _work)
         info_logger(f"[MYBATIS] Written {written} READS/WRITES MyBatis edges")
 
     def write_spring_data_repo_links(self, orm_batch: List[Dict[str, Any]]) -> None:
@@ -1319,13 +1356,14 @@ class GraphWriter:
         ]
 
         batch_size = 500
-        written = 0
-        for op in ("READS", "WRITES"):
-            op_edges = [e for e in edges if e["operation"] == op]
-            if not op_edges:
-                continue
-            for i in range(0, len(op_edges), batch_size):
-                with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
+            local_written = 0
+            for op in ("READS", "WRITES"):
+                op_edges = [e for e in edges if e["operation"] == op]
+                if not op_edges:
+                    continue
+                for i in range(0, len(op_edges), batch_size):
                     session.run(
                         f"""
                         UNWIND $batch AS q
@@ -1335,7 +1373,9 @@ class GraphWriter:
                         """,
                         batch=op_edges[i : i + batch_size],
                     )
-                written += len(op_edges[i : i + batch_size])
+                    local_written += len(op_edges[i : i + batch_size])
+            return local_written
+        written = execute_write_operation(self.driver, backend, _work)
         info_logger(f"[SPRING_DATA] Written {written} READS/WRITES derived-query edges")
 
     def delete_repository_from_graph(self, repo_path: str) -> bool:
@@ -1346,7 +1386,8 @@ class GraphWriter:
         repo_path_str = _normalize_path(repo_path)
         path_prefix = _normalize_prefix(repo_path)
 
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             result = session.run(
                 "MATCH (r:Repository {path: $path}) RETURN count(r) as cnt",
                 path=repo_path_str,
@@ -1355,9 +1396,13 @@ class GraphWriter:
                 warning_logger(f"Attempted to delete non-existent repository: {repo_path}")
                 return False
 
+        res = execute_write_operation(self.driver, backend, _work)
+        if res is False:
+            return False
         for rel_type in ("CALLS", "INHERITS", "IMPORTS"):
             while True:
-                with self.driver.session() as session:
+                backend = get_backend_type(self.driver, self._db_manager)
+                def _work(session):
                     result = session.run(
                         f"MATCH (a)-[r:{rel_type}]->(b) "
                         "WHERE a.path STARTS WITH $prefix OR a.path = $path "
@@ -1366,13 +1411,15 @@ class GraphWriter:
                         prefix=path_prefix,
                         path=repo_path_str,
                     ).single()
-                    deleted = result["deleted"] if result else 0
+                    return result["deleted"] if result else 0
+                deleted = execute_write_operation(self.driver, backend, _work)
                 if deleted == 0:
                     break
                 info_logger(f"[DELETE] Removed {deleted} {rel_type} rels for {repo_path_str}")
 
         while True:
-            with self.driver.session() as session:
+            backend = get_backend_type(self.driver, self._db_manager)
+            def _work(session):
                 result = session.run(
                     "MATCH (a)-[r:CONTAINS]->(b) "
                     "WHERE a.path STARTS WITH $prefix OR a.path = $path "
@@ -1380,7 +1427,8 @@ class GraphWriter:
                     prefix=path_prefix,
                     path=repo_path_str,
                 ).single()
-                deleted = result["deleted"] if result else 0
+                return result["deleted"] if result else 0
+            deleted = execute_write_operation(self.driver, backend, _work)
             if deleted == 0:
                 break
             info_logger(f"[DELETE] Removed {deleted} CONTAINS rels for {repo_path_str}")
@@ -1389,26 +1437,31 @@ class GraphWriter:
 
         for label in all_labels:
             while True:
-                with self.driver.session() as session:
+                backend = get_backend_type(self.driver, self._db_manager)
+                def _work(session):
                     result = session.run(
                         f"MATCH (n:{label}) WHERE n.path STARTS WITH $prefix OR n.path = $path "
                         "WITH n LIMIT 10000 DETACH DELETE n RETURN count(n) AS deleted",
                         prefix=path_prefix,
                         path=repo_path_str,
                     ).single()
-                    deleted = result["deleted"] if result else 0
+                    return result["deleted"] if result else 0
+                deleted = execute_write_operation(self.driver, backend, _work)
                 if deleted == 0:
                     break
                 info_logger(f"[DELETE] Removed {deleted} {label} nodes for {repo_path_str}")
 
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             session.run("MATCH (r:Repository {path: $path}) DETACH DELETE r", path=repo_path_str)
 
+        execute_write_operation(self.driver, backend, _work)
         info_logger(f"Deleted repository and its contents from graph: {repo_path_str}")
         return True
 
     def get_caller_file_paths(self, file_path_str: str) -> set:
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             result = session.run(
                 "MATCH (caller)-[:CALLS]->(callee) "
                 "WHERE callee.path = $path "
@@ -1417,8 +1470,10 @@ class GraphWriter:
             )
             return {r["p"] for r in result if r["p"] and r["p"] != file_path_str}
 
+        return execute_read_operation(self.driver, backend, _work)
     def get_inheritance_neighbor_paths(self, file_path_str: str) -> set:
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             result = session.run(
                 "MATCH (a)-[:INHERITS]->(b) "
                 "WHERE a.path = $path OR b.path = $path "
@@ -1427,30 +1482,37 @@ class GraphWriter:
             )
             return {r["p"] for r in result if r["p"] and r["p"] != file_path_str}
 
+        return execute_read_operation(self.driver, backend, _work)
     def delete_outgoing_calls_from_files(self, file_paths: List[str]) -> None:
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             result = session.run(
                 "MATCH (a)-[r:CALLS]->(b) WHERE a.path IN $paths DELETE r RETURN count(r) AS cnt",
                 paths=file_paths,
             ).single()
-            cnt = result["cnt"] if result else 0
+            return result["cnt"] if result else 0
+        cnt = execute_write_operation(self.driver, backend, _work)
         info_logger(f"[RELINK] Deleted {cnt} outgoing CALLS from {len(file_paths)} caller files")
 
     def delete_inherits_for_files(self, file_paths: List[str]) -> None:
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             result = session.run(
                 "MATCH (a)-[r:INHERITS]->(b) WHERE a.path IN $paths OR b.path IN $paths "
                 "DELETE r RETURN count(r) AS cnt",
                 paths=file_paths,
             ).single()
-            cnt = result["cnt"] if result else 0
+            return result["cnt"] if result else 0
+        cnt = execute_write_operation(self.driver, backend, _work)
         info_logger(f"[RELINK] Deleted {cnt} INHERITS for {len(file_paths)} affected files")
 
     def get_repo_class_lookup(self, repo_path: Path) -> Dict[str, set]:
         # Use _normalize_prefix so the STARTS WITH matches forward-slash stored paths
         prefix = _normalize_prefix(repo_path)
         result_map: Dict[str, set] = {}
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
+            local_map = {}
             result = session.run(
                 "MATCH (c:Class) WHERE c.path STARTS WITH $prefix "
                 "RETURN c.name AS name, c.path AS path",
@@ -1458,15 +1520,18 @@ class GraphWriter:
             )
             for record in result:
                 path = record["path"]
-                if path not in result_map:
-                    result_map[path] = set()
-                result_map[path].add(record["name"])
+                if path not in local_map:
+                    local_map[path] = set()
+                local_map[path].add(record["name"])
+            return local_map
+        result_map.update(execute_read_operation(self.driver, backend, _work))
         return result_map
 
     def delete_relationship_links(self, repo_path: Path) -> None:
         # Use _normalize_prefix so the STARTS WITH matches forward-slash stored paths
         repo_path_str = _normalize_prefix(repo_path)
-        with self.driver.session() as session:
+        backend = get_backend_type(self.driver, self._db_manager)
+        def _work(session):
             result = session.run(
                 "MATCH (a)-[r:CALLS]->(b) WHERE a.path STARTS WITH $prefix DELETE r RETURN count(r) AS cnt",
                 prefix=repo_path_str,
@@ -1478,7 +1543,9 @@ class GraphWriter:
                 prefix=repo_path_str,
             ).single()
             inherits_deleted = result["cnt"] if result else 0
+            return calls_deleted, inherits_deleted
 
+        calls_deleted, inherits_deleted = execute_write_operation(self.driver, backend, _work)
         info_logger(
             f"[RELINK] Cleared {calls_deleted} CALLS and {inherits_deleted} INHERITS before re-linking: {repo_path}"
         )

--- a/src/codegraphcontext/tools/indexing/resolution/post_resolution.py
+++ b/src/codegraphcontext/tools/indexing/resolution/post_resolution.py
@@ -24,6 +24,7 @@ import time
 from typing import Any, Dict, List, Optional, Set
 
 from ....utils.debug_log import info_logger, warning_logger
+from ..persistence.utils import get_backend_type, execute_read_operation, execute_write_operation
 
 # Tier 10: resolved via inheritance graph (better than tier 8 first-match bias)
 _TIER_INHERIT_CONFIDENCE = 0.78
@@ -52,8 +53,9 @@ def run_inheritance_reresolve(
 
     # Step 1: find all low-confidence same-file CALLS edges (tier 8 or 9)
     # These are edges where the resolver gave up and pointed to the caller's file.
-    with driver.session() as session:
-        low_confidence = list(session.run(
+    backend = get_backend_type(driver)
+    def _read_work_1(session):
+        return list(session.run(
             """
             MATCH (caller)-[c:CALLS]->(called)
             WHERE (caller.path STARTS WITH $repo_path_prefix
@@ -70,6 +72,7 @@ def run_inheritance_reresolve(
             """,
             repo_path_prefix=repo_path_prefix,
         ))
+    low_confidence = execute_read_operation(driver, backend, _read_work_1)
 
     info_logger(f"[INHERIT-RESOLVE] Found {len(low_confidence)} low-confidence edges to re-examine")
     if not low_confidence:
@@ -87,7 +90,9 @@ def run_inheritance_reresolve(
 
     _NAMES_BATCH = 500  # stay well under Cypher parameter-list limits
     unique_names_list = list(unique_names)
-    with driver.session() as session:
+    backend = get_backend_type(driver)
+    def _read_work_2(session):
+        local_impls = {}
         for _i in range(0, len(unique_names_list), _NAMES_BATCH):
             chunk = unique_names_list[_i : _i + _NAMES_BATCH]
             result = session.run(
@@ -105,7 +110,10 @@ def run_inheritance_reresolve(
                 repo_path_prefix=repo_path_prefix,
             )
             for row in result:
-                name_to_impls.setdefault(row["queried_name"], []).append(dict(row))
+                local_impls.setdefault(row["queried_name"], []).append(dict(row))
+        return local_impls
+    
+    name_to_impls.update(execute_read_operation(driver, backend, _read_work_2))
 
     # Step 3: for each low-confidence edge, check if INHERITS narrows candidates
     # Strategy:
@@ -177,7 +185,9 @@ def run_inheritance_reresolve(
 
     # Step 4: write updated edges in batches
     batch_size = 500
-    with driver.session() as session:
+    backend = get_backend_type(driver)
+    def _write_work(session):
+        local_improved = 0
         for i in range(0, len(improvements), batch_size):
             batch = improvements[i : i + batch_size]
             session.run(
@@ -198,7 +208,9 @@ def run_inheritance_reresolve(
                 """,
                 batch=batch,
             )
-            improved += len(batch)
+            local_improved += len(batch)
+        return local_improved
+    improved += execute_write_operation(driver, backend, _write_work)
 
     info_logger(
         f"[INHERIT-RESOLVE] Improved {improved} CALLS edges in {time.time()-t0:.1f}s"

--- a/tests/unit/tools/test_graph_writer_transactions.py
+++ b/tests/unit/tools/test_graph_writer_transactions.py
@@ -1,0 +1,155 @@
+"""Unit tests for managed transaction operations."""
+
+import sys
+from unittest.mock import MagicMock
+from pathlib import Path
+
+# Provide a standalone runnable if needed
+if __name__ == "__main__":
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "src"))
+
+from codegraphcontext.tools.indexing.persistence.utils import (
+    execute_write_operation,
+    execute_read_operation,
+    get_backend_type,
+)
+
+PASSED = 0
+FAILED = 0
+
+def run_test(name, func):
+    global PASSED, FAILED
+    try:
+        func()
+        PASSED += 1
+        print(f"  [PASS] {name}")
+    except Exception as e:
+        FAILED += 1
+        print(f"  [FAIL] {name}")
+        print(f"         {e}")
+
+
+# ===========================================================================
+# Mock Factories
+# ===========================================================================
+def _make_driver_with_execute_methods():
+    mock_session = MagicMock()
+    mock_session.__enter__ = MagicMock(return_value=mock_session)
+    mock_session.__exit__ = MagicMock(return_value=False)
+    
+    mock_driver = MagicMock()
+    mock_driver.session.return_value = mock_session
+    return mock_driver, mock_session
+
+
+def _make_legacy_driver():
+    mock_session = MagicMock()
+    del mock_session.execute_write
+    del mock_session.execute_read
+    mock_session.write_transaction = MagicMock()
+    mock_session.read_transaction = MagicMock()
+    
+    mock_session.__enter__ = MagicMock(return_value=mock_session)
+    mock_session.__exit__ = MagicMock(return_value=False)
+    
+    mock_driver = MagicMock()
+    mock_driver.session.return_value = mock_session
+    return mock_driver, mock_session
+
+
+def _make_raw_driver():
+    mock_session = MagicMock()
+    del mock_session.execute_write
+    del mock_session.execute_read
+    del mock_session.write_transaction
+    del mock_session.read_transaction
+    
+    mock_session.__enter__ = MagicMock(return_value=mock_session)
+    mock_session.__exit__ = MagicMock(return_value=False)
+    
+    mock_driver = MagicMock()
+    mock_driver.session.return_value = mock_session
+    return mock_driver, mock_session
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+def test_execute_write_neo4j_modern():
+    driver, session = _make_driver_with_execute_methods()
+    work_fn = MagicMock(return_value="result")
+    
+    res = execute_write_operation(driver, "neo4j", work_fn)
+    
+    session.execute_write.assert_called_once_with(work_fn)
+    # verify work_fn is NOT called directly, but passed to execute_write
+    work_fn.assert_not_called()
+
+def test_execute_write_neo4j_legacy():
+    driver, session = _make_legacy_driver()
+    work_fn = MagicMock(return_value="result")
+    
+    res = execute_write_operation(driver, "neo4j", work_fn)
+    
+    session.write_transaction.assert_called_once_with(work_fn)
+    work_fn.assert_not_called()
+
+def test_execute_write_neo4j_fallback():
+    driver, session = _make_raw_driver()
+    work_fn = MagicMock(return_value="result")
+    
+    res = execute_write_operation(driver, "neo4j", work_fn)
+    
+    work_fn.assert_called_once_with(session)
+    assert res == "result"
+
+def test_execute_write_other_backend():
+    driver, session = _make_driver_with_execute_methods()
+    work_fn = MagicMock(return_value="result")
+    
+    res = execute_write_operation(driver, "kuzudb", work_fn)
+    
+    # execute_write should NOT be called for kuzudb even if present
+    session.execute_write.assert_not_called()
+    work_fn.assert_called_once_with(session)
+    assert res == "result"
+
+def test_execute_read_neo4j_modern():
+    driver, session = _make_driver_with_execute_methods()
+    work_fn = MagicMock(return_value="result")
+    
+    res = execute_read_operation(driver, "neo4j", work_fn)
+    
+    session.execute_read.assert_called_once_with(work_fn)
+
+def test_get_backend_type():
+    db_manager = MagicMock()
+    db_manager.get_backend_type.return_value = "custom"
+    
+    driver = MagicMock()
+    driver.get_backend_type.return_value = "driver_backend"
+    
+    # prefers db_manager
+    assert get_backend_type(driver, db_manager) == "custom"
+    
+    # falls back to driver
+    db_manager = MagicMock(spec=[])
+    assert get_backend_type(driver, db_manager) == "driver_backend"
+    
+    # falls back to neo4j
+    driver = MagicMock(spec=[])
+    assert get_backend_type(driver, None) == "neo4j"
+
+
+if __name__ == "__main__":
+    run_test("test_execute_write_neo4j_modern", test_execute_write_neo4j_modern)
+    run_test("test_execute_write_neo4j_legacy", test_execute_write_neo4j_legacy)
+    run_test("test_execute_write_neo4j_fallback", test_execute_write_neo4j_fallback)
+    run_test("test_execute_write_other_backend", test_execute_write_other_backend)
+    run_test("test_execute_read_neo4j_modern", test_execute_read_neo4j_modern)
+    run_test("test_get_backend_type", test_get_backend_type)
+    
+    print(f"\nRESULTS: {PASSED} passed, {FAILED} failed")
+    if FAILED > 0:
+        sys.exit(1)


### PR DESCRIPTION
This PR introduces a comprehensive architectural refactor of the database ingestion pipeline for Neo4j. Previously, the ingestion methods relied on basic begin_transaction() contexts which lacked automatic retry semantics on transient database errors. Additionally, multi-batch data insertion methods executed individual transactions per batch, leaving severe atomicity gaps where a mid-run crash would result in partial writes and orphaned nodes.

closes #1101 

This update resolves these architectural flaws by migrating the adapter to utilize natively managed execution wrappers (session.execute_write).

Extracted backend resolution logic into a centralized get_backend_type utility.
Introduced execute_write_operation and execute_read_operation to intelligently wrap Neo4j writes with auto-retry support and manage fallback logic for legacy and non-Neo4j drivers (e.g. KuzuDB, FalkorDB).
Atomic Method-Level Closures (writer.py & post_resolution.py)

Refactored over 20+ ingestion loops, including complex multi-stage methods (write_datasource_graph, write_orm_mappings, write_maven_build_graph, etc.) to securely group all batches into a single def _work(session): closure block.
This ensures that if any part of the method fails or is interrupted, the transaction rolls back cleanly, effectively eliminating the orphaned node issue.

Resolved associated runtime issues like proper loop variable closure binding (_i=i) where needed, and local variable capturing (NameError fixes for variables like cnt and deleted).
Read-Only Safeties

Properly designated read queries like CALL db.labels() and graph re-resolution queries in post_resolution.py to use execute_read_operation to avoid unnecessary write lock acquisitions.

Guarded against transient retry mutation risks by moving outer-scope mutations (like dict updates) entirely outside of the retryable read/write blocks.

Added comprehensive unit tests in tests/unit/tools/test_graph_writer_transactions.py to continuously assert the correct driver routing and retry behavior across the neo4j (modern and legacy) and fallback code paths.
<img width="923" height="380" alt="image" src="https://github.com/user-attachments/assets/0d15857d-93a1-4815-8edc-32ca7b28daf3" />
