### PR TITLE
fix: stop pip install button from drifting on hover

### DIFF
--- a/website/src/components/HeroSection.tsx
+++ b/website/src/components/HeroSection.tsx
@@ -374,13 +374,13 @@ const HeroSection = () => {
         </p>
 
         <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto items-center justify-center mb-24">
-          <MagneticButton 
+          <Button
             className="bg-purple-600 hover:bg-purple-500 shadow-[0_0_20px_rgba(168,85,247,0.4)] text-white hover:opacity-90 transition-all duration-300 cursor-pointer w-full sm:w-[320px] h-14 flex items-center justify-center font-bold text-sm tracking-wide rounded-full uppercase border-0"
             onClick={handleCopy}
           >
             {copied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
             pip install codegraphcontext
-          </MagneticButton>
+          </Button>
 
           <Button asChild className="bg-cyan-400 hover:bg-cyan-300 text-black shadow-[0_0_20px_rgba(34,211,238,0.4)] border-0 transition-colors w-full sm:w-auto h-14 rounded-full font-bold uppercase tracking-widest text-xs px-8">
             <a href="https://github.com/CodeGraphContext/CodeGraphContext" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Closes #1190

### What changed
- Replaced the magnetic wrapper with a standard button for the hero copy action
- Preserved the rest of the hero styling and click-to-copy behavior

### Validation
- `git diff --check`
- `npm run build` in `website/`