### PR TITLE
docs: add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+CodeGraphContext is committed to providing a welcoming, respectful, and inclusive environment for contributors, maintainers, and users.
+
+## Expected Behavior
+
+- Be kind, constructive, and collaborative.
+- Respect different viewpoints, skill levels, and experiences.
+- Focus feedback on ideas and implementation, not people.
+- Keep communication clear and professional.
+
+## Unacceptable Behavior
+
+- Harassment, discrimination, or personal attacks.
+- Offensive, demeaning, or exclusionary language.
+- Trolling, spam, or intentionally disruptive behavior.
+- Sharing private information without permission.
+
+## Reporting Issues
+
+If you experience or witness behavior that violates this code of conduct, please contact the project maintainer:
+
+- GitHub: [@Shashankss1205](https://github.com/Shashankss1205)
+- Email: [shashankshekharsingh1205@gmail.com](mailto:shashankshekharsingh1205@gmail.com)
+
+Reports will be handled respectfully and confidentially.
+
+## Scope
+
+This code of conduct applies to all project spaces, including GitHub issues, pull requests, discussions, and related community channels.


### PR DESCRIPTION
Closes #1184

### What changed
- Added a repository-level CODE_OF_CONDUCT.md
- Included expected behavior, unacceptable behavior, reporting, and scope sections

### Validation
- `git diff --check`