### PR TITLE
fix: purge orphan parameter and variable nodes on repo delete

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -1896,7 +1896,7 @@ DETACH DELETE r, n
         return True
 
     def _purge_dangling_pathless_nodes(self) -> None:
-        """Remove shared pathless nodes (e.g. imported Module headers) left without references."""
+        """Remove shared pathless or orphaned nodes left without references."""
         dangling_queries = [
             (
                 "MATCH (m:Module) WHERE NOT ()-[:IMPORTS|INCLUDES]->(m) "
@@ -1910,7 +1910,16 @@ DETACH DELETE r, n
                 "MATCH (n:ExternalFunction) WHERE NOT ()-[]->(n) "
                 "WITH n LIMIT 5000 DETACH DELETE n RETURN count(n) AS deleted"
             ),
+            (
+                "MATCH (p:Parameter) WHERE NOT ()-[]-(p) "
+                "WITH p LIMIT 5000 DETACH DELETE p RETURN count(p) AS deleted"
+            ),
+            (
+                "MATCH (v:Variable) WHERE NOT ()-[]-(v) "
+                "WITH v LIMIT 5000 DETACH DELETE v RETURN count(v) AS deleted"
+            ),
         ]
+
         for query in dangling_queries:
             try:
                 while True:
@@ -1919,7 +1928,7 @@ DETACH DELETE r, n
                         deleted = result["deleted"] if result else 0
                     if deleted == 0:
                         break
-                    info_logger(f"[DELETE] Purged {deleted} dangling pathless nodes")
+                    info_logger("[DELETE] Purged dangling pathless or orphan nodes")
             except Exception as e:
                 if _is_binder_exception(e):
                     continue

--- a/tests/unit/tools/test_graph_builder_perf_fixes.py
+++ b/tests/unit/tools/test_graph_builder_perf_fixes.py
@@ -836,6 +836,22 @@ class TestDeleteRepositoryFromGraph:
             "`CALL db.labels()`, including labels not in any hardcoded list."
         )
 
+    def test_purges_dangling_parameters_and_variables(self):
+        """Orphan Parameter and Variable nodes should be removed after repo delete."""
+        session = self._make_repo_exists_session()
+        gb, _ = _make_graph_builder(session)
+        gb.delete_repository_from_graph("/my/repo")
+
+        queries = [c["query"] for c in session.calls]
+        assert any(
+            "Parameter" in q and "NOT ()-[]-(p)" in q and "DETACH DELETE p" in q
+            for q in queries
+        ), "Expected dangling Parameter purge after repository deletion"
+        assert any(
+            "Variable" in q and "NOT ()-[]-(v)" in q and "DETACH DELETE v" in q
+            for q in queries
+        ), "Expected dangling Variable purge after repository deletion"
+
     def test_calls_db_labels_after_existence_check(self):
         """Label discovery should happen exactly once, after the repo
         existence check passes, before any per-label deletion loops."""


### PR DESCRIPTION
Closes #1209

### What changed
- Add an orphan cleanup pass after repository deletion
- Purge dangling `Parameter` and `Variable` nodes that no longer have any relationships
- Add a regression test covering the new purge queries

### Validation
- `PYTHONPATH=src python3 -m pytest tests/unit/tools/test_graph_builder_perf_fixes.py -k 'delete_repository or dangling'`
- `python3 -m py_compile src/codegraphcontext/tools/indexing/persistence/writer.py tests/unit/tools/test_graph_builder_perf_fixes.py`