### PR TITLE
feat(server): implement prompt text truncation safety

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -75,6 +75,10 @@ DEFAULT_CONFIG = {
     "SKIP_EXTERNAL_RESOLUTION": "false",
     # 0 = unlimited; any positive integer caps MCP tool response size.
     "MAX_TOOL_RESPONSE_TOKENS": "0",
+    # 0 = unlimited; any positive integer caps response size in raw characters.
+    # When both MAX_TOOL_RESPONSE_TOKENS and MAX_PROMPT_CHARS are set, the
+    # stricter (smaller) effective character budget wins.
+    "MAX_PROMPT_CHARS": "0",
     # JSON object mapping tool names to integer result-count limits.
     # Example: {"find_code": 20, "analyze_code_relationships": 10, "find_dead_code": 30}
     "TOOL_RESULT_LIMITS": "{}",
@@ -115,6 +119,7 @@ CONFIG_DESCRIPTIONS = {
     "SCIP_LANGUAGES": "Comma-separated languages to index via SCIP when SCIP_INDEXER=true (python,typescript,javascript,go,rust,java,dart,cpp,c,csharp)",
     "SKIP_EXTERNAL_RESOLUTION": "Skip resolution attempts for external library method calls (recommended for enterprise large Java/Spring codebases)",
     "MAX_TOOL_RESPONSE_TOKENS": "Maximum tokens per MCP tool response (0 = unlimited). Truncates oversized payloads and appends a notice.",
+    "MAX_PROMPT_CHARS": "Maximum characters per MCP tool response (0 = unlimited). When set alongside MAX_TOOL_RESPONSE_TOKENS the stricter limit wins. Truncated payloads receive a visible [CGC] notice and a stdout warning is emitted.",
     "TOOL_RESULT_LIMITS": "JSON object mapping tool names to max result counts, e.g. {\"find_code\": 20, \"analyze_code_relationships\": 10}. Missing keys use built-in defaults.",
     # Post-indexing resolution phases
     "ENABLE_INHERIT_RESOLVE": (
@@ -479,6 +484,14 @@ def validate_config_value(key: str, value: str) -> tuple[bool, Optional[str]]:
                 return False, "MAX_TOOL_RESPONSE_TOKENS must be 0 (unlimited) or a positive integer"
         except ValueError:
             return False, "MAX_TOOL_RESPONSE_TOKENS must be an integer (0 = unlimited)"
+
+    if key == "MAX_PROMPT_CHARS":
+        try:
+            limit = int(value)
+            if limit < 0:
+                return False, "MAX_PROMPT_CHARS must be 0 (unlimited) or a positive integer"
+        except ValueError:
+            return False, "MAX_PROMPT_CHARS must be an integer (0 = unlimited)"
 
     if key == "TOOL_RESULT_LIMITS":
         import json as _json

--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -91,33 +91,74 @@ def _strip_workspace_prefix(obj):
 _CHARS_PER_TOKEN = 4
 
 
-def _apply_response_token_limit(tool_name: str, text: str) -> str:
-    """Truncate *text* to the configured token budget and append a notice.
+def _effective_char_limit(max_tokens: int, max_chars_direct: int) -> int:
+    """Return the effective character budget from both config knobs.
 
-    Reads ``MAX_TOOL_RESPONSE_TOKENS`` from the CGC config at call time so
-    that live config changes are respected without a server restart.
-    Returns *text* unchanged when the limit is 0 (unlimited) or not set.
+    Picks the stricter (smallest) non-zero value.  Returns 0 when both
+    are zero, meaning no limit is active.
+    """
+    candidates = [c for c in (max_tokens * _CHARS_PER_TOKEN, max_chars_direct) if c > 0]
+    return min(candidates) if candidates else 0
+
+
+def _limit_source_label(max_tokens: int, max_chars_direct: int, effective: int) -> str:
+    """Human-readable description of which config key produced *effective*."""
+    token_chars = max_tokens * _CHARS_PER_TOKEN
+    both_active = token_chars > 0 and max_chars_direct > 0
+    if both_active:
+        winner = "MAX_TOOL_RESPONSE_TOKENS" if token_chars <= max_chars_direct else "MAX_PROMPT_CHARS"
+        return f"{winner} ({effective} chars)"
+    if token_chars > 0:
+        return f"MAX_TOOL_RESPONSE_TOKENS ({max_tokens} tokens → {effective} chars)"
+    return f"MAX_PROMPT_CHARS ({effective} chars)"
+
+
+def _apply_response_token_limit(tool_name: str, text: str) -> str:
+    """Truncate *text* to the configured budget and append a visible notice.
+
+    Reads two independent config knobs at call time so live changes are
+    respected without a server restart:
+
+    * ``MAX_TOOL_RESPONSE_TOKENS`` — token-based cap (4 chars/token)
+    * ``MAX_PROMPT_CHARS``         — direct character cap
+
+    The stricter non-zero value wins.  When both are 0 the text is returned
+    unchanged.  A structured warning is printed to stdout whenever truncation
+    fires so operators can trace oversized payloads.
     """
     from .cli.config_manager import get_config_value
 
-    raw = get_config_value("MAX_TOOL_RESPONSE_TOKENS") or "0"
+    raw_tokens = get_config_value("MAX_TOOL_RESPONSE_TOKENS") or "0"
     try:
-        max_tokens = int(raw)
+        max_tokens = int(raw_tokens)
     except ValueError:
         max_tokens = 0
 
-    if max_tokens <= 0:
-        return text  # unlimited
+    raw_chars = get_config_value("MAX_PROMPT_CHARS") or "0"
+    try:
+        max_chars_direct = int(raw_chars)
+    except ValueError:
+        max_chars_direct = 0
 
-    max_chars = max_tokens * _CHARS_PER_TOKEN
-    if len(text) <= max_chars:
+    max_chars = _effective_char_limit(max_tokens, max_chars_direct)
+    if max_chars <= 0 or len(text) <= max_chars:
         return text
 
+    label = _limit_source_label(max_tokens, max_chars_direct, max_chars)
     notice = (
-        f"Response truncated: output exceeded MAX_TOOL_RESPONSE_TOKENS "
-        f"({max_tokens} tokens) for tool '{tool_name}'. "
+        f"[CGC] Response truncated: output exceeded {label} "
+        f"for tool '{tool_name}'. "
         "Increase the limit or narrow your query for full results."
     )
+
+    print(
+        f"[CGC WARNING] Truncation fired | tool={tool_name} | "
+        f"original_chars={len(text)} | truncated_chars={max_chars} | "
+        f"limit={label}",
+        file=sys.stderr,
+        flush=True,
+    )
+
     budget = max(0, max_chars - 200)
     try:
         payload = json.loads(text)

--- a/tests/unit/tools/test_prompt_truncation_safety.py
+++ b/tests/unit/tools/test_prompt_truncation_safety.py
@@ -1,0 +1,269 @@
+"""
+Unit tests for prompt/response truncation safety (issue #1102).
+
+Covers:
+- _effective_char_limit: picking the stricter of token vs char knobs
+- _limit_source_label: correct human-readable label for each case
+- _apply_response_token_limit: full end-to-end truncation behaviour
+    * MAX_PROMPT_CHARS only
+    * MAX_TOOL_RESPONSE_TOKENS only
+    * both set (stricter wins)
+    * both zero (unlimited — no truncation)
+    * payload just at or below the limit (no truncation)
+    * non-JSON payload
+    * stdout warning emitted on truncation
+    * config validation for MAX_PROMPT_CHARS
+"""
+
+import json
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from codegraphcontext.server import (
+    _apply_response_token_limit,
+    _effective_char_limit,
+    _limit_source_label,
+)
+from codegraphcontext.cli.config_manager import validate_config_value
+
+
+# ---------------------------------------------------------------------------
+# _effective_char_limit
+# ---------------------------------------------------------------------------
+
+class TestEffectiveCharLimit:
+    def test_both_zero_returns_zero(self):
+        assert _effective_char_limit(0, 0) == 0
+
+    def test_only_token_limit(self):
+        # 50 tokens × 4 chars/token = 200
+        assert _effective_char_limit(50, 0) == 200
+
+    def test_only_char_limit(self):
+        assert _effective_char_limit(0, 500) == 500
+
+    def test_token_limit_stricter(self):
+        # 50 tokens → 200 chars vs 500 chars direct → 200 wins
+        assert _effective_char_limit(50, 500) == 200
+
+    def test_char_limit_stricter(self):
+        # 200 tokens → 800 chars vs 300 chars direct → 300 wins
+        assert _effective_char_limit(200, 300) == 300
+
+    def test_equal_limits_returns_that_value(self):
+        # 100 tokens → 400 chars, direct also 400 → 400
+        assert _effective_char_limit(100, 400) == 400
+
+
+# ---------------------------------------------------------------------------
+# _limit_source_label
+# ---------------------------------------------------------------------------
+
+class TestLimitSourceLabel:
+    def test_only_token_limit(self):
+        label = _limit_source_label(50, 0, 200)
+        assert "MAX_TOOL_RESPONSE_TOKENS" in label
+        assert "50" in label
+        assert "200" in label
+
+    def test_only_char_limit(self):
+        label = _limit_source_label(0, 500, 500)
+        assert "MAX_PROMPT_CHARS" in label
+        assert "500" in label
+
+    def test_both_token_stricter(self):
+        label = _limit_source_label(50, 500, 200)
+        assert "MAX_TOOL_RESPONSE_TOKENS" in label
+
+    def test_both_char_stricter(self):
+        label = _limit_source_label(200, 100, 100)
+        assert "MAX_PROMPT_CHARS" in label
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _config_map(tokens="0", chars="0"):
+    """Return a get_config_value side_effect that serves fixed values."""
+    mapping = {
+        "MAX_TOOL_RESPONSE_TOKENS": tokens,
+        "MAX_PROMPT_CHARS": chars,
+    }
+    return lambda key: mapping.get(key, "0")
+
+
+def _big_json(size: int = 2000) -> str:
+    """Return a JSON string of at least *size* characters."""
+    payload = {"results": ["x" * 50] * (size // 52 + 1)}
+    return json.dumps(payload, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# _apply_response_token_limit — no truncation cases
+# ---------------------------------------------------------------------------
+
+class TestNoTruncation:
+    def test_both_zero_returns_text_unchanged(self):
+        text = _big_json(2000)
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map()):
+            result = _apply_response_token_limit("find_code", text)
+        assert result == text
+
+    def test_text_exactly_at_limit_not_truncated(self):
+        limit = 500
+        text = "x" * limit
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(chars=str(limit))):
+            result = _apply_response_token_limit("find_code", text)
+        assert result == text
+
+    def test_text_one_char_below_limit_not_truncated(self):
+        limit = 500
+        text = "x" * (limit - 1)
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(chars=str(limit))):
+            result = _apply_response_token_limit("find_code", text)
+        assert result == text
+
+
+# ---------------------------------------------------------------------------
+# _apply_response_token_limit — MAX_PROMPT_CHARS only
+# ---------------------------------------------------------------------------
+
+class TestMaxPromptChars:
+    def test_truncates_oversized_json(self, capsys):
+        text = _big_json(2000)
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(chars="300")):
+            result = _apply_response_token_limit("find_code", text)
+
+        parsed = json.loads(result)
+        assert parsed["truncated"] is True
+        assert "[CGC] Response truncated" in parsed["notice"]
+        assert "MAX_PROMPT_CHARS" in parsed["notice"]
+
+    def test_truncates_non_json_text(self):
+        text = "plain text " * 200
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(chars="200")):
+            result = _apply_response_token_limit("find_code", text)
+
+        parsed = json.loads(result)
+        assert parsed["truncated"] is True
+        assert len(parsed["preview"]) <= 200
+
+    def test_warning_emitted_to_stderr(self, capsys):
+        text = _big_json(2000)
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(chars="300")):
+            _apply_response_token_limit("find_code", text)
+
+        captured = capsys.readouterr()
+        assert "[CGC WARNING] Truncation fired" in captured.err
+        assert "find_code" in captured.err
+        assert "original_chars=" in captured.err
+        assert "truncated_chars=300" in captured.err
+
+    def test_tool_name_in_notice(self):
+        text = _big_json(2000)
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(chars="300")):
+            result = _apply_response_token_limit("analyze_code_relationships", text)
+
+        parsed = json.loads(result)
+        assert "analyze_code_relationships" in parsed["notice"]
+
+
+# ---------------------------------------------------------------------------
+# _apply_response_token_limit — MAX_TOOL_RESPONSE_TOKENS only
+# ---------------------------------------------------------------------------
+
+class TestMaxToolResponseTokens:
+    def test_truncates_by_token_budget(self, capsys):
+        # 50 tokens × 4 = 200 chars; use a 2000-char payload
+        text = _big_json(2000)
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(tokens="50")):
+            result = _apply_response_token_limit("find_code", text)
+
+        parsed = json.loads(result)
+        assert parsed["truncated"] is True
+        assert "MAX_TOOL_RESPONSE_TOKENS" in parsed["notice"]
+
+    def test_warning_mentions_tokens(self, capsys):
+        text = _big_json(2000)
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(tokens="50")):
+            _apply_response_token_limit("find_code", text)
+
+        captured = capsys.readouterr()
+        assert "MAX_TOOL_RESPONSE_TOKENS" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# _apply_response_token_limit — both limits set, stricter wins
+# ---------------------------------------------------------------------------
+
+class TestBothLimitsSet:
+    def test_token_limit_stricter(self, capsys):
+        # 50 tokens → 200 chars; direct limit 500 → token wins
+        text = _big_json(2000)
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(tokens="50", chars="500")):
+            result = _apply_response_token_limit("find_code", text)
+
+        parsed = json.loads(result)
+        assert parsed["truncated"] is True
+        # effective limit is 200 chars
+        captured = capsys.readouterr()
+        assert "truncated_chars=200" in captured.err
+        assert "MAX_TOOL_RESPONSE_TOKENS" in captured.err
+
+    def test_char_limit_stricter(self, capsys):
+        # 200 tokens → 800 chars; direct limit 300 → char wins
+        text = _big_json(2000)
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(tokens="200", chars="300")):
+            result = _apply_response_token_limit("find_code", text)
+
+        parsed = json.loads(result)
+        assert parsed["truncated"] is True
+        captured = capsys.readouterr()
+        assert "truncated_chars=300" in captured.err
+        assert "MAX_PROMPT_CHARS" in captured.err
+
+    def test_no_warning_when_text_fits_stricter_limit(self, capsys):
+        # Both limits larger than the text → no truncation, no warning
+        text = "small text"
+        with patch("codegraphcontext.cli.config_manager.get_config_value", side_effect=_config_map(tokens="1000", chars="1000")):
+            result = _apply_response_token_limit("find_code", text)
+
+        assert result == text
+        captured = capsys.readouterr()
+        assert "[CGC WARNING]" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Config validation — MAX_PROMPT_CHARS
+# ---------------------------------------------------------------------------
+
+class TestMaxPromptCharsValidation:
+    def test_zero_is_valid(self):
+        ok, msg = validate_config_value("MAX_PROMPT_CHARS", "0")
+        assert ok is True
+        assert msg is None
+
+    def test_positive_integer_is_valid(self):
+        ok, msg = validate_config_value("MAX_PROMPT_CHARS", "500")
+        assert ok is True
+
+    def test_large_value_is_valid(self):
+        ok, msg = validate_config_value("MAX_PROMPT_CHARS", "1000000")
+        assert ok is True
+
+    def test_negative_is_invalid(self):
+        ok, msg = validate_config_value("MAX_PROMPT_CHARS", "-1")
+        assert ok is False
+        assert "MAX_PROMPT_CHARS" in msg
+
+    def test_string_is_invalid(self):
+        ok, msg = validate_config_value("MAX_PROMPT_CHARS", "abc")
+        assert ok is False
+        assert "integer" in msg.lower()
+
+    def test_float_string_is_invalid(self):
+        ok, msg = validate_config_value("MAX_PROMPT_CHARS", "3.14")
+        assert ok is False


### PR DESCRIPTION
## Closes #1102

### Summary (program: GSSoC)

Large code graph results can exceed LLM context windows silently. This PR cuts payloads at a configurable limit, appends a visible notice, and logs a warning so nothing fails quietly.

### What's New

- 🔒 **Dual config knobs:** Added `MAX_PROMPT_CHARS` alongside `MAX_TOOL_RESPONSE_TOKENS`. Whichever is stricter wins.
  _**To test:** Set `MAX_PROMPT_CHARS=500` and `MAX_TOOL_RESPONSE_TOKENS=50` in CGC config, run a graph query with large output, and confirm truncation fires._

- ✂️ **Truncation logic:** Updated `_apply_response_token_limit()` to use `_effective_char_limit()` for the budget, cut at a clean JSON boundary, and append a `[CGC] Response truncated` notice to the payload.
  _**To test:** Query a large codebase and look for the `[CGC] Response truncated` notice at the end of the response._

- 📢 **Truncation warnings:** Prints a `[CGC WARNING]` line to stderr on every truncation, with `tool`, `original_chars`, `truncated_chars`, and `limit`. No more silent failures.

- 🧪 **Tests:** Unit tests for `_effective_char_limit`, `_limit_source_label`, and the full `_apply_response_token_limit` flow: both knobs, stricter-wins, unlimited, at-limit, non-JSON, and warning emission.
### Implementation

**Feature Testing (Scenario)** 👇 

https://github.com/user-attachments/assets/b7808160-8847-4ea9-9209-f5ef60792f3a


**Testing Edge Cases** 👇 

<img width="723" height="340" alt="image" src="https://github.com/user-attachments/assets/5bf16f24-a906-4d6e-9bbc-dae39997b200" />

### Files Changed

- `src/codegraphcontext/server.py` (53 additions, 12 deletions): added `_effective_char_limit()` and `_limit_source_label()`; updated `_apply_response_token_limit()` to read both config knobs and emit a stderr warning on truncation.

- `src/codegraphcontext/cli/config_manager.py` (13 additions): registered `MAX_PROMPT_CHARS` with default value, config description, and non-negative integer validation.

- `tests/unit/tools/test_prompt_truncation_safety.py` (269 additions): new test file covering both config knobs, stricter-wins logic, at-limit/below-limit edge cases, non-JSON payloads, stderr warning emission, and `MAX_PROMPT_CHARS` config validation.

- `tests/test_truncation_real_scenario.py` (new): real-scenario integration test mirroring an actual CGC config state with realistic tool response payloads.


### Edge cases covered

- Both knobs at zero → no truncation, text returned unchanged ✅
- Only one knob active → that knob is the limit ✅
- Both knobs active → stricter value wins ✅
- Non-JSON payload → character slice still applies ✅
- Payload at exactly the limit → no truncation fires ✅
- Invalid config value (non-integer) → silently defaults to 0, no crash ✅
