### PR TITLE
fix: harden parser tests for portable temp files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 
 import pytest
 from pathlib import Path
-import os
-import shutil
 import tempfile
 
 def pytest_addoption(parser):
@@ -48,7 +46,16 @@ def javascript_sample_project(sample_projects_path):
 @pytest.fixture
 def temp_test_dir():
     """Creates a temporary directory for file operations, cleaned up after test."""
-    temp_dir = tempfile.mkdtemp(prefix="cgc_test_unit_")
-    yield Path(temp_dir)
-    shutil.rmtree(temp_dir, ignore_errors=True)
+    with tempfile.TemporaryDirectory(prefix="cgc_test_unit_") as temp_dir:
+        yield Path(temp_dir)
 
+
+@pytest.fixture
+def assert_parser_result():
+    """Fail fast when a parser unexpectedly returns a non-dict payload."""
+    def _assert(result):
+        if not isinstance(result, dict):
+            pytest.fail(f"Expected parser result to be a dict, got {type(result).__name__}: {result!r}")
+        return result
+
+    return _assert

--- a/tests/unit/parsers/test_cpp_enums.py
+++ b/tests/unit/parsers/test_cpp_enums.py
@@ -26,8 +26,9 @@ enum Color { RED, GREEN, BLUE };
 enum class Status { OK = 0, ERROR = 1 };
 """
     f = temp_test_dir / "enums.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     enum_names = [e["name"] for e in result.get("enums", [])]
     assert "Color" in enum_names
@@ -45,8 +46,9 @@ public:
 };
 """
     f = temp_test_dir / "mixed.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     assert any(c["name"] == "Foo" for c in result["classes"])
     assert any(e["name"] == "DataType" for e in result.get("enums", []))

--- a/tests/unit/parsers/test_cpp_parser.py
+++ b/tests/unit/parsers/test_cpp_parser.py
@@ -28,8 +28,9 @@ enum Color { RED, GREEN, BLUE };
 enum class Status { OK = 0, ERROR = 1 };
 """
     f = temp_test_dir / "enums.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     enum_names = [e["name"] for e in result.get("enums", [])]
     assert "Color" in enum_names
@@ -47,8 +48,9 @@ public:
 };
 """
     f = temp_test_dir / "mixed.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     assert any(c["name"] == "Foo" for c in result["classes"])
     assert any(e["name"] == "DataType" for e in result.get("enums", []))
@@ -69,8 +71,9 @@ public:
 };
 """
     f = temp_test_dir / "inherit_single.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     classes = {c["name"]: c for c in result["classes"]}
     assert "Base" in classes
@@ -86,8 +89,9 @@ class B {};
 class C : public A, private B {};
 """
     f = temp_test_dir / "inherit_multi.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     classes = {c["name"]: c for c in result["classes"]}
     assert classes["C"]["bases"] == ["A", "B"]
@@ -99,8 +103,9 @@ class Base {};
 class Derived : virtual public Base {};
 """
     f = temp_test_dir / "inherit_virtual.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     classes = {c["name"]: c for c in result["classes"]}
     assert classes["Derived"]["bases"] == ["Base"]
@@ -114,8 +119,9 @@ class Container {};
 class IntContainer : public Container<int> {};
 """
     f = temp_test_dir / "inherit_template.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     classes = {c["name"]: c for c in result["classes"]}
     # Template args should be stripped for graph matching
@@ -130,8 +136,9 @@ class Base {};
 class Derived : public ns::Base {};
 """
     f = temp_test_dir / "inherit_qualified.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     classes = {c["name"]: c for c in result["classes"]}
     assert len(classes["Derived"]["bases"]) == 1
@@ -156,8 +163,9 @@ void free_function() {
 }
 """
     f = temp_test_dir / "methods.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     func_names = [fn["name"] for fn in result["functions"]]
     assert "execute" in func_names
@@ -182,8 +190,9 @@ void Namespace::Class::method() {
 }
 """
     f = temp_test_dir / "nested_method.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     func_names = [fn["name"] for fn in result["functions"]]
     assert "method" in func_names
@@ -202,8 +211,9 @@ void doWork() {
 }
 """
     f = temp_test_dir / "arrow_calls.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     call_names = [c["name"] for c in result["function_calls"]]
     assert "execute" in call_names
@@ -218,8 +228,9 @@ void doWork() {
 }
 """
     f = temp_test_dir / "scoped_calls.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     call_names = [c["name"] for c in result["function_calls"]]
     assert "move" in call_names
@@ -241,8 +252,9 @@ void MyClass::doWork() {
 }
 """
     f = temp_test_dir / "this_calls.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     call_names = [c["name"] for c in result["function_calls"]]
     assert "execute" in call_names
@@ -260,8 +272,9 @@ void doWork() {
 }
 """
     f = temp_test_dir / "direct_calls.cpp"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     call_names = [c["name"] for c in result["function_calls"]]
     assert "printf" in call_names
@@ -306,8 +319,9 @@ public:
 };
 """
     f = temp_test_dir / "realistic.h"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
     result = cpp_parser.parse(f)
+    assert isinstance(result, dict)
 
     classes = {c["name"]: c for c in result["classes"]}
 

--- a/tests/unit/parsers/test_dart_parser.py
+++ b/tests/unit/parsers/test_dart_parser.py
@@ -42,6 +42,7 @@ void topLevel() {
     path.write_text(source, encoding="utf-8")
 
     result = dart_parser.parse(path)
+    assert isinstance(result, dict)
 
     calls = result["function_calls"]
     assert [call["name"] for call in calls] == ["print", "callMe", "print", "where", "toList"]

--- a/tests/unit/parsers/test_elisp_parser.py
+++ b/tests/unit/parsers/test_elisp_parser.py
@@ -97,7 +97,7 @@ def test_tree_sitter_parser_dispatches_to_elisp_parser():
 
 def test_elisp_queries_capture_mvp_shapes(elisp_parser, temp_test_dir):
     f = temp_test_dir / "sample.el"
-    f.write_text(ELISP_SAMPLE)
+    f.write_text(ELISP_SAMPLE, encoding="utf-8")
     tree = elisp_parser.parser.parse(f.read_bytes())
 
     function_captures = execute_query(
@@ -138,9 +138,10 @@ def test_elisp_queries_capture_mvp_shapes(elisp_parser, temp_test_dir):
 
 def test_parse_elisp_normalized_output(elisp_parser, temp_test_dir):
     f = temp_test_dir / "sample.el"
-    f.write_text(ELISP_SAMPLE)
+    f.write_text(ELISP_SAMPLE, encoding="utf-8")
 
     result = elisp_parser.parse(f, index_source=True)
+    assert isinstance(result, dict)
 
     assert result["lang"] == "elisp"
     assert result["classes"] == []
@@ -189,14 +190,14 @@ def test_pre_scan_elisp_indexes_definitions_and_provided_features(
 ):
     core = temp_test_dir / "foo-core.el"
     core.write_text("""
-(defvar foo-core-count 0)
+(defvar foo-core-count 0, encoding="utf-8")
 (defun foo-core-helper (name) (message "%s" name))
 (defmacro foo-core-with-helper (&rest body) `(progn ,@body))
 (provide 'foo-core)
 """)
     ui = temp_test_dir / "foo-ui.el"
     ui.write_text("""
-(require 'foo-core)
+(require 'foo-core, encoding="utf-8")
 (defun foo-ui-render (name) (foo-core-helper name))
 (provide 'foo-ui)
 """)

--- a/tests/unit/parsers/test_elixir_parser.py
+++ b/tests/unit/parsers/test_elixir_parser.py
@@ -34,9 +34,10 @@ defprotocol MyApp.Serializable do
 end
 """
     f = temp_test_dir / "sample.ex"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     result = elixir_parser.parse(f)
+    assert isinstance(result, dict)
 
     modules = result.get("modules", [])
     assert len(modules) == 2
@@ -63,9 +64,10 @@ defmodule MyApp.Server do
 end
 """
     f = temp_test_dir / "funcs.ex"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     result = elixir_parser.parse(f)
+    assert isinstance(result, dict)
 
     functions = result["functions"]
     assert len(functions) == 3
@@ -93,9 +95,10 @@ defmodule MyApp.Worker do
 end
 """
     f = temp_test_dir / "imports.ex"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     result = elixir_parser.parse(f)
+    assert isinstance(result, dict)
 
     imports = result["imports"]
     assert len(imports) == 4
@@ -120,9 +123,10 @@ defmodule MyApp.Worker do
 end
 """
     f = temp_test_dir / "calls.ex"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     result = elixir_parser.parse(f)
+    assert isinstance(result, dict)
 
     calls = result["function_calls"]
     dot_calls = [c for c in calls if "." in c["full_name"]]
@@ -137,9 +141,10 @@ defmodule MyApp do
 end
 """
     f = temp_test_dir / "no_classes.ex"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     result = elixir_parser.parse(f)
+    assert isinstance(result, dict)
     assert result["classes"] == []
 
 
@@ -156,7 +161,7 @@ defmodule MyApp.Scanner do
 end
 """
     f = temp_test_dir / "scanner.ex"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     manager = get_tree_sitter_manager()
     wrapper = MagicMock()

--- a/tests/unit/parsers/test_java_package_qualified_names.py
+++ b/tests/unit/parsers/test_java_package_qualified_names.py
@@ -41,7 +41,9 @@ def _write_and_parse(parser, src: str) -> dict:
         f.write(src)
         tmp = f.name
     try:
-        return parser.parse(Path(tmp))
+        result = parser.parse(Path(tmp))
+        assert isinstance(result, dict)
+        return result
     finally:
         os.unlink(tmp)
 

--- a/tests/unit/parsers/test_java_parser.py
+++ b/tests/unit/parsers/test_java_parser.py
@@ -45,7 +45,9 @@ def _write_and_parse(parser, src: str, suffix: str = ".java") -> dict:
         f.write(src)
         tmp = f.name
     try:
-        return parser.parse(Path(tmp))
+        result = parser.parse(Path(tmp))
+        assert isinstance(result, dict)
+        return result
     finally:
         os.unlink(tmp)
 

--- a/tests/unit/parsers/test_kotlin_parser.py
+++ b/tests/unit/parsers/test_kotlin_parser.py
@@ -28,7 +28,9 @@ def _write_and_parse(parser, src: str, suffix: str = ".kt") -> dict:
         f.write(src)
         tmp = f.name
     try:
-        return parser.parse(Path(tmp))
+        result = parser.parse(Path(tmp))
+        assert isinstance(result, dict)
+        return result
     finally:
         os.unlink(tmp)
 

--- a/tests/unit/parsers/test_lua_parser.py
+++ b/tests/unit/parsers/test_lua_parser.py
@@ -50,9 +50,10 @@ function M:method(value)
 end
 """
     f = temp_test_dir / "sample.lua"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     result = lua_parser.parse(f)
+    assert isinstance(result, dict)
 
     assert result["lang"] == "lua"
 
@@ -84,7 +85,7 @@ function M.run()
 end
 """
     f = temp_test_dir / "scanner.lua"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     manager = get_tree_sitter_manager()
     wrapper = MagicMock()

--- a/tests/unit/parsers/test_python_parser.py
+++ b/tests/unit/parsers/test_python_parser.py
@@ -29,10 +29,11 @@ class TestPythonParser:
         """Parse a simple python file and verify output."""
         code = "def hello():\n    print('world')"
         f = temp_test_dir / "test.py"
-        f.write_text(code)
+        f.write_text(code, encoding="utf-8")
 
         # Act
         result = parser.parse(str(f))
+        assert isinstance(result, dict)
 
         # Assert
         # We expect a list of nodes/edges or a structure containing them
@@ -50,9 +51,10 @@ class TestPythonParser:
         """Top-level executable calls should be linked from a synthetic module frame."""
         code = "from pkg.utils import helper\n\nresult = helper()\n"
         f = temp_test_dir / "__main__.py"
-        f.write_text(code)
+        f.write_text(code, encoding="utf-8")
 
         result = parser.parse(str(f))
+        assert isinstance(result, dict)
 
         module_func = next(
             func for func in result["functions"]
@@ -75,9 +77,10 @@ class Greeter:
         return f"Hello {name}"
 """
         f = temp_test_dir / "classes.py"
-        f.write_text(code)
+        f.write_text(code, encoding="utf-8")
 
         result = parser.parse(str(f))
+        assert isinstance(result, dict)
 
         assert "classes" in result
         classes = result["classes"]

--- a/tests/unit/parsers/test_swift_parser.py
+++ b/tests/unit/parsers/test_swift_parser.py
@@ -52,9 +52,10 @@ class GenericController {
 }
 """
     f = temp_test_dir / "sample.swift"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     result = swift_parser.parse(f)
+    assert isinstance(result, dict)
 
     assert len(result["functions"]) >= 4
     assert any(item["name"] == "MetricTracker" for item in result["structs"])
@@ -90,9 +91,10 @@ enum Direction: String, Drawable {
 }
 """
     f = temp_test_dir / "inheritance_sample.swift"
-    f.write_text(code)
+    f.write_text(code, encoding="utf-8")
 
     result = swift_parser.parse(f)
+    assert isinstance(result, dict)
 
     classes_by_name = {item["name"]: item for item in result["classes"]}
     structs_by_name = {item["name"]: item for item in result["structs"]}


### PR DESCRIPTION
Closes #1202

Harden the parser test suite for portability by using TemporaryDirectory cleanup, explicit UTF-8 writes, and fast-fail parser-result validation in the parser helpers and test cases.