### PR TITLE
validate setup wizard credentials before saving

### DIFF
--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -54,6 +54,37 @@ def _save_neo4j_credentials(creds):
     console.print("[dim]  cgc mcp setup[/dim]")
 
 
+def _validate_neo4j_credentials(creds):
+    """Validate Neo4j credentials and test the connection."""
+    is_valid, validation_error = DatabaseManager.validate_config(
+        creds.get("uri", ""),
+        creds.get("username", ""),
+        creds.get("password", ""),
+    )
+
+    if not is_valid:
+        console.print(validation_error)
+        console.print("\n[red]❌ Invalid configuration. Please try again.[/red]\n")
+        return False
+
+    console.print("[green]✅ Configuration format is valid[/green]")
+    console.print("\n[cyan]🔗 Testing connection...[/cyan]")
+
+    is_connected, error_msg = DatabaseManager.test_connection(
+        creds.get("uri", ""),
+        creds.get("username", ""),
+        creds.get("password", ""),
+    )
+
+    if not is_connected:
+        console.print(error_msg)
+        console.print("\n[red]❌ Connection test failed.[/red]\n")
+        return False
+
+    console.print("[green]✅ Connection successful![/green]")
+    return True
+
+
 def _generate_mcp_json(creds):
     """Generates and prints the MCP JSON configuration."""
     cgc_path = shutil.which("cgc")
@@ -668,6 +699,19 @@ def setup_existing_db():
                 console.print(f"[red]❌ Failed to parse credentials file: {e}[/red]")
                 return
 
+        if creds and not _validate_neo4j_credentials(creds):
+            retry = prompt([
+                {
+                    "type": "confirm",
+                    "message": "Connection failed. Would you like to re-enter the details instead of saving these credentials?",
+                    "name": "retry",
+                    "default": True,
+                }
+            ])
+            if retry.get("retry"):
+                return setup_existing_db()
+            console.print("[yellow]Proceeding with the provided credentials anyway.[/yellow]")
+
     elif cred_method: # Manual entry
         console.print("Please enter your Neo4j connection details.")
         
@@ -683,38 +727,12 @@ def setup_existing_db():
             if not manual_creds: 
                 return # User cancelled
             
-            # Validate the user input
-            console.print("\n[cyan]🔍 Validating configuration...[/cyan]")
-            from codegraphcontext.core.database import DatabaseManager
-            is_valid, validation_error = DatabaseManager.validate_config(
-                manual_creds.get("uri", ""),
-                manual_creds.get("username", ""),
-                manual_creds.get("password", "")
-            )
-            
-            if not is_valid:
-                console.print(validation_error)
-                console.print("\n[red]❌ Invalid configuration. Please try again.[/red]\n")
-                continue  # Ask for input again
-            
-            console.print("[green]✅ Configuration format is valid[/green]")
-            
-            # Test the connection
-            console.print("\n[cyan]🔗 Testing connection...[/cyan]")
-            is_connected, error_msg = DatabaseManager.test_connection(
-                manual_creds.get("uri", ""),
-                manual_creds.get("username", ""),
-                manual_creds.get("password", "")
-            )
-            
-            if not is_connected:
-                console.print(error_msg)
+            if not _validate_neo4j_credentials(manual_creds):
                 retry = prompt([{"type": "confirm", "message": "Connection failed. Try again with different credentials?", "name": "retry", "default": True}])
                 if not retry.get("retry"):
                     return
                 continue  # Ask for input again
-            
-            console.print("[green]✅ Connection successful![/green]")
+
             creds = manual_creds
             break  # Exit loop with valid credentials
 
@@ -787,6 +805,19 @@ def setup_hosted_db():
                 console.print(f"[red]❌ Failed to parse credentials file: {e}[/red]")
                 return
 
+        if creds and not _validate_neo4j_credentials(creds):
+            retry = prompt([
+                {
+                    "type": "confirm",
+                    "message": "Connection failed. Would you like to re-enter the details instead of saving these credentials?",
+                    "name": "retry",
+                    "default": True,
+                }
+            ])
+            if retry.get("retry"):
+                return setup_hosted_db()
+            console.print("[yellow]Proceeding with the provided credentials anyway.[/yellow]")
+
     elif cred_method: # Manual entry
         console.print("Please enter your remote Neo4j connection details.")
         
@@ -802,38 +833,12 @@ def setup_hosted_db():
             if not manual_creds:
                 return # User cancelled
             
-            # Validate the user input
-            console.print("\n[cyan]🔍 Validating configuration...[/cyan]")
-            from codegraphcontext.core.database import DatabaseManager
-            is_valid, validation_error = DatabaseManager.validate_config(
-                manual_creds.get("uri", ""),
-                manual_creds.get("username", ""),
-                manual_creds.get("password", "")
-            )
-            
-            if not is_valid:
-                console.print(validation_error)
-                console.print("\n[red]❌ Invalid configuration. Please try again.[/red]\n")
-                continue  # Ask for input again
-            
-            console.print("[green]✅ Configuration format is valid[/green]")
-            
-            # Test the connection
-            console.print("\n[cyan]🔗 Testing connection...[/cyan]")
-            is_connected, error_msg = DatabaseManager.test_connection(
-                manual_creds.get("uri", ""),
-                manual_creds.get("username", ""),
-                manual_creds.get("password", "")
-            )
-            
-            if not is_connected:
-                console.print(error_msg)
+            if not _validate_neo4j_credentials(manual_creds):
                 retry = prompt([{"type": "confirm", "message": "Connection failed. Try again with different credentials?", "name": "retry", "default": True}])
                 if not retry.get("retry"):
                     return
                 continue  # Ask for input again
-            
-            console.print("[green]✅ Connection successful![/green]")
+
             creds = manual_creds
             break  
 

--- a/tests/unit/cli/test_setup_wizard_credentials.py
+++ b/tests/unit/cli/test_setup_wizard_credentials.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+inquirerpy_stub = types.ModuleType("InquirerPy")
+inquirerpy_stub.prompt = lambda *args, **kwargs: {}
+sys.modules.setdefault("InquirerPy", inquirerpy_stub)
+
+neo4j_stub = types.ModuleType("neo4j")
+
+
+class _DummyDriver:
+    def session(self, **_kwargs):  # pragma: no cover - import stub only
+        raise RuntimeError("neo4j driver stub should not be used in tests")
+
+
+class _DummyGraphDatabase:
+    @staticmethod
+    def driver(*_args, **_kwargs):  # pragma: no cover - import stub only
+        return _DummyDriver()
+
+
+neo4j_stub.GraphDatabase = _DummyGraphDatabase
+neo4j_stub.Driver = _DummyDriver
+sys.modules.setdefault("neo4j", neo4j_stub)
+
+from codegraphcontext.cli import setup_wizard
+
+
+def _make_neo4j_creds_file(tmp_path: Path) -> Path:
+    creds_file = tmp_path / "neo4j-creds.txt"
+    creds_file.write_text(
+        "NEO4J_URI=bolt://localhost:7687\n"
+        "NEO4J_USERNAME=neo4j\n"
+        "NEO4J_PASSWORD=supersecret\n",
+        encoding="utf-8",
+    )
+    return creds_file
+
+
+@pytest.mark.parametrize("entrypoint", ["setup_existing_db", "setup_hosted_db"])
+def test_file_credentials_can_proceed_after_failed_validation(tmp_path, monkeypatch, entrypoint):
+    creds_file = _make_neo4j_creds_file(tmp_path)
+    save_mock = MagicMock()
+    prompt_mock = MagicMock(
+        side_effect=[
+            {"cred_method": "Add credentials from file"},
+            {"use_latest": True},
+            {"retry": False},
+        ]
+    )
+
+    monkeypatch.setattr(setup_wizard, "prompt", prompt_mock)
+    monkeypatch.setattr(setup_wizard, "find_latest_neo4j_creds_file", lambda: creds_file)
+    monkeypatch.setattr(setup_wizard.DatabaseManager, "validate_config", lambda *args, **kwargs: (True, None))
+    monkeypatch.setattr(setup_wizard.DatabaseManager, "test_connection", lambda *args, **kwargs: (False, "Connection failed"))
+    monkeypatch.setattr(setup_wizard, "_save_neo4j_credentials", save_mock)
+    monkeypatch.setattr(setup_wizard, "console", MagicMock())
+
+    getattr(setup_wizard, entrypoint)()
+
+    save_mock.assert_called_once_with(
+        {
+            "uri": "bolt://localhost:7687",
+            "username": "neo4j",
+            "password": "supersecret",
+        }
+    )
+    assert prompt_mock.call_count == 3
+
+
+@pytest.mark.parametrize("entrypoint", ["setup_existing_db", "setup_hosted_db"])
+def test_file_credentials_retry_reopens_wizard(tmp_path, monkeypatch, entrypoint):
+    creds_file = _make_neo4j_creds_file(tmp_path)
+    save_mock = MagicMock()
+    prompt_mock = MagicMock(
+        side_effect=[
+            {"cred_method": "Add credentials from file"},
+            {"use_latest": True},
+            {"retry": True},
+        ]
+    )
+
+    monkeypatch.setattr(setup_wizard, "prompt", prompt_mock)
+    monkeypatch.setattr(setup_wizard, "find_latest_neo4j_creds_file", lambda: creds_file)
+    monkeypatch.setattr(setup_wizard.DatabaseManager, "validate_config", lambda *args, **kwargs: (True, None))
+    monkeypatch.setattr(setup_wizard.DatabaseManager, "test_connection", lambda *args, **kwargs: (False, "Connection failed"))
+    monkeypatch.setattr(setup_wizard, "_save_neo4j_credentials", save_mock)
+    monkeypatch.setattr(setup_wizard, "console", MagicMock())
+
+    original_entrypoint = getattr(setup_wizard, entrypoint)
+    reopen_mock = MagicMock(return_value="re-entered")
+    monkeypatch.setattr(setup_wizard, entrypoint, reopen_mock)
+
+    result = original_entrypoint()
+
+    assert result == "re-entered"
+    reopen_mock.assert_called_once()
+    save_mock.assert_not_called()
+    assert prompt_mock.call_count == 3


### PR DESCRIPTION
## What changed
- Added a shared Neo4j credential validator in the setup wizard
- Validated credentials parsed from credential files before saving them
- Added retry/proceed prompts so users can re-enter details or continue anyway after a failed connection check
- Reused the same validation flow for manual setup entry points
- Added focused tests for the file-based setup flow

## Why
The setup wizard could previously save credential files without checking whether the endpoint was valid. That meant users could finish setup successfully and only discover the problem later when starting MCP.

## Validation
- `git diff --check`
- `PYTHONPATH=src python3 -m pytest tests/unit/cli/test_setup_wizard_credentials.py`
- `python3 -m py_compile src/codegraphcontext/cli/setup_wizard.py tests/unit/cli/test_setup_wizard_credentials.py`

Closes #1059
