### PR TITLE
feat(website): add GitLab repository indexing to cgc.codes explorer

### DIFF
--- a/website/api/gitlab-zip.ts
+++ b/website/api/gitlab-zip.ts
@@ -1,0 +1,112 @@
+// Proxies GitLab archive downloads server-side so Sec-Fetch-* headers never reach GitLab.
+
+import https from "https";
+
+function parseGitlabZipPath(urlPath: string): { project: string; branch: string } | null {
+  const segments = urlPath.split("/").filter(Boolean);
+  // /api/gitlab-zip/:encodedProject/:branch
+  if (segments.length < 4 || segments[0] !== "api" || segments[1] !== "gitlab-zip") {
+    return null;
+  }
+  const encodedProject = segments[2];
+  const branch = segments[3];
+  if (!encodedProject || !branch) return null;
+
+  let project = encodedProject;
+  try {
+    project = decodeURIComponent(encodedProject);
+  } catch {
+    project = encodedProject;
+  }
+  return { project, branch };
+}
+
+function fetchGitlabArchive(project: string, branch: string, token?: string): Promise<{
+  statusCode: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: Buffer;
+}> {
+  const gitlabPath = `/api/v4/projects/${encodeURIComponent(project)}/repository/archive.zip?sha=${encodeURIComponent(branch)}`;
+  const headers: Record<string, string> = {
+    "User-Agent": "CodeGraphContext-Website/1.0",
+    Accept: "application/zip, application/octet-stream, */*",
+  };
+  if (token) {
+    headers["PRIVATE-TOKEN"] = token;
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: "gitlab.com",
+        path: gitlabPath,
+        method: "GET",
+        headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          resolve({
+            statusCode: res.statusCode || 500,
+            headers: res.headers,
+            body: Buffer.concat(chunks),
+          });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+export default async function handler(req: any, res: any) {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const rawUrl = req.url || "";
+  const urlPath = rawUrl.split("?")[0];
+  let parsed = parseGitlabZipPath(urlPath);
+
+  if (!parsed && req.query?.project && req.query?.branch) {
+    let project = String(req.query.project);
+    try {
+      project = decodeURIComponent(project);
+    } catch {
+      // keep raw value
+    }
+    parsed = { project, branch: String(req.query.branch) };
+  }
+
+  if (!parsed) {
+    return res.status(400).json({ error: "Expected /api/gitlab-zip/:project/:branch" });
+  }
+
+  const token =
+    (typeof req.headers?.["x-gitlab-token"] === "string" && req.headers["x-gitlab-token"]) ||
+    (typeof req.headers?.["private-token"] === "string" && req.headers["private-token"]) ||
+    undefined;
+
+  try {
+    const upstream = await fetchGitlabArchive(parsed.project, parsed.branch, token || undefined);
+    res.status(upstream.statusCode);
+
+    const contentType = upstream.headers["content-type"];
+    const contentLength = upstream.headers["content-length"];
+    const disposition = upstream.headers["content-disposition"];
+    if (contentType) res.setHeader("Content-Type", contentType);
+    if (contentLength) res.setHeader("Content-Length", contentLength);
+    if (disposition) res.setHeader("Content-Disposition", disposition);
+    res.setHeader("Cache-Control", "public, max-age=300");
+
+    if (req.method === "HEAD") {
+      return res.end();
+    }
+
+    return res.end(upstream.body);
+  } catch (err: any) {
+    console.error("[gitlab-zip] Proxy error:", err);
+    return res.status(502).json({ error: "Failed to fetch GitLab archive", details: err.message });
+  }
+}

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -40,6 +40,7 @@ const App: React.FC = () => {
               <Route path="/pr-reviewer" element={<PRReviewerPage />} />
               <Route path="/pr-reviewer/:owner/:repo/pull/:prNumber" element={<PRReviewerPage />} />
               <Route path="/github/:owner/:repo" element={<Explore />} />
+              <Route path="/gitlab/*" element={<Explore />} />
               <Route path="/:owner/:repo" element={<Explore />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />

--- a/website/src/components/LocalUploader.tsx
+++ b/website/src/components/LocalUploader.tsx
@@ -7,6 +7,12 @@ import { parseFilesIntoGraph } from "@/lib/parser";
 import JSZip from "jszip";
 import { motion, AnimatePresence } from "framer-motion";
 import { useNavigate } from "react-router-dom";
+import {
+  RepoProvider,
+  detectProviderFromInput,
+  getExploreRoute,
+  parseRepoInput,
+} from "@/lib/repo-provider";
 
 const IGNORED_DIRS = new Set([
   'node_modules', '.git', '.github', 'dist', 'build', 'out', 'coverage',
@@ -148,9 +154,10 @@ export default function LocalUploader({ onComplete, plain }: { onComplete: (data
   const navigate = useNavigate();
   const [isParsing, setIsParsing] = useState(false);
   const [progress, setProgress] = useState({ text: "", value: 0 });
-  const [activeTab, setActiveTab] = useState<'folder' | 'zip' | 'cgc' | 'github'>('github');
-  const [githubUrl, setGithubUrl] = useState("");
-  const [githubPat, setGithubPat] = useState(() => localStorage.getItem('github_pat') || "");
+  const [activeTab, setActiveTab] = useState<'folder' | 'zip' | 'cgc' | 'remote'>('remote');
+  const [remoteRepoUrl, setRemoteRepoUrl] = useState("");
+  const [detectedProvider, setDetectedProvider] = useState<RepoProvider>("github");
+  const [pat, setPat] = useState(() => localStorage.getItem("github_pat") || "");
 
   const [config, setConfig] = useState(() => {
     try {
@@ -419,37 +426,44 @@ export default function LocalUploader({ onComplete, plain }: { onComplete: (data
     }
   };
 
-  const handleGithubFetch = async () => {
-    const input = githubUrl.trim();
-    if (!input) {
-      alert("Please enter a GitHub URL or owner/repo.");
-      return;
+  const syncPatForProvider = (provider: RepoProvider) => {
+    setDetectedProvider(provider);
+    const tokenKey = provider === "gitlab" ? "gitlab_pat" : "github_pat";
+    setPat(localStorage.getItem(tokenKey) || "");
+  };
+
+  const handleRepoUrlChange = (value: string) => {
+    setRemoteRepoUrl(value);
+    const nextProvider = detectProviderFromInput(value);
+    if (nextProvider !== detectedProvider) {
+      syncPatForProvider(nextProvider);
     }
+  };
 
-    let owner = "";
-    let repo = "";
-
-    if (input.includes("github.com")) {
-      const match = input.match(/github\.com\/([^/]+)\/([^/]+)/);
-      if (match) {
-        owner = match[1];
-        repo = match[2].replace(/\.git$/, "").split("/")[0];
-      }
+  const handlePatChange = (value: string) => {
+    setPat(value);
+    const tokenKey = detectedProvider === "gitlab" ? "gitlab_pat" : "github_pat";
+    if (value.trim()) {
+      localStorage.setItem(tokenKey, value.trim());
     } else {
-      const match = input.match(/^([^/]+)\/([^/]+)$/);
-      if (match) {
-        owner = match[1];
-        repo = match[2];
-      }
+      localStorage.removeItem(tokenKey);
     }
+  };
 
-    if (!owner || !repo) {
-      alert("Please enter a valid GitHub repository (e.g. sktime/sktime-mcp or https://github.com/sktime/sktime-mcp).");
+  const handleRemoteRepoFetch = async () => {
+    const input = remoteRepoUrl.trim();
+    if (!input) {
+      alert("Please enter a GitHub or GitLab URL, or owner/repo.");
       return;
     }
 
-    // Redirect user to the optimized Direct Repo route
-    navigate(`/${owner}/${repo}`);
+    const ref = parseRepoInput(input);
+    if (!ref) {
+      alert("Please enter a valid repository URL (e.g. https://gitlab.com/gitlab-org/gitlab or facebook/react).");
+      return;
+    }
+
+    navigate(getExploreRoute(ref));
   };
 
   return (
@@ -460,7 +474,7 @@ export default function LocalUploader({ onComplete, plain }: { onComplete: (data
         <button onClick={() => setActiveTab('folder')} className={`w-full sm:flex-1 py-2.5 px-3 text-xs sm:text-sm font-semibold rounded-xl transition-all duration-300 ${activeTab === 'folder' ? 'bg-purple-600 text-white shadow-[0_0_15px_rgba(168,85,247,0.4)]' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-purple-500/10 dark:hover:bg-purple-500/20'}`}>Folder</button>
         <button onClick={() => setActiveTab('zip')} className={`w-full sm:flex-1 py-2.5 px-3 text-xs sm:text-sm font-semibold rounded-xl transition-all duration-300 ${activeTab === 'zip' ? 'bg-purple-600 text-white shadow-[0_0_15px_rgba(168,85,247,0.4)]' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-purple-500/10 dark:hover:bg-purple-500/20'}`}>ZIP</button>
         <button onClick={() => setActiveTab('cgc')} className={`w-full sm:flex-1 py-2.5 px-3 text-xs sm:text-sm font-semibold rounded-xl transition-all duration-300 ${activeTab === 'cgc' ? 'bg-purple-600 text-white shadow-[0_0_15px_rgba(168,85,247,0.4)]' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-purple-500/10 dark:hover:bg-purple-500/20'}`}>CGC Bundle</button>
-        <button onClick={() => setActiveTab('github')} className={`w-full sm:flex-1 py-2.5 px-3 text-xs sm:text-sm font-semibold rounded-xl transition-all duration-300 ${activeTab === 'github' ? 'bg-purple-600 text-white shadow-[0_0_15px_rgba(168,85,247,0.4)]' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-purple-500/10 dark:hover:bg-purple-500/20'}`}>GitHub</button>
+        <button onClick={() => setActiveTab('remote')} className={`w-full sm:flex-1 py-2.5 px-3 text-xs sm:text-sm font-semibold rounded-xl transition-all duration-300 ${activeTab === 'remote' ? 'bg-purple-600 text-white shadow-[0_0_15px_rgba(168,85,247,0.4)]' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-purple-500/10 dark:hover:bg-purple-500/20'}`}>GitHub / GitLab</button>
       </div>
 
 
@@ -507,39 +521,54 @@ export default function LocalUploader({ onComplete, plain }: { onComplete: (data
             </motion.div>
           )}
 
-          {activeTab === 'github' && (
-            <motion.div key="github" initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col items-center w-full">
+          {activeTab === 'remote' && (
+            <motion.div key="remote" initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col items-center w-full">
 
               <h3 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">Fetch Repository</h3>
-              <p className="text-gray-600 dark:text-gray-400 text-sm mb-6 max-w-[250px]">Pull raw files from a GitHub repository.</p>
+              <p className="text-gray-600 dark:text-gray-400 text-sm mb-6 max-w-[320px]">Pull raw files from a public GitHub or GitLab repository.</p>
 
               <div className="w-full space-y-3 mb-4">
                 <input
                   type="text"
-                  placeholder="https://github.com/facebook/react"
-                  value={githubUrl}
-                  onChange={e => setGithubUrl(e.target.value)}
+                  placeholder="GitHub or GitLab URL / owner/repo"
+                  value={remoteRepoUrl}
+                  onChange={e => handleRepoUrlChange(e.target.value)}
                   className="w-full bg-white/40 dark:bg-black/40 border border-gray-300 dark:border-white/20 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 px-5 py-3.5 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all text-sm"
                 />
+                <p className="text-[11px] text-gray-500 dark:text-gray-500 text-left leading-relaxed px-1">
+                  e.g.{" "}
+                  <button
+                    type="button"
+                    onClick={() => handleRepoUrlChange("https://github.com/facebook/react")}
+                    className="text-purple-400 hover:text-purple-300 underline-offset-2 hover:underline"
+                  >
+                    github.com/facebook/react
+                  </button>
+                  {" "}or{" "}
+                  <button
+                    type="button"
+                    onClick={() => handleRepoUrlChange("https://gitlab.com/fdroid/fdroidclient")}
+                    className="text-purple-400 hover:text-purple-300 underline-offset-2 hover:underline"
+                  >
+                    gitlab.com/fdroid/fdroidclient
+                  </button>
+                </p>
 
                 <input
                   type="password"
-                  placeholder="Personal Access Token (PAT) - Required for Private Repos"
-                  value={githubPat}
-                  onChange={e => {
-                    const val = e.target.value;
-                    setGithubPat(val);
-                    if (val.trim()) {
-                      localStorage.setItem('github_pat', val.trim());
-                    } else {
-                      localStorage.removeItem('github_pat');
-                    }
-                  }}
+                  placeholder="PAT for private repos — GitHub (ghp_...) or GitLab (glpat-...)"
+                  value={pat}
+                  onChange={e => handlePatChange(e.target.value)}
                   className="w-full bg-white/40 dark:bg-black/40 border border-gray-300 dark:border-white/20 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 px-5 py-3.5 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all text-sm"
                 />
+                {pat.trim() && remoteRepoUrl.trim() && (
+                  <p className="text-[10px] text-gray-500 text-left px-1">
+                    Saving to {detectedProvider === "gitlab" ? "GitLab" : "GitHub"} token store
+                  </p>
+                )}
               </div>
 
-              <Button onClick={handleGithubFetch} className="bg-purple-600 hover:bg-purple-500 text-white shadow-[0_0_15px_rgba(168,85,247,0.4)] w-full rounded-xl py-6 text-lg font-semibold shadow-[0_0_20px_rgba(255,255,255,0.1)]">
+              <Button onClick={handleRemoteRepoFetch} className="bg-purple-600 hover:bg-purple-500 text-white shadow-[0_0_15px_rgba(168,85,247,0.4)] w-full rounded-xl py-6 text-lg font-semibold shadow-[0_0_20px_rgba(255,255,255,0.1)]">
                 Scan & Visualize
               </Button>
             </motion.div>

--- a/website/src/lib/parser.ts
+++ b/website/src/lib/parser.ts
@@ -80,6 +80,48 @@ export async function unzipFiles(zipBuffer: ArrayBuffer) {
   return files;
 }
 
+export async function fetchGitlabRepoFiles(url: string, onProgress?: (msg: string) => void) {
+  const match = url.match(/gitlab\.com\/([^?#]+)/i);
+  if (!match) throw new Error("Invalid GitLab URL");
+  const path = match[1].replace(/\.git$/, "").replace(/\/-\/.*$/, "").replace(/\/$/, "");
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length < 2) throw new Error("Invalid GitLab project path");
+  const projectPath = encodeURIComponent(parts.join("/"));
+
+  let branch = "main";
+  const projectRes = await fetch(`https://gitlab.com/api/v4/projects/${projectPath}`);
+  if (projectRes.ok) {
+    const projectData = await projectRes.json();
+    if (projectData?.default_branch) branch = projectData.default_branch;
+  }
+
+  const treeRes = await fetch(
+    `https://gitlab.com/api/v4/projects/${projectPath}/repository/tree?recursive=true&per_page=100&ref=${encodeURIComponent(branch)}`
+  );
+  if (!treeRes.ok) throw new Error("Could not fetch GitLab repository tree.");
+  const treeData = await treeRes.json();
+  const filePaths = (Array.isArray(treeData) ? treeData : [])
+    .filter((t: { type: string }) => t.type === "blob")
+    .map((t: { path: string }) => t.path)
+    .filter((p: string) => p.match(/\.(js|ts|jsx|tsx|py|c|h|cpp|hpp|cc|cs|go|rs|rb|php|swift|kt|kts|dart)$/) && !p.includes("node_modules") && !p.includes(".git"));
+
+  if (onProgress) onProgress(`Found ${filePaths.length} files...`);
+
+  const files: { path: string; content: string }[] = [];
+  for (let i = 0; i < Math.min(filePaths.length, 150); i += 10) {
+    const batch = filePaths.slice(i, i + 10);
+    await Promise.all(batch.map(async (filePath: string) => {
+      try {
+        const r = await fetch(`https://gitlab.com/${parts.join("/")}/-/raw/${branch}/${filePath}`);
+        if (r.ok) files.push({ path: filePath, content: await r.text() });
+      } catch {
+        // skip failed files
+      }
+    }));
+  }
+  return files;
+}
+
 export async function fetchGithubRepoFiles(url: string, onProgress?: (msg: string) => void) {
   const match = url.match(/github\.com\/([^/]+)\/([^/]+)/);
   if (!match) throw new Error("Invalid GitHub URL");

--- a/website/src/lib/repo-fetcher.ts
+++ b/website/src/lib/repo-fetcher.ts
@@ -1,0 +1,251 @@
+import JSZip from "jszip";
+import {
+  RepoRef,
+  getAuthHeaders,
+  getAuthTokenKey,
+  getAuthenticatedZipUrl,
+  getBranchesToTry,
+  getCdnFileUrl,
+  getPublicZipUrl,
+  getRawFileUrl,
+  getZipProxyUrl,
+  estimateZipSize,
+  listRepositoryFiles,
+  resolveRepoMetadata,
+} from "./repo-provider";
+
+const SOURCE_FILE_PATTERN = /\.(js|ts|jsx|tsx|py|c|h|cpp|hpp|cc|cs|go|rs|rb|php|swift|kt|kts|dart)$/;
+
+export interface FetchedRepoFiles {
+  files: { path: string; content: string }[];
+  fileContents: Record<string, string>;
+  latestCommitSha: string;
+  detectedBranch: string;
+}
+
+export interface RepoFetchCallbacks {
+  onProgressText: (text: string) => void;
+  onProgressValue: (value: number) => void;
+  isPathIgnored: (path: string) => boolean;
+  fetchWithProgress: (url: string, onProgress: (loaded: number, total: number) => void) => Promise<Response>;
+  fetchWithFallbackProxies: (
+    url: string,
+    onProgress?: (loaded: number, total: number) => void
+  ) => Promise<Response>;
+}
+
+const isZipResponse = (res: Response) => {
+  const contentType = res.headers.get("content-type") || "";
+  return !contentType.includes("text/html") && !contentType.includes("application/json");
+};
+
+export async function fetchRepositoryFiles(
+  ref: RepoRef,
+  callbacks: RepoFetchCallbacks
+): Promise<FetchedRepoFiles> {
+  const { onProgressText, onProgressValue, isPathIgnored, fetchWithProgress, fetchWithFallbackProxies } =
+    callbacks;
+
+  let files: { path: string; content: string }[] = [];
+  let fileContents: Record<string, string> = {};
+
+  const { detectedBranch, latestCommitSha: initialCommitSha } = await resolveRepoMetadata(ref);
+  let latestCommitSha = initialCommitSha;
+  const branchesToTry = getBranchesToTry(detectedBranch);
+  const { estimatedZipSize, isEstimateReliable } = await estimateZipSize(ref, branchesToTry);
+
+  const updateDownloadProgress = (loaded: number, total: number) => {
+    const mbLoaded = (loaded / 1024 / 1024).toFixed(2);
+    const finalTotal = total > 0 ? total : estimatedZipSize;
+
+    let pct = 0;
+    if (loaded < finalTotal) {
+      pct = Math.round((loaded / finalTotal) * 90);
+    } else {
+      const overflow = loaded - finalTotal;
+      const extraPct = 9 * (1 - Math.exp(-overflow / (1024 * 1024 * 5)));
+      pct = Math.round(90 + extraPct);
+    }
+
+    if (total > 0) {
+      onProgressText(
+        `Downloading repository archive: ${pct}% (${mbLoaded} MB of ${(total / 1024 / 1024).toFixed(2)} MB)`
+      );
+    } else if (isEstimateReliable) {
+      onProgressText(
+        `Downloading repository archive: ${pct}% (${mbLoaded} MB of ~${(estimatedZipSize / 1024 / 1024).toFixed(2)} MB)`
+      );
+    } else {
+      onProgressText(`Downloading repository archive: ${pct}% (${mbLoaded} MB)`);
+    }
+    onProgressValue(10 + Math.floor(pct * 0.15));
+  };
+
+  try {
+    onProgressText("Downloading repository archive...");
+    onProgressValue(10);
+
+    let response: Response | null = null;
+    let zipSuccessBranch = detectedBranch;
+    const authHeaders = getAuthHeaders(ref);
+
+    if (localStorage.getItem(getAuthTokenKey(ref))) {
+      for (const branch of branchesToTry) {
+        try {
+          const zipUrl = getAuthenticatedZipUrl(ref, branch);
+          if (!zipUrl) continue;
+          const tempRes = await fetch(zipUrl, { headers: authHeaders });
+          if (tempRes.ok) {
+            response = tempRes;
+            zipSuccessBranch = branch;
+            break;
+          }
+        } catch (errAuth) {
+          console.warn(`[Explore] Authenticated zip failed for branch ${branch}:`, errAuth);
+        }
+      }
+    }
+
+    if (!response || !response.ok) {
+      for (const branch of branchesToTry) {
+        try {
+          const zipUrl = getZipProxyUrl(ref, branch);
+          const tempRes = await fetchWithProgress(zipUrl, updateDownloadProgress);
+          if (tempRes?.ok && isZipResponse(tempRes)) {
+            response = tempRes;
+            zipSuccessBranch = branch;
+            break;
+          }
+        } catch (err1) {
+          console.warn(`[Explore] Same-origin zip proxy failed for branch ${branch}:`, err1);
+        }
+      }
+    }
+
+    if (!response || !response.ok) {
+      for (const branch of branchesToTry) {
+        try {
+          const zipUrl = getPublicZipUrl(ref, branch);
+          const tempRes = await fetchWithFallbackProxies(zipUrl, updateDownloadProgress);
+          if (tempRes?.ok && isZipResponse(tempRes)) {
+            response = tempRes;
+            zipSuccessBranch = branch;
+            break;
+          }
+        } catch (err3) {
+          console.warn(`[Explore] Public zip fallback failed for branch ${branch}:`, err3);
+        }
+      }
+    }
+
+    if (!response || !response.ok) {
+      throw new Error("All ZIP download tiers failed.");
+    }
+
+    onProgressText("Unzipping archive in-memory...");
+    onProgressValue(30);
+    const buffer = await response.arrayBuffer();
+    const jszip = await JSZip.loadAsync(buffer);
+
+    const promises: Promise<void>[] = [];
+    jszip.forEach((path, entry) => {
+      if (!entry.dir && SOURCE_FILE_PATTERN.test(path) && !isPathIgnored(path)) {
+        promises.push(
+          entry.async("text").then((content) => {
+            const cleanPath = path.substring(path.indexOf("/") + 1);
+            files.push({ path: cleanPath, content });
+          })
+        );
+      }
+    });
+
+    if (promises.length === 0) {
+      throw new Error("No parseable code files found in the repository.");
+    }
+
+    onProgressText(`Extracting ${promises.length} files...`);
+    onProgressValue(45);
+    await Promise.all(promises);
+
+    for (const f of files) {
+      fileContents[f.path] = f.content;
+    }
+    console.log(
+      `[ZIP Flow] Successfully downloaded and extracted ${files.length} files from branch @${zipSuccessBranch}.`
+    );
+  } catch (zipErr) {
+    console.warn("[ZIP Flow] Failed, falling back to individual file pipeline...", zipErr);
+    files = [];
+    fileContents = {};
+
+    onProgressText("Fetching repository structure (fallback)...");
+    onProgressValue(5);
+
+    const listing = await listRepositoryFiles(ref, branchesToTry);
+    if (listing.files.length === 0) {
+      throw new Error("Failed to fetch repository file tree for all branch attempts.");
+    }
+    if (listing.commitSha) {
+      latestCommitSha = listing.commitSha;
+    }
+
+    const candidatePaths = listing.files.filter(
+      (path) => SOURCE_FILE_PATTERN.test(path) && !isPathIgnored(path)
+    );
+
+    if (candidatePaths.length === 0) {
+      throw new Error("No parseable code files found in the repository.");
+    }
+
+    onProgressText(`Found ${candidatePaths.length} code files. Downloading in parallel...`);
+    onProgressValue(15);
+
+    const BATCH_SIZE = 15;
+    let downloadedCount = 0;
+    const headers = getAuthHeaders(ref);
+
+    for (let i = 0; i < candidatePaths.length; i += BATCH_SIZE) {
+      const batch = candidatePaths.slice(i, i + BATCH_SIZE);
+
+      await Promise.all(
+        batch.map(async (filePath) => {
+          try {
+            const cdnUrl = getCdnFileUrl(ref, listing.branch, filePath);
+            if (cdnUrl) {
+              const fileRes = await fetch(cdnUrl);
+              if (fileRes.ok) {
+                const content = await fileRes.text();
+                files.push({ path: filePath, content });
+                fileContents[filePath] = content;
+                return;
+              }
+            }
+
+            const rawUrl = getRawFileUrl(ref, listing.branch, filePath);
+            const fileRes = await fetch(rawUrl, { headers });
+            if (!fileRes.ok) throw new Error(`Status ${fileRes.status}`);
+            const content = await fileRes.text();
+            files.push({ path: filePath, content });
+            fileContents[filePath] = content;
+          } catch (err) {
+            console.warn(`Failed to fetch file content for ${filePath}:`, err);
+          } finally {
+            downloadedCount++;
+            const progress = 15 + Math.min(35, Math.floor((downloadedCount / candidatePaths.length) * 35));
+            onProgressText(`Downloading files (${downloadedCount}/${candidatePaths.length})...`);
+            onProgressValue(progress);
+          }
+        })
+      );
+    }
+
+    if (files.length === 0) {
+      throw new Error("Failed to download any code files from the CDN.");
+    }
+    console.log(
+      `[CDN Flow] Successfully downloaded ${files.length} files from branch @${listing.branch}.`
+    );
+  }
+
+  return { files, fileContents, latestCommitSha, detectedBranch };
+}

--- a/website/src/lib/repo-provider.ts
+++ b/website/src/lib/repo-provider.ts
@@ -1,0 +1,410 @@
+export type RepoProvider = "github" | "gitlab";
+
+export interface RepoRef {
+  provider: RepoProvider;
+  /** Namespace / owner segment (may contain slashes for nested GitLab groups). */
+  owner: string;
+  /** Project / repository name. */
+  repo: string;
+  /** Full project path, e.g. `gitlab-org/gitlab` or `facebook/react`. */
+  fullPath: string;
+  host: string;
+}
+
+const GITHUB_HOST = "github.com";
+const GITLAB_HOST = "gitlab.com";
+
+const DEFAULT_BRANCHES = ["main", "master", "unstable", "trunk", "develop", "dev"];
+
+/** Strip trailing .git, /-/* UI paths, and query/hash from a repo path segment. */
+export function cleanRepoPathSegment(path: string): string {
+  return path
+    .replace(/\.git$/, "")
+    .replace(/\/-$/, "")
+    .replace(/\/-\/.*$/, "")
+    .replace(/[?#].*$/, "")
+    .replace(/\/$/, "");
+}
+
+/** Parse a user-supplied URL or `owner/repo` shorthand into a RepoRef. */
+export function parseRepoInput(input: string): RepoRef | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const gitlabMatch = trimmed.match(/gitlab\.com\/([^?#]+)/i);
+  if (gitlabMatch) {
+    const path = cleanRepoPathSegment(gitlabMatch[1]);
+    const parts = path.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    const repo = parts[parts.length - 1];
+    const owner = parts.slice(0, -1).join("/");
+    return {
+      provider: "gitlab",
+      owner,
+      repo,
+      fullPath: `${owner}/${repo}`,
+      host: GITLAB_HOST,
+    };
+  }
+
+  const githubMatch = trimmed.match(/github\.com\/([^/]+)\/([^/?#]+)/i);
+  if (githubMatch) {
+    const owner = githubMatch[1];
+    const repo = githubMatch[2].replace(/\.git$/, "");
+    return {
+      provider: "github",
+      owner,
+      repo,
+      fullPath: `${owner}/${repo}`,
+      host: GITHUB_HOST,
+    };
+  }
+
+  const shorthand = trimmed.match(/^([^/]+\/[^/]+(?:\/[^/]+)*)\/?$/);
+  if (shorthand) {
+    const path = cleanRepoPathSegment(shorthand[1]);
+    const parts = path.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    const repo = parts[parts.length - 1];
+    const owner = parts.slice(0, -1).join("/");
+    return {
+      provider: "github",
+      owner,
+      repo,
+      fullPath: `${owner}/${repo}`,
+      host: GITHUB_HOST,
+    };
+  }
+
+  return null;
+}
+
+/** Build a RepoRef from route parameters. */
+export function repoRefFromRoute(
+  provider: RepoProvider | undefined,
+  owner: string | undefined,
+  repo: string | undefined,
+  gitlabSplat?: string
+): RepoRef | null {
+  if (provider === "gitlab") {
+    const fullPath = cleanRepoPathSegment(gitlabSplat || "");
+    if (!fullPath) return null;
+    const parts = fullPath.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    const repoName = parts[parts.length - 1];
+    const ownerPath = parts.slice(0, -1).join("/");
+    return {
+      provider: "gitlab",
+      owner: ownerPath,
+      repo: repoName,
+      fullPath,
+      host: GITLAB_HOST,
+    };
+  }
+
+  if (!owner || !repo) return null;
+  return {
+    provider: provider === "github" ? "github" : "github",
+    owner,
+    repo,
+    fullPath: `${owner}/${repo}`,
+    host: GITHUB_HOST,
+  };
+}
+
+/** Guess provider from partial user input (URL or shorthand). Defaults to GitHub. */
+export function detectProviderFromInput(input: string): RepoProvider {
+  const trimmed = input.trim().toLowerCase();
+  if (trimmed.includes("gitlab.com") || trimmed.includes("gitlab:")) {
+    return "gitlab";
+  }
+  return "github";
+}
+
+export function getExploreRoute(ref: RepoRef): string {
+  if (ref.provider === "gitlab") {
+    return `/gitlab/${ref.fullPath}`;
+  }
+  return `/${ref.owner}/${ref.repo}`;
+}
+
+export function getCacheKey(ref: RepoRef): string {
+  return `${ref.provider}:${ref.fullPath.toLowerCase()}`;
+}
+
+export function getLegacyCacheKey(ref: RepoRef): string {
+  return `${ref.owner.toLowerCase()}/${ref.repo.toLowerCase()}`;
+}
+
+export function getAuthTokenKey(ref: RepoRef): string {
+  return ref.provider === "gitlab" ? "gitlab_pat" : "github_pat";
+}
+
+export function getAuthHeaders(ref: RepoRef): Record<string, string> {
+  const token = localStorage.getItem(getAuthTokenKey(ref));
+  if (!token) return {};
+  if (ref.provider === "gitlab") {
+    return { "PRIVATE-TOKEN": token };
+  }
+  return { Authorization: `token ${token}` };
+}
+
+export function getBranchesToTry(detectedBranch: string): string[] {
+  return Array.from(new Set([detectedBranch, ...DEFAULT_BRANCHES]));
+}
+
+/** Resolve default branch and latest commit SHA for a repository. */
+export async function resolveRepoMetadata(
+  ref: RepoRef
+): Promise<{ detectedBranch: string; latestCommitSha: string }> {
+  let detectedBranch = "main";
+  let latestCommitSha = "";
+
+  const headers = getAuthHeaders(ref);
+
+  try {
+    if (ref.provider === "github") {
+      const apiRes = await fetch(
+        `https://api.github.com/repos/${ref.owner}/${ref.repo}`,
+        { headers }
+      );
+      if (apiRes.ok) {
+        const apiData = await apiRes.json();
+        if (apiData?.default_branch) {
+          detectedBranch = apiData.default_branch;
+        }
+      }
+
+      const commitsRes = await fetch(
+        `https://api.github.com/repos/${ref.owner}/${ref.repo}/commits/${detectedBranch}`,
+        { headers }
+      );
+      if (commitsRes.ok) {
+        const commitsData = await commitsRes.json();
+        if (commitsData?.sha) {
+          latestCommitSha = commitsData.sha;
+        }
+      }
+    } else {
+      const projectPath = encodeURIComponent(ref.fullPath);
+      const apiRes = await fetch(
+        `https://gitlab.com/api/v4/projects/${projectPath}`,
+        { headers }
+      );
+      if (apiRes.ok) {
+        const apiData = await apiRes.json();
+        if (apiData?.default_branch) {
+          detectedBranch = apiData.default_branch;
+        }
+        if (apiData?.last_commit_id) {
+          latestCommitSha = apiData.last_commit_id;
+        }
+      }
+    }
+  } catch (err) {
+    console.warn(`[Explore] Failed to resolve branch metadata for ${ref.fullPath}:`, err);
+  }
+
+  return { detectedBranch, latestCommitSha };
+}
+
+export function getZipProxyUrl(ref: RepoRef, branch: string): string {
+  if (ref.provider === "gitlab") {
+    return `/api/gitlab-zip/${encodeURIComponent(ref.fullPath)}/${branch}`;
+  }
+  return `/api/github-zip/${ref.owner}/${ref.repo}/${branch}`;
+}
+
+export function getPublicZipUrl(ref: RepoRef, branch: string): string {
+  if (ref.provider === "gitlab") {
+    return `https://gitlab.com/${ref.fullPath}/-/archive/${branch}/${ref.repo}-${branch}.zip`;
+  }
+  return `https://github.com/${ref.owner}/${ref.repo}/archive/refs/heads/${branch}.zip`;
+}
+
+export function getAuthenticatedZipUrl(ref: RepoRef, branch: string): string | null {
+  const token = localStorage.getItem(getAuthTokenKey(ref));
+  if (!token) return null;
+
+  if (ref.provider === "gitlab") {
+    const projectPath = encodeURIComponent(ref.fullPath);
+    return `https://gitlab.com/api/v4/projects/${projectPath}/repository/archive.zip?sha=${branch}`;
+  }
+  return `https://api.github.com/repos/${ref.owner}/${ref.repo}/zipball/${branch}`;
+}
+
+export function getJsdelivrMetaUrl(ref: RepoRef, branch: string): string | null {
+  if (ref.provider !== "github") return null;
+  return `https://data.jsdelivr.net/v1/packages/gh/${ref.owner}/${ref.repo}@${branch}`;
+}
+
+export function getRawFileUrl(ref: RepoRef, branch: string, filePath: string): string {
+  if (ref.provider === "gitlab") {
+    return `https://gitlab.com/${ref.fullPath}/-/raw/${branch}/${filePath}`;
+  }
+  return `https://raw.githubusercontent.com/${ref.owner}/${ref.repo}/${branch}/${filePath}`;
+}
+
+export function getCdnFileUrl(ref: RepoRef, branch: string, filePath: string): string | null {
+  if (ref.provider === "github") {
+    return `https://cdn.jsdelivr.net/gh/${ref.owner}/${ref.repo}@${branch}/${filePath}`;
+  }
+  return null;
+}
+
+/** List all file paths in a repository (fallback when ZIP download fails). */
+export async function listRepositoryFiles(
+  ref: RepoRef,
+  branchesToTry: string[]
+): Promise<{ files: string[]; branch: string; commitSha: string }> {
+  const headers = getAuthHeaders(ref);
+  let filesList: string[] = [];
+  let successBranch = branchesToTry[0] || "main";
+  let commitSha = "";
+
+  if (ref.provider === "github") {
+    for (const branch of branchesToTry) {
+      const jsdelivrMetaUrl = getJsdelivrMetaUrl(ref, branch);
+      if (jsdelivrMetaUrl) {
+        try {
+          const metaRes = await fetch(jsdelivrMetaUrl);
+          if (metaRes.ok) {
+            const metaData = await metaRes.json();
+            if (metaData?.files && Array.isArray(metaData.files)) {
+              filesList = flattenJsdelivrTree(metaData.files);
+              successBranch = branch;
+              if (metaData.version) commitSha = metaData.version;
+              break;
+            }
+          }
+        } catch (e) {
+          console.warn(`[Explore] jsDelivr listing failed for @${branch}:`, e);
+        }
+      }
+    }
+
+    if (filesList.length === 0) {
+      for (const branch of branchesToTry) {
+        try {
+          const treeResponse = await fetch(
+            `https://api.github.com/repos/${ref.owner}/${ref.repo}/git/trees/${branch}?recursive=true`,
+            { headers }
+          );
+          if (treeResponse.ok) {
+            const treeData = await treeResponse.json();
+            if (treeData?.tree && Array.isArray(treeData.tree)) {
+              filesList = treeData.tree
+                .filter((item: { type: string }) => item.type === "blob")
+                .map((item: { path: string }) => item.path);
+              successBranch = branch;
+              break;
+            }
+          }
+        } catch (e) {
+          console.warn(`[Explore] GitHub tree listing failed for @${branch}:`, e);
+        }
+      }
+    }
+  } else {
+    const projectPath = encodeURIComponent(ref.fullPath);
+    for (const branch of branchesToTry) {
+      try {
+        let page = 1;
+        const pageFiles: string[] = [];
+        while (page <= 50) {
+          const treeResponse = await fetch(
+            `https://gitlab.com/api/v4/projects/${projectPath}/repository/tree?recursive=true&per_page=100&page=${page}&ref=${encodeURIComponent(branch)}`,
+            { headers }
+          );
+          if (!treeResponse.ok) break;
+          const treeData = await treeResponse.json();
+          if (!Array.isArray(treeData) || treeData.length === 0) break;
+          pageFiles.push(
+            ...treeData
+              .filter((item: { type: string }) => item.type === "blob")
+              .map((item: { path: string }) => item.path)
+          );
+          const nextPage = treeResponse.headers.get("x-next-page");
+          if (!nextPage || nextPage === "") break;
+          page = parseInt(nextPage, 10) || page + 1;
+        }
+        if (pageFiles.length > 0) {
+          filesList = pageFiles;
+          successBranch = branch;
+          break;
+        }
+      } catch (e) {
+        console.warn(`[Explore] GitLab tree listing failed for @${branch}:`, e);
+      }
+    }
+  }
+
+  return { files: filesList, branch: successBranch, commitSha };
+}
+
+interface JsdelivrFile {
+  name: string;
+  type: "file" | "directory";
+  size?: number;
+  files?: JsdelivrFile[];
+}
+
+function flattenJsdelivrTree(items: JsdelivrFile[], currentPath = ""): string[] {
+  let filePaths: string[] = [];
+  for (const item of items) {
+    const itemPath = currentPath ? `${currentPath}/${item.name}` : item.name;
+    if (item.type === "file") {
+      filePaths.push(itemPath);
+    } else if (item.type === "directory" && item.files) {
+      filePaths.push(...flattenJsdelivrTree(item.files, itemPath));
+    }
+  }
+  return filePaths;
+}
+
+export function getJsdelivrTotalSize(items: JsdelivrFile[]): number {
+  let total = 0;
+  for (const item of items) {
+    if (item.type === "file" && item.size) {
+      total += item.size;
+    } else if (item.type === "directory" && item.files) {
+      total += getJsdelivrTotalSize(item.files);
+    }
+  }
+  return total;
+}
+
+export async function estimateZipSize(
+  ref: RepoRef,
+  branchesToTry: string[]
+): Promise<{ estimatedZipSize: number; isEstimateReliable: boolean }> {
+  let estimatedZipSize = 4 * 1024 * 1024;
+  let isEstimateReliable = false;
+
+  if (ref.provider !== "github") {
+    return { estimatedZipSize, isEstimateReliable };
+  }
+
+  for (const branch of branchesToTry) {
+    const jsdelivrMetaUrl = getJsdelivrMetaUrl(ref, branch);
+    if (!jsdelivrMetaUrl) continue;
+    try {
+      const metaRes = await fetch(jsdelivrMetaUrl);
+      if (metaRes.ok) {
+        const metaData = await metaRes.json();
+        if (metaData?.files && Array.isArray(metaData.files)) {
+          const uncompressedSize = getJsdelivrTotalSize(metaData.files);
+          if (uncompressedSize > 0) {
+            estimatedZipSize = Math.max(500 * 1024, uncompressedSize * 0.22);
+            isEstimateReliable = true;
+          }
+          break;
+        }
+      }
+    } catch (err) {
+      console.warn(`[Explore] Failed jsDelivr metadata fetch for branch ${branch}:`, err);
+    }
+  }
+
+  return { estimatedZipSize, isEstimateReliable };
+}

--- a/website/src/pages/Explore.tsx
+++ b/website/src/pages/Explore.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { useSearchParams, useParams } from "react-router-dom";
+import { useSearchParams, useParams, useLocation } from "react-router-dom";
 import CodeGraphViewer from "../components/CodeGraphViewer";
 import LocalUploader from "../components/LocalUploader";
 import { motion, AnimatePresence } from "framer-motion";
@@ -9,6 +9,14 @@ import JSZip from "jszip";
 import { parseFilesIntoGraph } from "../lib/parser";
 import { KuzuCoordinator } from "../lib/kuzu-coordinator";
 import { getOrCreateSessionId } from "../lib/utils";
+import {
+  RepoRef,
+  getAuthTokenKey,
+  getCacheKey,
+  getLegacyCacheKey,
+  repoRefFromRoute,
+} from "../lib/repo-provider";
+import { fetchRepositoryFiles } from "../lib/repo-fetcher";
 
 
 const IGNORED_DIRS = new Set([
@@ -76,23 +84,32 @@ const openDB = (): Promise<IDBDatabase> => {
   });
 };
 
-const getCachedGraph = async (owner: string, repo: string): Promise<any | null> => {
+const getCachedGraph = async (ref: RepoRef): Promise<any | null> => {
   try {
     const db = await openDB();
+    const cacheKeys = [getCacheKey(ref), getLegacyCacheKey(ref)];
     return new Promise((resolve, reject) => {
       const transaction = db.transaction(STORE_NAME, "readonly");
       const store = transaction.objectStore(STORE_NAME);
-      const request = store.get(`${owner.toLowerCase()}/${repo.toLowerCase()}`);
-      request.onerror = () => reject(request.error);
-      request.onsuccess = () => {
-        const result = request.result;
-        // Keep cache valid for 7 days
-        if (result && (Date.now() - result.timestamp < 7 * 24 * 60 * 60 * 1000)) {
-          resolve(result.graphData);
-        } else {
-          resolve(null);
-        }
-      };
+      let pending = cacheKeys.length;
+      let found: any | null = null;
+
+      for (const key of cacheKeys) {
+        const request = store.get(key);
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          const result = request.result;
+          if (
+            !found &&
+            result &&
+            Date.now() - result.timestamp < 7 * 24 * 60 * 60 * 1000
+          ) {
+            found = result.graphData;
+          }
+          pending -= 1;
+          if (pending === 0) resolve(found);
+        };
+      }
     });
   } catch (e) {
     console.error("Failed to read from IndexedDB", e);
@@ -100,14 +117,14 @@ const getCachedGraph = async (owner: string, repo: string): Promise<any | null> 
   }
 };
 
-const cacheGraph = async (owner: string, repo: string, graphData: any): Promise<void> => {
+const cacheGraph = async (ref: RepoRef, graphData: any): Promise<void> => {
   try {
     const db = await openDB();
     return new Promise((resolve, reject) => {
       const transaction = db.transaction(STORE_NAME, "readwrite");
       const store = transaction.objectStore(STORE_NAME);
       const request = store.put({
-        key: `${owner.toLowerCase()}/${repo.toLowerCase()}`,
+        key: getCacheKey(ref),
         graphData,
         timestamp: Date.now()
       });
@@ -160,41 +177,14 @@ const fetchWithProgress = async (
   });
 };
 
-interface JSDelivrFile {
-  name: string;
-  type: "file" | "directory";
-  size?: number;
-  files?: JSDelivrFile[];
-}
-
-const flattenJSDelivrTree = (items: JSDelivrFile[], currentPath = ""): string[] => {
-  let filePaths: string[] = [];
-  for (const item of items) {
-    const itemPath = currentPath ? `${currentPath}/${item.name}` : item.name;
-    if (item.type === "file") {
-      filePaths.push(itemPath);
-    } else if (item.type === "directory" && item.files) {
-      filePaths.push(...flattenJSDelivrTree(item.files, itemPath));
-    }
-  }
-  return filePaths;
-};
-
-const getJSDelivrTotalSize = (items: JSDelivrFile[]): number => {
-  let total = 0;
-  for (const item of items) {
-    if (item.type === "file" && item.size) {
-      total += item.size;
-    } else if (item.type === "directory" && item.files) {
-      total += getJSDelivrTotalSize(item.files);
-    }
-  }
-  return total;
-};
-
 const Explore = () => {
   const [searchParams] = useSearchParams();
-  const { owner, repo } = useParams();
+  const location = useLocation();
+  const { owner, repo, "*": gitlabSplat } = useParams();
+  const isGitlabRoute = location.pathname.startsWith("/gitlab/");
+  const repoRef = isGitlabRoute
+    ? repoRefFromRoute("gitlab", undefined, undefined, gitlabSplat)
+    : repoRefFromRoute("github", owner, repo);
   const [graphData, setGraphData] = useState<any>(null);
   const graphDataRef = useRef<any>(null);
   useEffect(() => {
@@ -325,21 +315,19 @@ const Explore = () => {
     throw lastError || new Error("Failed to fetch via all available CORS proxies.");
   };
 
-  // If owner and repo path parameters are present, auto-fetch and index the codebase!
+  // If route parameters resolve to a repository, auto-fetch and index the codebase.
   useEffect(() => {
-    if (!owner || !repo) return;
-    
-    // Ignore static routes like "explore" getting caught as owner/repo
-    if (owner.toLowerCase() === "explore") return;
+    if (!repoRef) return;
+
+    if (!isGitlabRoute && owner?.toLowerCase() === "explore") return;
 
     const autoFetchAndIndex = async () => {
       setLoading(true);
       setError(null);
       
       try {
-        // 1. Try to load from IndexedDB cache first
         try {
-          const cached = await getCachedGraph(owner, repo);
+          const cached = await getCachedGraph(repoRef);
           if (cached) {
             setProgressText("Loading cached codebase graph...");
             setProgressValue(90);
@@ -348,353 +336,20 @@ const Explore = () => {
             setProgressText("Complete!");
             setProgressValue(100);
             setLoading(false);
-            console.log(`[Cache] Loaded repository graph for ${owner}/${repo} from IndexedDB cache.`);
+            console.log(`[Cache] Loaded repository graph for ${repoRef.fullPath} from IndexedDB cache.`);
             return;
           }
         } catch (cacheErr) {
           console.warn("[Cache] Error reading from cache:", cacheErr);
         }
 
-        let files: any[] = [];
-        let fileContents: Record<string, string> = {};
-
-        const getGithubHeaders = () => {
-          const headers: Record<string, string> = {};
-          const pat = localStorage.getItem('github_pat');
-          if (pat) {
-            headers['Authorization'] = `token ${pat}`;
-          }
-          return headers;
-        };
-
-        // 2. Resolve the default branch dynamically (natively CORS-compliant, rate-limited at 60/hr/IP on GitHub REST API)
-        let detectedBranch = "main";
-        let latestCommitSha = "";
-        try {
-          console.log(`[Explore] Resolving default branch for ${owner}/${repo} dynamically...`);
-          const apiRes = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers: getGithubHeaders() });
-          if (apiRes.ok) {
-            const apiData = await apiRes.json();
-            if (apiData && apiData.default_branch) {
-              detectedBranch = apiData.default_branch;
-              console.log(`[Explore] GitHub REST API resolved default branch: ${detectedBranch}`);
-            }
-          }
-          
-          console.log(`[Explore] Resolving latest commit SHA for branch ${detectedBranch} dynamically...`);
-          const commitsRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/commits/${detectedBranch}`, { headers: getGithubHeaders() });
-          if (commitsRes.ok) {
-            const commitsData = await commitsRes.json();
-            if (commitsData && commitsData.sha) {
-              latestCommitSha = commitsData.sha;
-              console.log(`[Explore] GitHub REST API resolved latest commit SHA: ${latestCommitSha}`);
-            }
-          }
-        } catch (err) {
-          console.warn("[Explore] Failed to resolve default branch or commit SHA dynamically via GitHub API:", err);
-        }
-
-        // Compile a robust fallback order of branch names to try (ensuring non-standard branches like unstable/trunk/develop work)
-        const branchesToTry = Array.from(new Set([
-          detectedBranch,
-          "main",
-          "master",
-          "unstable",
-          "trunk",
-          "develop",
-          "dev"
-        ]));
-
-        // 3. Estimate the repository size using jsDelivr API (Rate-limit free)
-        let estimatedZipSize = 4 * 1024 * 1024; // Default to 4MB estimate
-        let isEstimateReliable = false;
-        let sizeMetaData = null;
-        let sizeSuccessBranch = detectedBranch;
-
-        console.log("[Explore] Fetching repo metadata to estimate ZIP download size...");
-        for (const branch of branchesToTry) {
-          try {
-            const jsdelivrMetaUrl = `https://data.jsdelivr.net/v1/packages/gh/${owner}/${repo}@${branch}`;
-            const metaRes = await fetch(jsdelivrMetaUrl);
-            if (metaRes.ok) {
-              sizeMetaData = await metaRes.json();
-              sizeSuccessBranch = branch;
-              console.log(`[Explore] Successfully fetched jsDelivr metadata for size estimation (@${branch})`);
-              break;
-            }
-          } catch (err) {
-            console.warn(`[Explore] Failed jsDelivr metadata fetch for branch ${branch}:`, err);
-          }
-        }
-
-        if (sizeMetaData && Array.isArray(sizeMetaData.files)) {
-          const uncompressedSize = getJSDelivrTotalSize(sizeMetaData.files);
-          if (uncompressedSize > 0) {
-            estimatedZipSize = Math.max(500 * 1024, uncompressedSize * 0.22); // Assume 22% average compression
-            isEstimateReliable = true;
-            console.log(`[Explore] Estimated ZIP size: ${(estimatedZipSize / 1024 / 1024).toFixed(2)} MB (based on ${(uncompressedSize / 1024 / 1024).toFixed(2)} MB uncompressed, branch @${sizeSuccessBranch})`);
-          }
-        }
-
-        try {
-          // --- METHOD 1: ZIP ARCHIVE FLOW (PRIMARY) ---
-          setProgressText("Downloading repository archive...");
-          setProgressValue(10);
-          
-          let response = null;
-          let zipSuccessBranch = detectedBranch;
-
-          const updateDownloadProgress = (loaded: number, total: number) => {
-            const mbLoaded = (loaded / 1024 / 1024).toFixed(2);
-            const finalTotal = total > 0 ? total : estimatedZipSize;
-            
-            let pct = 0;
-            if (loaded < finalTotal) {
-              pct = Math.round((loaded / finalTotal) * 90);
-            } else {
-              const overflow = loaded - finalTotal;
-              const extraPct = 9 * (1 - Math.exp(-overflow / (1024 * 1024 * 5))); // 5MB half-life
-              pct = Math.round(90 + extraPct);
-            }
-
-            if (total > 0) {
-              setProgressText(`Downloading repository archive: ${pct}% (${mbLoaded} MB of ${(total / 1024 / 1024).toFixed(2)} MB)`);
-            } else if (isEstimateReliable) {
-              setProgressText(`Downloading repository archive: ${pct}% (${mbLoaded} MB of ~${(estimatedZipSize / 1024 / 1024).toFixed(2)} MB)`);
-            } else {
-              setProgressText(`Downloading repository archive: ${pct}% (${mbLoaded} MB)`);
-            }
-            setProgressValue(10 + Math.floor(pct * 0.15));
-          };
-
-          // TIER 0: Authenticated GitHub REST API Zipball (Direct & CORS-compliant for Private Repos)
-          const pat = localStorage.getItem('github_pat');
-          if (pat) {
-            for (const branch of branchesToTry) {
-              try {
-                console.log(`[Explore] Authenticated Tier: Fetching private zipball for branch: ${branch}`);
-                const zipUrl = `https://api.github.com/repos/${owner}/${repo}/zipball/${branch}`;
-                const tempRes = await fetch(zipUrl, {
-                  headers: {
-                    'Authorization': `token ${pat}`
-                  }
-                });
-                if (tempRes && tempRes.ok) {
-                  response = tempRes;
-                  zipSuccessBranch = branch;
-                  console.log(`[Explore] Authenticated Tier succeeded for branch: ${branch}`);
-                  break;
-                }
-              } catch (errAuth) {
-                console.warn(`[Explore] Authenticated Tier zip failed for branch ${branch}:`, errAuth);
-              }
-            }
-          }
-
-          // TIER 1: Same-Origin Serverless Rewrite / Dev Proxy (Fastest & CORS-Free)
-          if (!response || !response.ok) {
-            for (const branch of branchesToTry) {
-              try {
-                console.log(`[Explore] Tier 1: Fetching zip archive via same-origin rewrite for branch: ${branch}`);
-                const zipUrl = `/api/github-zip/${owner}/${repo}/${branch}`;
-                const tempRes = await fetchWithProgress(zipUrl, updateDownloadProgress);
-                if (tempRes && tempRes.ok) {
-                  const contentType = tempRes.headers.get("content-type") || "";
-                  if (!contentType.includes("text/html") && !contentType.includes("application/json")) {
-                    response = tempRes;
-                    zipSuccessBranch = branch;
-                    console.log(`[Explore] Tier 1 succeeded for branch: ${branch}`);
-                    break;
-                  }
-                }
-              } catch (err1) {
-                console.warn(`[Explore] Tier 1 same-origin zip failed for branch ${branch}:`, err1);
-              }
-            }
-          }
-
-          // TIER 2: Fallback to public CORS Proxies (Standard Web Archive)
-          if (!response || !response.ok) {
-            console.log("[Explore] Tier 2: Falling back to public CORS proxies...");
-            for (const branch of branchesToTry) {
-              try {
-                console.log(`[Explore] Tier 2: Fetching zip archive via CORS proxy for branch: ${branch}`);
-                const zipUrl = `https://github.com/${owner}/${repo}/archive/refs/heads/${branch}.zip`;
-                const tempRes = await fetchWithFallbackProxies(zipUrl, updateDownloadProgress);
-                if (tempRes && tempRes.ok) {
-                  const contentType = tempRes.headers.get("content-type") || "";
-                  if (!contentType.includes("text/html") && !contentType.includes("application/json")) {
-                    response = tempRes;
-                    zipSuccessBranch = branch;
-                    console.log(`[Explore] Tier 2 succeeded for branch: ${branch}`);
-                    break;
-                  }
-                }
-              } catch (err3) {
-                console.warn(`[Explore] Tier 2 fallback zip failed for branch ${branch}:`, err3);
-              }
-            }
-          }
-
-          if (!response || !response.ok) {
-            throw new Error("All ZIP download tiers failed.");
-          }
-
-          setProgressText("Unzipping archive in-memory...");
-          setProgressValue(30);
-          const buffer = await response.arrayBuffer();
-          const jszip = await JSZip.loadAsync(buffer);
-          
-          const promises: Promise<void>[] = [];
-          
-          jszip.forEach((path, entry) => {
-            if (
-              !entry.dir && 
-              path.match(/\.(js|ts|jsx|tsx|py|c|h|cpp|hpp|cc|cs|go|rs|rb|php|swift|kt|kts|dart)$/) && 
-              !isPathIgnored(path)
-            ) {
-              promises.push(
-                entry.async("text").then((content) => {
-                  const cleanPath = path.substring(path.indexOf("/") + 1);
-                  files.push({ path: cleanPath, content });
-                })
-              );
-            }
-          });
-          
-          if (promises.length === 0) {
-            throw new Error("No parseable code files found in the repository.");
-          }
-          
-          setProgressText(`Extracting ${promises.length} files...`);
-          setProgressValue(45);
-          await Promise.all(promises);
-
-          for (const f of files) {
-            fileContents[f.path] = f.content;
-          }
-          console.log(`[ZIP Flow] Successfully downloaded and extracted ${files.length} files from branch @${zipSuccessBranch}.`);
-
-        } catch (zipErr: any) {
-          console.warn("[ZIP Flow] Failed, falling back to CDN individual file pipeline...", zipErr);
-          files = [];
-          fileContents = {};
-
-          // --- METHOD 2: FALLBACK FAST CDN FLOW ---
-          setProgressText("Fetching repository structure (fallback)...");
-          setProgressValue(5);
-          
-          let filesList: string[] = [];
-          let cdnSuccessBranch = detectedBranch;
-
-          // TIER 1: Try jsDelivr Data API first
-          for (const branch of branchesToTry) {
-            try {
-              console.log(`[Explore] Fallback Tier 1: Attempting to list repository files via jsDelivr API (@${branch})...`);
-              const jsdelivrMetaUrl = `https://data.jsdelivr.net/v1/packages/gh/${owner}/${repo}@${branch}`;
-              const metaRes = await fetch(jsdelivrMetaUrl);
-              if (metaRes.ok) {
-                const metaData = await metaRes.json();
-                if (metaData && Array.isArray(metaData.files)) {
-                  filesList = flattenJSDelivrTree(metaData.files);
-                  cdnSuccessBranch = branch;
-                  if (metaData.version) {
-                    latestCommitSha = metaData.version;
-                    console.log(`[Explore] jsDelivr resolved version/commit: ${latestCommitSha}`);
-                  }
-                  console.log(`[Explore] Successfully resolved ${filesList.length} files from jsDelivr API (@${branch}).`);
-                  break;
-                }
-              }
-            } catch (e) {
-              console.warn(`[Explore] Fallback Tier 1 jsDelivr @${branch} failed:`, e);
-            }
-          }
-
-          // TIER 2: Fallback to GitHub REST API
-          if (filesList.length === 0) {
-            console.log("[Explore] Fallback Tier 2: Fetching structure from GitHub REST API...");
-            for (const branch of branchesToTry) {
-              try {
-                console.log(`[Explore] Fallback Tier 2: Fetching structure for branch @${branch} from GitHub REST API...`);
-                const treeResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=true`, { headers: getGithubHeaders() });
-                if (treeResponse.ok) {
-                  const treeData = await treeResponse.json();
-                  if (treeData && Array.isArray(treeData.tree)) {
-                    filesList = treeData.tree
-                      .filter((item: any) => item.type === "blob")
-                      .map((item: any) => item.path);
-                    cdnSuccessBranch = branch;
-                    console.log(`[Explore] Resolved ${filesList.length} files from GitHub REST API for branch @${branch}.`);
-                    break;
-                  }
-                }
-              } catch (e) {
-                console.warn(`[Explore] Fallback Tier 2 GitHub REST API @${branch} failed:`, e);
-              }
-            }
-          }
-
-          if (filesList.length === 0) {
-            throw new Error("Failed to fetch tree from GitHub REST API or jsDelivr API for all branch attempts.");
-          }
-
-          // Filter files matching our source-code pattern
-          const candidatePaths = filesList.filter((path) => 
-            path.match(/\.(js|ts|jsx|tsx|py|c|h|cpp|hpp|cc|cs|go|rs|rb|php|swift|kt|kts|dart)$/) &&
-            !isPathIgnored(path)
-          );
-          
-          if (candidatePaths.length === 0) {
-            throw new Error("No parseable code files found in the repository.");
-          }
-
-          const candidateFiles = candidatePaths.map(p => ({ path: p }));
-          
-          setProgressText(`Found ${candidateFiles.length} code files. Downloading in parallel...`);
-          setProgressValue(15);
-          
-          const BATCH_SIZE = 15;
-          let downloadedCount = 0;
-          
-          for (let i = 0; i < candidateFiles.length; i += BATCH_SIZE) {
-            const batch = candidateFiles.slice(i, i + BATCH_SIZE);
-            
-            await Promise.all(
-              batch.map(async (file: any) => {
-                const fileUrl = `https://cdn.jsdelivr.net/gh/${owner}/${repo}@${cdnSuccessBranch}/${file.path}`;
-                try {
-                  const fileRes = await fetch(fileUrl);
-                  if (!fileRes.ok) throw new Error(`Status ${fileRes.status}`);
-                  const content = await fileRes.text();
-                  files.push({ path: file.path, content });
-                  fileContents[file.path] = content;
-                } catch (err) {
-                  try {
-                    const fallbackUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${cdnSuccessBranch}/${file.path}`;
-                    const fileRes = await fetch(fallbackUrl, { headers: getGithubHeaders() });
-                    if (!fileRes.ok) throw new Error(`Status ${fileRes.status}`);
-                    const content = await fileRes.text();
-                    files.push({ path: file.path, content });
-                    fileContents[file.path] = content;
-                  } catch (e2) {
-                    console.warn(`Failed to fetch file content for ${file.path}:`, err, e2);
-                  }
-                } finally {
-                  downloadedCount++;
-                  const progress = 15 + Math.min(35, Math.floor((downloadedCount / candidateFiles.length) * 35));
-                  setProgressText(`Downloading files (${downloadedCount}/${candidateFiles.length})...`);
-                  setProgressValue(progress);
-                }
-              })
-            );
-          }
-          
-          if (files.length === 0) {
-            throw new Error("Failed to download any code files from the CDN.");
-          }
-          console.log(`[CDN Flow] Successfully downloaded ${files.length} files from CDN branch @${cdnSuccessBranch}.`);
-        }
+        const { files, fileContents, latestCommitSha } = await fetchRepositoryFiles(repoRef, {
+          onProgressText: setProgressText,
+          onProgressValue: setProgressValue,
+          isPathIgnored,
+          fetchWithProgress,
+          fetchWithFallbackProxies,
+        });
 
         // --- COMMON SEMANTIC INDEXING PHASE ---
         setProgressText("Initializing WebAssembly semantic engine...");
@@ -734,7 +389,8 @@ const Explore = () => {
           ...graphData,
           fileContents,
           metadata: {
-            repo: `${owner}/${repo}`,
+            repo: repoRef.fullPath,
+            provider: repoRef.provider,
             version: latestCommitSha ? (latestCommitSha.length === 40 && /^[0-9a-fA-F]+$/.test(latestCommitSha) ? latestCommitSha.substring(0, 7) : latestCommitSha) : "1.0.0",
             commit: latestCommitSha || "",
             exported_at: new Date().toISOString(),
@@ -743,10 +399,9 @@ const Explore = () => {
         };
         setGraphData(finalGraphData);
         
-        // Cache the newly indexed graph data to IndexedDB
         try {
-          await cacheGraph(owner, repo, finalGraphData);
-          console.log(`[Cache] Successfully cached repository graph for ${owner}/${repo} in IndexedDB.`);
+          await cacheGraph(repoRef, finalGraphData);
+          console.log(`[Cache] Successfully cached repository graph for ${repoRef.fullPath} in IndexedDB.`);
         } catch (cacheErr) {
           console.warn("[Cache] Failed to save graph to IndexedDB:", cacheErr);
         }
@@ -760,41 +415,42 @@ const Explore = () => {
     };
 
     autoFetchAndIndex();
-  }, [owner, repo]);
+  }, [repoRef?.fullPath, repoRef?.provider, owner, repo, isGitlabRoute, gitlabSplat]);
 
   // ✅ Automatic Graph Caching: Safely caches all graphs (local folder uploads, ZIPs, CGC bundles) to IndexedDB!
   useEffect(() => {
     if (!graphData) return;
 
     const saveToCache = async () => {
+      let cacheRef = repoRef;
       const metaRepo = graphData.metadata?.repo || "";
-      let cleanOwner = "local";
-      let cleanRepo = metaRepo || "local-project";
 
-      if (metaRepo) {
-        if (metaRepo.includes("/")) {
-          const parts = metaRepo.split("/");
-          cleanOwner = parts[0];
-          cleanRepo = parts[1];
-        } else {
-          cleanOwner = "local";
-          cleanRepo = metaRepo;
-        }
-      } else if (owner && repo) {
-        cleanOwner = owner;
-        cleanRepo = repo;
+      if (!cacheRef && metaRepo.includes("/")) {
+        const parts = metaRepo.split("/").filter(Boolean);
+        const repoName = parts[parts.length - 1];
+        const ownerPath = parts.slice(0, -1).join("/");
+        const provider = graphData.metadata?.provider === "gitlab" ? "gitlab" : "github";
+        cacheRef = {
+          provider,
+          owner: ownerPath,
+          repo: repoName,
+          fullPath: metaRepo,
+          host: provider === "gitlab" ? "gitlab.com" : "github.com",
+        };
       }
 
+      if (!cacheRef) return;
+
       try {
-        await cacheGraph(cleanOwner, cleanRepo, graphData);
-        console.log(`[Cache] Automatically cached active graph for ${cleanOwner}/${cleanRepo} in IndexedDB.`);
+        await cacheGraph(cacheRef, graphData);
+        console.log(`[Cache] Automatically cached active graph for ${cacheRef.fullPath} in IndexedDB.`);
       } catch (cacheErr) {
         console.warn("[Cache] Failed to auto-save graph to IndexedDB:", cacheErr);
       }
     };
 
     saveToCache();
-  }, [graphData, owner, repo]);
+  }, [graphData, repoRef]);
 
   // ✅ Supabase Realtime Signaling Tunnel: Bridges ChatGPT Action calls to browser's AST Code Graph!
   useEffect(() => {
@@ -814,9 +470,11 @@ const Explore = () => {
     }
 
     // 3. We segment traffic based on the active repo, or fallback to global channel
-    const activeRepoPath = (owner && repo && owner.toLowerCase() !== "explore") 
-      ? `${owner}/${repo}`.toLowerCase()
-      : "playground";
+    const activeRepoPath = repoRef
+      ? repoRef.fullPath.toLowerCase()
+      : (owner && repo && owner.toLowerCase() !== "explore")
+        ? `${owner}/${repo}`.toLowerCase()
+        : "playground";
       
     const cleanRepoName = activeRepoPath.replace(/\//g, "_");
 
@@ -1262,7 +920,7 @@ const Explore = () => {
   }, [backend, repoPath, cypherQuery]);
 
   if (loading) {
-    const isAutoIndexing = owner && repo && owner.toLowerCase() !== "explore";
+    const isAutoIndexing = !!repoRef;
     return (
       <div className="min-h-screen flex flex-col items-center justify-center bg-black text-center px-6 w-full relative overflow-hidden">
         
@@ -1345,27 +1003,30 @@ const Explore = () => {
           <h1 className="text-sm font-black uppercase tracking-widest mb-3 text-white">Access or Loading Error</h1>
           <p className="text-[10px] font-mono text-gray-500 uppercase tracking-widest max-w-md mb-6 leading-relaxed">{error}</p>
           
-          {(owner && repo) && (
+          {repoRef && (
             <div className="mb-6 p-4 rounded-2xl bg-white/5 border border-white/10 text-left">
               <label className="text-[10px] font-black uppercase tracking-widest text-gray-400 block mb-2">
                 Private Repository? Access Token (PAT)
               </label>
               <input
                 type="password"
-                placeholder="ghp_..."
-                defaultValue={localStorage.getItem('github_pat') || ""}
+                placeholder="PAT — GitHub (ghp_...) or GitLab (glpat-...)"
+                defaultValue={localStorage.getItem(getAuthTokenKey(repoRef)) || ""}
                 onChange={(e) => {
                   const val = e.target.value.trim();
+                  const tokenKey = getAuthTokenKey(repoRef);
                   if (val) {
-                    localStorage.setItem('github_pat', val);
+                    localStorage.setItem(tokenKey, val);
                   } else {
-                    localStorage.removeItem('github_pat');
+                    localStorage.removeItem(tokenKey);
                   }
                 }}
                 className="w-full bg-black border border-white/20 rounded-full px-4 py-2.5 text-[10px] font-mono text-white placeholder-gray-600 focus:outline-none focus:border-white transition-colors uppercase tracking-widest"
               />
               <p className="text-[8px] font-mono text-gray-600 mt-2 leading-normal uppercase tracking-widest">
-                If the repository is private, dynamic auto-indexing requires a GitHub Personal Access Token with read/repo scopes.
+                {repoRef.provider === "gitlab"
+                  ? "Private GitLab repos need a Personal Access Token with read_api scope."
+                  : "Private GitHub repos need a Personal Access Token with read:repo scope."}
               </p>
             </div>
           )}

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -22,6 +22,10 @@
       "destination": "https://codeload.github.com/:owner/:repo/legacy.zip/:branch"
     },
     {
+      "source": "/api/gitlab-zip/:project/:branch",
+      "destination": "/api/gitlab-zip?project=:project&branch=:branch"
+    },
+    {
       "source": "/api/pypi/:path*",
       "destination": "/api/pypi"
     },

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -16,10 +16,38 @@ function localApiServer() {
         if (pathname.startsWith("/api/")) {
           // Exclude already proxied paths
           if (
-            pathname.startsWith("/api/github-zip") || 
+            pathname.startsWith("/api/github-zip") ||
             pathname.startsWith("/api/pypi")
           ) {
             return next();
+          }
+
+          if (pathname.startsWith("/api/gitlab-zip/")) {
+            try {
+              const modulePath = path.resolve(__dirname, "./api/gitlab-zip.ts");
+              const apiModule = await server.ssrLoadModule(modulePath);
+              const handler = apiModule.default || apiModule;
+              req.query = parsedUrl.query;
+              res.status = (code: number) => {
+                res.statusCode = code;
+                return res;
+              };
+              res.json = (data: any) => {
+                if (!res.headersSent) {
+                  res.setHeader("Content-Type", "application/json");
+                }
+                res.end(JSON.stringify(data));
+                return res;
+              };
+              await handler(req, res);
+            } catch (err: any) {
+              console.error("GitLab zip API error:", err);
+              if (!res.headersSent) {
+                res.statusCode = 500;
+                res.end(JSON.stringify({ error: "GitLab zip proxy failed", details: err.message }));
+              }
+            }
+            return;
           }
 
           const apiName = pathname.replace("/api/", "");


### PR DESCRIPTION
Enable browser-side indexing for public GitLab projects alongside GitHub, with provider-aware URL parsing, a unified PAT field, and a server-side zip proxy that avoids GitLab 406 errors from forwarded Sec-Fetch headers.