### PR TITLE
fix(config): add default LLM model fallbacks for cloud providers

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -72,6 +72,9 @@ DEFAULT_CONFIG = {
     "CGC_EMBEDDING_BATCH_SIZE": "256",
     # Default fuzzy matching behavior for `cgc find name` (overridable per-command with --fuzzy/--no-fuzzy)
     "FUZZY_SEARCH": "true",
+    # Default LLM model names used for graph queries when no value is explicitly configured
+    "OPENAI_MODEL": "gpt-4o",
+    "ANTHROPIC_MODEL": "claude-3-5-sonnet-20241022",
 }
 
 # Configuration key descriptions
@@ -138,6 +141,16 @@ CONFIG_DESCRIPTIONS = {
         "Enable fuzzy matching by default for `cgc find name` (true|false). "
         "Per-invocation overrides are available via --fuzzy / --no-fuzzy."
     ),
+    "OPENAI_MODEL": (
+        "Default OpenAI model used for graph queries. "
+        "Requires OPENAI_API_KEY environment variable. "
+        "Default: gpt-4o"
+    ),
+    "ANTHROPIC_MODEL": (
+        "Default Anthropic model used for graph queries. "
+        "Requires ANTHROPIC_API_KEY environment variable. "
+        "Default: claude-3-5-sonnet-20241022"
+    ),
 }
 
 # Valid values for each config key
@@ -195,6 +208,25 @@ __pycache__/
 coverage/
 .next/
 """
+
+
+def resolve_model_name(provider: str, configured_value: Optional[str] = None) -> str:
+    """Get the model it should use for an LLM provider.
+
+    If the user configured a model, it uses that. Otherwise, it falls back to the default
+    model for the provider (like OPENAI_MODEL or ANTHROPIC_MODEL).
+
+    Args:
+        provider: The name of the provider, like "openai" or "anthropic" (case-insensitive).
+        configured_value: The model name from the user's config, if they set one.
+
+    Returns:
+        The model name it should use, or an empty string if it doesn't know the provider.
+    """
+    if configured_value and configured_value.strip():
+        return configured_value.strip()
+    key = f"{provider.upper()}_MODEL"
+    return DEFAULT_CONFIG.get(key, "")
 
 
 def normalize_config_path(value: str, *, absolute: bool = False, base_dir: Optional[Path] = None) -> str:

--- a/tests/unit/cli/test_model_defaults.py
+++ b/tests/unit/cli/test_model_defaults.py
@@ -1,0 +1,46 @@
+"""Tests for default LLM model fallbacks and resolve_model_name (issue #1103)
+
+"""
+
+from codegraphcontext.cli.config_manager import DEFAULT_CONFIG, resolve_model_name
+
+
+class TestModelDefaults:
+    def test_openai_model_key_exists_in_defaults(self):
+        assert "OPENAI_MODEL" in DEFAULT_CONFIG
+
+    def test_openai_model_default_value(self):
+        assert DEFAULT_CONFIG["OPENAI_MODEL"] == "gpt-4o"
+
+    def test_anthropic_model_key_exists_in_defaults(self):
+        assert "ANTHROPIC_MODEL" in DEFAULT_CONFIG
+
+    def test_anthropic_model_default_value(self):
+        assert DEFAULT_CONFIG["ANTHROPIC_MODEL"] == "claude-3-5-sonnet-20241022"
+
+
+class TestResolveModelName:
+    def test_returns_configured_value_when_set(self):
+        assert resolve_model_name("openai", "gpt-3.5-turbo") == "gpt-3.5-turbo"
+
+    def test_falls_back_to_default_when_empty_string(self):
+        assert resolve_model_name("openai", "") == "gpt-4o"
+
+    def test_falls_back_to_default_when_none(self):
+        assert resolve_model_name("openai", None) == "gpt-4o"
+
+    def test_anthropic_falls_back_to_default(self):
+        assert resolve_model_name("anthropic", "") == "claude-3-5-sonnet-20241022"
+
+    def test_anthropic_returns_configured_value_when_set(self):
+        assert resolve_model_name("anthropic", "claude-3-haiku-20240307") == "claude-3-haiku-20240307"
+
+    def test_unknown_provider_returns_empty_string(self):
+        assert resolve_model_name("mistral", "") == ""
+
+    def test_strips_surrounding_whitespace(self):
+        assert resolve_model_name("openai", "  gpt-4o  ") == "gpt-4o"
+
+    def test_case_insensitive_provider_name(self):
+        assert resolve_model_name("OpenAI", "") == "gpt-4o"
+        assert resolve_model_name("ANTHROPIC", "") == "claude-3-5-sonnet-20241022"


### PR DESCRIPTION
## closes #1103

### Summary (program: gssoc)

Fixes a crash when `OPENAI_MODEL` or `ANTHROPIC_MODEL` is missing from config. The change adds provider defaults directly to `DEFAULT_CONFIG`, so graph queries have a model to use without any extra setup.

### What's New

- **Default model fallbacks:** Added `OPENAI_MODEL` (`gpt-4o`) and `ANTHROPIC_MODEL` (`claude-3-5-sonnet-20241022`) to `DEFAULT_CONFIG` in `config_manager.py`, so graph queries always have a model to fall back on.
  _To test: Remove `OPENAI_MODEL` or `ANTHROPIC_MODEL` from `~/.codegraphcontext/.env` and run a graph query. It should complete without error._
- **`resolve_model_name` helper:** Added `resolve_model_name(provider, configured_value)`, a function that returns the configured model when set, or the provider default when the value is empty, `None`, or absent.
  _To test: `from codegraphcontext.cli.config_manager import resolve_model_name; resolve_model_name("openai", "")` returns `"gpt-4o"`_
- **Tests:** `tests/unit/cli/test_model_defaults.py` has 12 unit tests covering default values, fallback behavior, whitespace stripping, case-insensitive provider names, and unknown providers.

### Feature Implementation

**Testing Edge Cases** 👇 

https://github.com/user-attachments/assets/dc3e269c-436f-4609-bccd-e2ce563c1b88

<img width="990" height="525" alt="1103-2" src="https://github.com/user-attachments/assets/5b3ba7b6-c4d4-423d-a19c-8f0f7787d733" />
<img width="984" height="530" alt="1103" src="https://github.com/user-attachments/assets/df859e28-a737-4fbf-987c-b391539f4ebc" />

### Files Changed

- `src/codegraphcontext/cli/config_manager.py` - added `OPENAI_MODEL` and `ANTHROPIC_MODEL` to `DEFAULT_CONFIG` and `CONFIG_DESCRIPTIONS`, added `resolve_model_name()` helper
- `tests/unit/cli/test_model_defaults.py` - new file, 12 unit tests

### Edge Cases Covered

- Config value is `None` -> falls back to provider default ✅
- Config value is `""` -> falls back to provider default ✅
- Config value has surrounding whitespace (`"  gpt-4o  "`) -> stripped before returning ✅
- Provider name is mixed-case (`"OpenAI"`, `"ANTHROPIC"`) -> resolved case-insensitively ✅
- Unknown provider (`"mistral"`) -> returns `""`, no crash ✅
- Existing non-empty config value -> returned unchanged ✅

### Type of Change

- [x] Bug fix (non-breaking)
