### PR TITLE
docs: add backend compatibility tables

### DIFF
--- a/docs/docs/concepts/backends.md
+++ b/docs/docs/concepts/backends.md
@@ -25,6 +25,12 @@ KuzuDB is an in-process property graph database management system. It requires z
 - **Cross-Platform**: Natively supports Windows, Linux, and macOS on Python 3.10+.
 - **Data Directory**: Graphs are saved inside the local `.codegraphcontext/` directory within the workspace.
 
+### Version Compatibility
+
+| Package | Declared bounds (`pyproject.toml`) | Versions |
+| :--- | :--- | :--- |
+| `kuzu` | Not declared | `0.10.0`, `0.11.0`, `0.11.1`, `0.11.2`, `0.11.3` |
+
 ### Setup
 Ensure the driver is installed:
 ```bash
@@ -65,6 +71,14 @@ An embedded, in-memory graph engine that uses local shared memory drivers.
 ### FalkorDB Remote
 Connects to an external Redis-compatible FalkorDB server instance running in a Docker container or network host.
 
+### Version Compatibility
+
+| Package | Declared bounds (`pyproject.toml`) | Versions |
+| :--- | :--- | :--- |
+| `falkordblite` | `>=0.7, <0.10` | `0.7.0`, `0.8.0`, `0.9.0` |
+| `falkordb` | `>=1.0, <1.6` | `1.5.0` |
+| `redis` | `>=5, <6` | `5.3.1` |
+
 ### Setup
 Install the target drivers:
 ```bash
@@ -92,6 +106,12 @@ Neo4j is the enterprise standard for graph database clustering, management, and 
 
 - **Neo4j Browser**: Connect to `http://localhost:7474` to visualize and interact with your code graph using Neo4j's query visualizer.
 - **Scale**: Handles repositories containing millions of lines of code.
+
+### Version Compatibility
+
+| Package | Declared bounds (`pyproject.toml`) | Versions |
+| :--- | :--- | :--- |
+| `neo4j` | `>=5.15.0` | `6.2.0` |
 
 ### Setup
 Start a Neo4j server (e.g., using Docker):


### PR DESCRIPTION
Fixes #1105 

Adds explicit backend compatibility tables to `docs/docs/concepts/backends.md` for:

* Neo4j
* FalkorDB (Lite + Remote)
* KuzuDB

### Changes made

* Added database engine and package driver compatibility tables
* Added declared dependency bounds from `pyproject.toml`
* Added manually tested working versions for backend drivers
* Kept changes scoped only from `docs/docs/concepts/backends.md`

### Kuzu version boundaries

* `kuzu` currently has no explicit version bounds declared in `pyproject.toml`, so only manually tested working versions are documented.
* Compatibility was manually verified using the sample dataset as requested in the issue.

### Manual testing

Commands used:

```bash
cgc index
cgc stats
```

Sample dataset:

```txt
tests/fixtures/sample_projects/sample_project_elisp
```

### Tested versions

**KuzuDB**

* `0.10.0`
* `0.11.0`
* `0.11.1`
* `0.11.2`
* `0.11.3`

**FalkorDB Lite**

* `0.7.0`
* `0.8.0`
* `0.9.0`

**FalkorDB Remote**

* `1.5.0`

**Redis**

* `5.3.1`

**Neo4j**

* `6.2.0`
