### PR TITLE
Fix SameFileError in per-repo auto-init when run from home directory

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -887,10 +887,15 @@ def resolve_context(
 
         inherited_db = load_config().get("DEFAULT_DATABASE", "falkordb")
 
-        # Copy global .env into local context for easy per-repo tweaking
+        # Copy global .env into local context for easy per-repo tweaking.
+        # Guard against the self-copy case: when cwd is the home directory,
+        # local_cgc resolves to CONFIG_DIR itself, so `local_cgc / ".env"` is
+        # CONFIG_FILE. Copying a file onto itself raises shutil.SameFileError,
+        # which crashes resolve_context for any session started from home.
         import shutil
-        if CONFIG_FILE.exists():
-            shutil.copy2(CONFIG_FILE, local_cgc / ".env")
+        _target_env = local_cgc / ".env"
+        if CONFIG_FILE.exists() and _target_env.resolve() != CONFIG_FILE.resolve():
+            shutil.copy2(CONFIG_FILE, _target_env)
 
         local_yaml = local_cgc / "config.yaml"
         if not local_yaml.exists():


### PR DESCRIPTION
## Problem

In `src/codegraphcontext/cli/config_manager.py`, `resolve_context()` auto-initializes
a per-repo context when `mode: per-repo` and no local `.codegraphcontext/` is found:

```python
if local_cgc is None and cfg.mode == "per-repo":
    local_cgc = cwd / ".codegraphcontext"
    ...
    if CONFIG_FILE.exists():
        shutil.copy2(CONFIG_FILE, local_cgc / ".env")   # <-- crashes
```

When `cwd` is the user's **home directory**, `cwd / ".codegraphcontext"` resolves to
`CONFIG_DIR` itself, so `local_cgc / ".env"` *is* `CONFIG_FILE`
(`~/.codegraphcontext/.env`). `shutil.copy2()` of a file onto itself raises
`shutil.SameFileError`, which propagates out of `resolve_context()` and crashes any
process whose working directory is the home dir — e.g. an MCP server or coding agent
launched from `~`.

## Reproduction

```bash
cd ~                       # any dir whose ./.codegraphcontext == global CONFIG_DIR
# with config.yaml mode: per-repo
python -c "from codegraphcontext.cli.config_manager import resolve_context; resolve_context()"
# -> shutil.SameFileError: ...\.codegraphcontext\.env and ...\.codegraphcontext\.env are the same file
```

## Fix

Guard the copy with a samefile check so the self-copy is skipped:

```python
import shutil
_target_env = local_cgc / ".env"
if CONFIG_FILE.exists() and _target_env.resolve() != CONFIG_FILE.resolve():
    shutil.copy2(CONFIG_FILE, _target_env)
```

The auto-init still proceeds normally (directory + `config.yaml` are created); only the
redundant self-copy is skipped. In the home-cwd case the `.env` already *is* the global
one, so nothing is lost.

## Scope

One-line behavioral guard, no API change. `py_compile` clean.

---
*Note for maintainers: the sibling `find_dotenv(usecwd=True)` issue we also hit on an
older release (0.4.7) appears already resolved on current `main` — no `find_dotenv` call
remains in `cli/main.py` — so no PR is filed for it.*