### PR TITLE
docs: restructure README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,10 @@
-# 🏗️ CodeGraphContext (CGC)
+# CodeGraphContext (CGC)
 
 **Turn code repositories into a queryable graph for AI agents.**
 
-🌐 **Languages:**
-- 🇬🇧 [English](README.md)
-- 🇨🇳 [中文](docs/translations/README.zh-CN.md)
-- 🇰🇷 [한국어](docs/translations/README.kor.md)
-- 🇺🇦 [Українська](docs/translations/README.uk.md)
-- 🇷🇺 [Русский](docs/translations/README.ru-RU.md)
-- 🇯🇵 [日本語](docs/translations/README.ja.md)
-- 🇪🇸 Español (Soon)
-
-🌍 **Help translate CodeGraphContext to your language by raising an issue & PR on [GitHub Issues](https://github.com/Shashankss1205/CodeGraphContext/issues)!**
+CodeGraphContext is an MCP server and CLI toolkit that indexes local code into a graph database. Use it to inspect relationships across a repository, run code-quality queries, generate visualizations, or give AI assistants structured context about your codebase.
 
 <p align="center">
-  <br>
-  <b>Bridge the gap between deep code graphs and AI context.</b>
-  <br><br>
   <a href="https://pypi.org/project/codegraphcontext/">
     <img src="https://img.shields.io/pypi/v/codegraphcontext?style=flat-square&logo=pypi" alt="PyPI Version">
   </a>
@@ -28,9 +16,9 @@
   </a>
   <img src="https://img.shields.io/badge/MCP-Compatible-green?style=flat-square" alt="MCP Compatible">
   <a href="https://discord.gg/VCwUdCnn">
-    <img src="https://img.shields.io/discord/1421769154507309150?label=Discord&logo=discord&logoColor=white&style=flat-square">
+    <img src="https://img.shields.io/discord/1421769154507309150?label=Discord&logo=discord&logoColor=white&style=flat-square" alt="Discord">
   </a>
-  <br><br>
+  <br>
   <a href="https://github.com/CodeGraphContext/CodeGraphContext/stargazers">
     <img src="https://img.shields.io/github/stars/CodeGraphContext/CodeGraphContext?style=flat-square&logo=github" alt="Stars">
   </a>
@@ -46,290 +34,161 @@
   <a href="https://github.com/CodeGraphContext/CodeGraphContext/graphs/contributors">
     <img src="https://img.shields.io/github/contributors/CodeGraphContext/CodeGraphContext?style=flat-square&logo=github" alt="Contributors">
   </a>
-<br><br>
+  <br>
   <a href="https://github.com/CodeGraphContext/CodeGraphContext/actions/workflows/test.yml">
     <img src="https://github.com/CodeGraphContext/CodeGraphContext/actions/workflows/test.yml/badge.svg" alt="Tests">
   </a>
   <a href="https://github.com/CodeGraphContext/CodeGraphContext/actions/workflows/e2e-tests.yml">
     <img src="https://github.com/CodeGraphContext/CodeGraphContext/actions/workflows/e2e-tests.yml/badge.svg" alt="E2E Tests">
   </a>
-  <a href="http://codegraphcontext.vercel.app/">
-    <img src="https://img.shields.io/badge/website-up-brightgreen?style=flat-square" alt="Website">
-  </a>
   <a href="https://codegraphcontext.vercel.app/">
-    <img src="https://img.shields.io/badge/docs-GitHub%20Pages-blue?style=flat-square" alt="Docs">
+    <img src="https://img.shields.io/badge/website-up-brightgreen?style=flat-square" alt="Website">
   </a>
   <a href="https://youtu.be/KYYSdxhg1xU">
     <img src="https://img.shields.io/badge/YouTube-Watch%20Demo-red?style=flat-square&logo=youtube" alt="YouTube Demo">
   </a>
 </p>
 
+## Translations
 
-A powerful **MCP server** and **CLI toolkit** that indexes local code into a graph database to provide context to AI assistants and developers. Use it as a standalone CLI for comprehensive code analysis or connect it to your favorite AI IDE via MCP for AI-powered code understanding.
+- [English](README.md)
+- [Chinese](docs/translations/README.zh-CN.md)
+- [Korean](docs/translations/README.kor.md)
+- [Ukrainian](docs/translations/README.uk.md)
+- [Russian](docs/translations/README.ru-RU.md)
+- [Japanese](docs/translations/README.ja.md)
 
----
+Want to add another language? Open an issue or pull request on [GitHub](https://github.com/CodeGraphContext/CodeGraphContext/issues).
 
-## 📍 Quick Navigation
-* [🚀 Quick Start](#-installation--quick-start) 
-* [📋 Prerequisites](#-prerequisites)
-* [🏃 How to Run the Project Locally](#-how-to-run-the-project-locally)
-* [🌐 Supported Programming Languages](#supported-programming-languages) 
-* [🛠️ CLI Toolkit](#for-cli-toolkit-mode) 
-* [🤖 MCP Server](#-for-mcp-server-mode) 
-* [🗄️ Database Options](#database-options)
-* [🔬 SCIP indexing (optional)](#scip-indexing-optional)
+## Table of Contents
 
----
+- [Overview](#overview)
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Installation](#installation)
+- [Usage](#usage)
+- [MCP Server](#mcp-server)
+- [Configuration](#configuration)
+- [Supported Languages](#supported-languages)
+- [Database Backends](#database-backends)
+- [SCIP Indexing](#scip-indexing)
+- [Contributing](#contributing)
+- [License](#license)
 
-## ✨ Experience CGC
+## Overview
 
+CodeGraphContext builds a code graph from a local repository and exposes it through two main workflows:
 
-### 👨🏻‍💻 Installation and CLI
-> Install in seconds with pip and unlock a powerful CLI for code graph analysis.
-![Install and unlock the CLI instantly](https://github.com/CodeGraphContext/CodeGraphContext/blob/main/images/install&cli.gif)
+- **CLI toolkit**: index repositories, query symbols, analyze relationships, detect dead code, and generate visual graph reports.
+- **MCP server**: connect the same graph context to AI IDEs and assistants so they can answer codebase questions with repository-aware context.
 
-
-### 🛠️ Indexing in Seconds
-> The CLI intelligently parses your tree-sitter nodes to build the graph.
-![Indexing using an MCP client](https://github.com/CodeGraphContext/CodeGraphContext/blob/main/images/Indexing.gif)
-
-### 🤖 Powering your AI Assistant
-> Use natural language to query complex call-chains via MCP.
-![Using the MCP server](https://github.com/CodeGraphContext/CodeGraphContext/blob/main/images/Usecase.gif)
-
----
-
-## Project Details
-- **Version:** 0.5.1
-- **Authors:** Shashank Shekhar Singh <shashankshekharsingh1205@gmail.com>
-- **License:** MIT License (See [LICENSE](LICENSE) for details)
-- **Website:** [CodeGraphContext](http://codegraphcontext.vercel.app/)
-
----
-
-## 👨‍💻 Maintainer
-**CodeGraphContext** is created and actively maintained by:
-
-**Shashank Shekhar Singh**  
-- 📧 Email: [shashankshekharsingh1205@gmail.com](mailto:shashankshekharsingh1205@gmail.com)
-- 🐙 GitHub: [@Shashankss1205](https://github.com/Shashankss1205)
-- 🔗 LinkedIn: [Shashank Shekhar Singh](https://www.linkedin.com/in/shashank-shekhar-singh-a67282228/)
-- 🌐 Website: [codegraphcontext.vercel.app](https://codegraphcontext.vercel.app/)
-
-*Contributions and feedback are always welcome! Feel free to reach out for questions, suggestions, or collaboration opportunities.*
-
----
-
-## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
-
----
+Typical use cases include impact analysis, call-chain exploration, AI-assisted code understanding, onboarding to unfamiliar repositories, and local code-quality checks.
 
 ## Features
--   **Code Indexing:** Analyzes code and builds a knowledge graph of its components.
--   **Relationship Analysis:** Query for callers, callees, class hierarchies, call chains and more.
--   **Pre-indexed Bundles:** Load famous repositories instantly with `.cgc` bundles - no indexing required! ([Learn more](docs/docs/guides/bundles.md))
--   **Live File Watching:** Watch directories for changes and automatically update the graph in real-time (`cgc watch`).
--   **Interactive Setup:** A user-friendly command-line wizard for easy setup.
--   **Dual Mode:** Works as a standalone **CLI toolkit** for developers and as an **MCP server** for AI agents.
--   **Multi-Language Support:** Full support for 23 programming languages.
--   **Flexible Database Backend:** FalkorDB Lite (Default), KuzuDB, LadybugDB, FalkorDB Remote, Nornic DB, or Neo4j (all platforms via Docker/native).
 
+- **Code indexing**: Parse source files and build a searchable graph of functions, classes, methods, imports, calls, parameters, and inheritance.
+- **Relationship analysis**: Query callers, callees, class trees, dependency paths, complexity, and dead code.
+- **MCP integration**: Run an MCP server for VS Code, Cursor, Windsurf, Zed, Claude, Gemini CLI, ChatGPT Codex, Cline, RooCode, Amazon Q Developer, Kiro, Goose, and OpenCode.
+- **Pre-indexed bundles**: Load `.cgc` bundles for known repositories without re-indexing from source.
+- **Live watching**: Keep the graph synchronized with file changes by running `codegraphcontext watch`.
+- **Interactive visualization**: Generate standalone HTML graph views with searchable nodes and relationship panels.
+- **Multi-language support**: Analyze 23 programming languages with Tree-sitter, with optional SCIP support for richer C, C++, and C# indexing.
+- **Flexible storage**: Use FalkorDB Lite, KuzuDB, LadybugDB, FalkorDB Remote, Nornic DB, or Neo4j.
 
----
+## Experience CGC
 
-## Supported Programming Languages
+### Installation and CLI
 
-CodeGraphContext provides comprehensive parsing and analysis for the following languages:
+Install the package and start querying a repository from your terminal.
 
-| | Language | | Language | | Language |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| 🐍 | **Python** | 📜 | **JavaScript** | 🔷 | **TypeScript** |
-| ☕ | **Java** | 🔵 | **C** | ➕ | **C++** |
-| #️⃣ | **C#** | 🐹 | **Go** | 🦀 | **Rust** |
-| 💎 | **Ruby** | 🐘 | **PHP** | 🍎 | **Swift** |
-| 🎨 | **Kotlin** | 🎯 | **Dart** | 🐪 | **Perl** |
-| 🌙 | **Lua** | 🚀 | **Scala** | λ | **Haskell** |
-| 💧 | **Elixir** | 📜 | **Emacs Lisp (elisp)** | 🌐 | **HTML** |
-| 🎨 | **CSS** | ⚛️ | **TSX** | | |
+![Install and unlock the CLI instantly](https://github.com/CodeGraphContext/CodeGraphContext/blob/main/images/install&cli.gif)
 
-Each language parser extracts functions, classes, methods, parameters, inheritance relationships, function calls, and imports to build a comprehensive code graph.
+### Indexing in Seconds
 
----
+Build a code graph from a local repository.
 
-## Database Options
+![Indexing using an MCP client](https://github.com/CodeGraphContext/CodeGraphContext/blob/main/images/Indexing.gif)
 
-CodeGraphContext supports multiple graph database backends to suit your environment:
+### Powering Your AI Assistant
 
-| Feature | KuzuDB | LadybugDB | FalkorDB Lite | Neo4j / Nornic DB |
-| :--- | :--- | :--- | :--- | :--- |
-| **Typical default** | Cross-platform fallback when FalkorDB Lite is unavailable | Optional embedded backend | **Default on Unix** (Python 3.12+, when `falkordblite` is installed) | When explicitly configured via `cgc config db` |
-| **Setup** | Zero-config / Embedded | Zero-config / Embedded | Zero-config / In-process | Docker / External |
-| **Platform** | **All (Windows Native, macOS, Linux)** | **All (Windows Native, macOS, Linux)** | Unix-only (Linux/macOS/WSL) | All Platforms |
-| **Use Case** | Desktop, IDE, Local development | Custom research projects | Specialized Unix development | Enterprise, Massive graphs |
-| **Requirement**| `pip install kuzu` | `pip install ladybug` | `pip install falkordblite` | Neo4j Server / Docker / Nornic Cloud |
-| **Speed** | ⚡ Extremely Fast | ⚡ Fast | 🚀 Scalable |
-| **Persistence**| Yes (to disk) | Yes (to disk) | Yes (to disk) |
+Use natural language through an MCP client to inspect code relationships.
 
----
+![Using the MCP server](https://github.com/CodeGraphContext/CodeGraphContext/blob/main/images/Usecase.gif)
 
-## SCIP indexing (optional)
+## Tech Stack
 
-When `SCIP_INDEXER=true` in your CGC config (`~/.codegraphcontext/.env`), some languages use external **SCIP** indexers for more accurate calls and inheritance than Tree-sitter heuristics alone.
+| Area | Technology |
+| --- | --- |
+| Runtime | Python 3.10-3.14 |
+| CLI | Typer, Rich, InquirerPy |
+| Parsing | Tree-sitter, tree-sitter-language-pack, optional SCIP indexers |
+| MCP and API | MCP, FastAPI, Uvicorn |
+| Graph backends | FalkorDB Lite, KuzuDB, LadybugDB, FalkorDB Remote, Nornic DB, Neo4j |
+| Packaging | PyPI package with `codegraphcontext` and `cgc` console scripts |
 
-**C and C++** use **scip-clang**, which requires a **`compile_commands.json`** file (a [JSON compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html)): one entry per translation unit with the real compiler command (include paths, `-D` defines, `-std`, etc.). Without it, scip-clang cannot run; CGC logs a warning and **falls back to Tree-sitter** for that repo. Typical ways to produce the file: **CMake** with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, or wrap your real build with **[Bear](https://github.com/rizsotto/Bear)** (e.g. `bear -- make`). CGC also looks under `build/` and `cmake-build-*/` for that filename.
+## Installation
 
-**C#** uses **scip-dotnet** (Roslyn); you need a normal **`.csproj` / `.sln`** and a successful restore—no `compile_commands.json`.
+### Prerequisites
 
-SCIP is **independent of which graph database** you use (Kuzu, Neo4j, etc.); the same flag applies to all backends.
+- Python 3.10 or later
+- `pip`
+- Git, if you want to clone repositories before indexing them
 
----
-
-## Used By
-
-CodeGraphContext is already being explored by developers and projects for:
-
-- **Static code analysis in AI assistants**
-- **Graph-based visualization of projects**
-- **Dead code and complexity detection**
-
-_If you’re using CodeGraphContext in your project, feel free to open a PR and add it here! 🚀_
-
----
-
-## Dependencies
-
-- `neo4j>=5.15.0`
-- `watchdog>=3.0.0`
-- `stdlibs>=2023.11.18`
-- `typer>=0.9.0`
-- `rich>=13.7.0`
-- `inquirerpy>=0.3.4`
-- `python-dotenv>=1.0.0`
-- `tree-sitter>=0.21.0` (not installed on Python 3.13)
-- `tree-sitter-language-pack>=0.6.0` (not installed on Python 3.13)
-- `pyyaml`
-- `pathspec>=0.12.1`
-- `falkordb>=1.0,<1.6`
-- `falkordblite>=0.7,<0.10` (Unix only, Python 3.12+)
-- `kuzu` (KuzuDB engine)
-- `fastapi>=0.100.0`
-- `uvicorn>=0.22.0`
-- `requests>=2.28.0`
-- `protobuf>=3.20,<3.21`
-
-**Note:** Python 3.10-3.14 is supported.
-
----
-
-### 🚀 Installation & Quick Start
-
-1.  **Install the toolkit:**
-    ```bash
-    pip install codegraphcontext
-    ```
-
-2.  **Troubleshooting (Command not found):**
-    If the `codegraphcontext` command is not found, run this one-line fix:
-    ```bash
-    curl -sSL https://raw.githubusercontent.com/CodeGraphContext/CodeGraphContext/main/scripts/post_install_fix.sh | bash
-    ```
-
-3.  **Database Setup (Automatic):**
-    CodeGraphContext uses an embedded graph database by default.
-    - **FalkorDB Lite:** Default backend.
-    - **KuzuDB:** Cross-platform embedded backend.
-    - **Neo4j:** Run `codegraphcontext neo4j setup` to use an external server.
-
----
-
-## 📋 Prerequisites
-
-Before installing CodeGraphContext, ensure you have:
-
-* Python 3.10 or later
-* pip package manager
-* Git (optional, for cloning repositories)
-
-Verify your Python installation:
+Verify Python is available:
 
 ```bash
 python --version
 ```
 
----
-
-## 🚀 Step-by-Step Setup Guide
-
-### Step 1: Install CodeGraphContext
+### Install from PyPI
 
 ```bash
 pip install codegraphcontext
 ```
 
-This command installs CodeGraphContext and all required dependencies.
-
-### Step 2: Verify Installation
+Confirm the CLI is installed:
 
 ```bash
 codegraphcontext --help
 ```
 
-If the command displays the available CLI commands, the installation was successful.
-
-### Step 3: Database Setup
-
-CodeGraphContext automatically uses an embedded database by default, so no additional configuration is required for most users.
-
----
-
-## 🏃 How to Run the Project Locally
-
-### Index a Repository
+The short alias is also available:
 
 ```bash
+cgc --help
+```
+
+If your shell cannot find the command after installation, run the post-install path helper:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/CodeGraphContext/CodeGraphContext/main/scripts/post_install_fix.sh | bash
+```
+
+## Usage
+
+### Quick Start
+
+```bash
+# Index the current repository
 codegraphcontext index .
-```
 
-This scans the current project and creates a searchable code graph.
-
-### View Indexed Repositories
-
-```bash
+# List indexed repositories
 codegraphcontext list
-```
 
-Displays all repositories currently indexed by CodeGraphContext.
-
-### Analyze Code
-
-```bash
+# Find dead code
 codegraphcontext analyze dead-code
 ```
 
-Finds potentially unused code in the indexed repository.
+If `codegraphcontext list` shows your indexed repository, the local setup is ready.
 
----
-
-## ✅ Verify Everything Works
-
-After indexing a repository, run:
+### Common CLI Commands
 
 ```bash
-codegraphcontext list
-```
+# Index a repository
+codegraphcontext index /path/to/repo
 
-If the command executes successfully and displays indexed repositories, your setup is complete and CodeGraphContext is ready to use.
-
-### For CLI Toolkit Mode
-
-**Start using immediately with CLI commands:**
-```bash
-# Index your current directory
-codegraphcontext index .
-
-# List all indexed repositories
-codegraphcontext list
+# Watch a repository and update the graph after file changes
+codegraphcontext watch /path/to/repo
 
 # Analyze who calls a function
 codegraphcontext analyze callers my_function
@@ -337,85 +196,108 @@ codegraphcontext analyze callers my_function
 # Find complex code
 codegraphcontext analyze complexity --threshold 10
 
-# Find dead code
-codegraphcontext analyze dead-code
-
-# Watch for live changes (optional)
-codegraphcontext watch .
-
-# See all commands
-codegraphcontext help
-```
-
-  **See the full [CLI Commands Guide](docs/CLI_COMPLETE_REFERENCE.md) for all available commands and usage scenarios.**
-
-### 🎨 Premium Interactive Visualization
-CodeGraphContext can generate stunning, interactive knowledge graphs of your code. Unlike static diagrams, these are premium web-based explorers:
-
-- **Premium Aesthetics**: Dark mode, glassmorphism, and modern typography (Outfit/JetBrains Mono).
-- **Interactive Inspection**: Click any node to open a detailed side panel with symbol information, file paths, and context.
-- **Quick Search**: Live-search through the graph to find specific symbols instantly.
-- **Intelligent Layouts**: Force-directed and hierarchical layouts that make complex relationships readable.
-- **Zero-Dependency Viewing**: Standalone HTML files that work in any modern browser.
-
-```bash
-# Visualize function calls
+# Generate an interactive visualization
 codegraphcontext analyze calls my_function --viz
 
 # Explore class hierarchies
 codegraphcontext analyze tree MyClass --viz
 
-# Visualize search results
+# Search symbols or content
+codegraphcontext find pattern "Auth"
+```
+
+See the [complete CLI reference](docs/CLI_COMPLETE_REFERENCE.md) for all commands and options.
+
+### Visualization
+
+Visualization commands create standalone HTML reports that can be opened in a browser. They include searchable graph nodes, detailed side panels, and layouts for call graphs, class trees, and search results.
+
+```bash
+codegraphcontext analyze calls my_function --viz
+codegraphcontext analyze tree MyClass --viz
 codegraphcontext find pattern "Auth" --viz
 ```
 
+## MCP Server
 
----
+Use the MCP setup wizard to configure supported editors and AI assistants:
 
-### 🤖 For MCP Server Mode
-
-**Configure your AI assistant to use CodeGraphContext:**
-1.  **Setup:** Run the MCP setup wizard to configure your IDE/AI assistant:
-    
-    ```bash
-    codegraphcontext mcp setup
-    ```
-    
-    The wizard can automatically detect and configure:
-    *   VS Code
-    *   Cursor
-    *   Windsurf
-    *   Zed
-    *   Claude
-    *   Gemini CLI
-    *   ChatGPT Codex
-    *   Cline
-    *   RooCode
-    *   Amazon Q Developer
-    *   Kiro
-    *   Goose
-    *   OpenCode
-
-    Upon successful configuration, `codegraphcontext mcp setup` will generate and place the necessary configuration files:
-    *   It creates an `mcp.json` file in your current directory for reference.
-    *   It stores your database credentials securely in `~/.codegraphcontext/.env`.
-    *   It updates the settings file of your chosen IDE/CLI (e.g., `.claude.json` or VS Code's `settings.json`).
-
-2.  **Start:** Launch the MCP server:    
-    ```bash
-    codegraphcontext mcp start
-    ```
-
-3.  **Use:** Now interact with your codebase through your AI assistant using natural language! See examples below.
-
----
-
-## Ignoring Files (`.cgcignore`)
-
-You can tell CodeGraphContext to ignore specific files and directories by creating a `.cgcignore` file in the root of your project. This file uses the same syntax as `.gitignore`.
-
-**Example `.cgcignore` file:**
+```bash
+codegraphcontext mcp setup
 ```
+
+The wizard can configure VS Code, Cursor, Windsurf, Zed, Claude, Gemini CLI, ChatGPT Codex, Cline, RooCode, Amazon Q Developer, Kiro, Goose, and OpenCode. It writes the MCP configuration and stores database settings in `~/.codegraphcontext/.env`.
+
+Start the MCP server:
+
+```bash
+codegraphcontext mcp start
+```
+
+### Manual MCP Configuration
+
+If your client is not configured automatically, add this server entry to your MCP client settings:
+
+```json
+{
+  "mcpServers": {
+    "CodeGraphContext": {
+      "command": "codegraphcontext",
+      "args": ["mcp", "start"],
+      "env": {
+        "NEO4J_URI": "YOUR_NEO4J_URI",
+        "NEO4J_USERNAME": "YOUR_NEO4J_USERNAME",
+        "NEO4J_PASSWORD": "YOUR_NEO4J_PASSWORD"
+      },
+      "disabled": false,
+      "alwaysAllow": []
+    }
+  }
+}
+```
+
+For `pipx` installs, use `pipx run`:
+
+```json
+{
+  "mcpServers": {
+    "CodeGraphContext": {
+      "command": "pipx",
+      "args": ["run", "codegraphcontext", "mcp", "start"],
+      "env": {
+        "NEO4J_URI": "YOUR_NEO4J_URI",
+        "NEO4J_USERNAME": "YOUR_NEO4J_USERNAME",
+        "NEO4J_PASSWORD": "YOUR_NEO4J_PASSWORD"
+      },
+      "disabled": false,
+      "alwaysAllow": []
+    }
+  }
+}
+```
+
+OpenCode users can also follow the [OpenCode MCP guide](https://opencode.ai/docs/ko/mcp-servers/#_top).
+
+### Example Prompts
+
+After indexing a repository and starting the MCP server, ask your assistant questions such as:
+
+- "Where is the `process_payment` function?"
+- "What calls `get_user_by_id`?"
+- "If I change `calculate_tax`, what files might be affected?"
+- "Show the inheritance hierarchy for `BaseController`."
+- "Find all implementations of `render`."
+- "Trace the call chain from `main` to `process_data`."
+- "Which files import `requests`?"
+- "Is there any dead or unused code?"
+
+## Configuration
+
+### Ignoring Files
+
+Create a `.cgcignore` file in the repository root to skip files and directories during indexing. The syntax matches `.gitignore`.
+
+```gitignore
 # Ignore build artifacts
 /build/
 /dist/
@@ -428,133 +310,87 @@ You can tell CodeGraphContext to ignore specific files and directories by creati
 *.log
 ```
 
----
+### Database Setup
 
-## MCP Client Configuration
+CodeGraphContext uses an embedded graph database by default. Most users can install the package and run `codegraphcontext index .` without additional database setup.
 
-The `codegraphcontext mcp setup` command attempts to automatically configure your IDE/CLI. If you choose not to use the automatic setup, or if your tool is not supported, you can configure it manually.
+For an external Neo4j server, run:
 
-Add the following server configuration to your client's settings file (e.g., VS Code's `settings.json` or `.claude.json`):
-
-```json
-{
-  "mcpServers": {
-    "CodeGraphContext": {
-      "command": "codegraphcontext",
-      "args": [
-        "mcp",
-        "start"
-      ],
-      "env": {
-        "NEO4J_URI": "YOUR_NEO4J_URI",
-        "NEO4J_USERNAME": "YOUR_NEO4J_USERNAME",
-        "NEO4J_PASSWORD": "YOUR_NEO4J_PASSWORD"
-      },
-      "disabled": false,
-      "alwaysAllow": []
-    }
-  }
-}
+```bash
+codegraphcontext neo4j setup
 ```
 
-#### OpenCode Configuration
+## Supported Languages
 
-For instructions on installing and configuring MCP servers with OpenCode, see the [OpenCode MCP Guide](https://opencode.ai/docs/ko/mcp-servers/#_top).
+CodeGraphContext parses and analyzes these languages:
 
-#### If installed via pipx
+| Language | Language | Language |
+| --- | --- | --- |
+| Python | JavaScript | TypeScript |
+| Java | C | C++ |
+| C# | Go | Rust |
+| Ruby | PHP | Swift |
+| Kotlin | Dart | Perl |
+| Lua | Scala | Haskell |
+| Elixir | Emacs Lisp | HTML |
+| CSS | TSX | |
 
-If you installed CodeGraphContext using `pipx`, use the following configuration instead:
-```json
-{
-  "mcpServers": {
-    "CodeGraphContext": {
-      "command": "pipx",
-      "args": [
-        "run",
-        "codegraphcontext",
-        "mcp",
-        "start"
-      ],
-      "env": {
-        "NEO4J_URI": "YOUR_NEO4J_URI",
-        "NEO4J_USERNAME": "YOUR_NEO4J_USERNAME",
-        "NEO4J_PASSWORD": "YOUR_NEO4J_PASSWORD"
-      },
-      "disabled": false,
-      "alwaysAllow": []
-    }
-  }
-}
-```
+## Database Backends
 
----
+| Feature | KuzuDB | LadybugDB | FalkorDB Lite | Neo4j / Nornic DB |
+| --- | --- | --- | --- | --- |
+| Typical use | Cross-platform embedded backend | Optional embedded backend | Unix local development | External or cloud graph database |
+| Setup | Zero-config | Zero-config | Zero-config / in-process | Docker, native server, or hosted service |
+| Platform | Windows, macOS, Linux | Windows, macOS, Linux | Linux, macOS, WSL | Windows, macOS, Linux |
+| Requirement | `pip install kuzu` | `pip install ladybug` | `pip install falkordblite` | Neo4j Server, Docker, or Nornic Cloud |
+| Persistence | Disk-backed | Disk-backed | Disk-backed | Server-backed |
 
-## Natural Language Interaction Examples
+## SCIP Indexing
 
-Once the server is running, you can interact with it through your AI assistant using plain English. Here are some examples of what you can say:
+Set `SCIP_INDEXER=true` in `~/.codegraphcontext/.env` to enable external SCIP indexers for languages where they provide more accurate calls and inheritance than Tree-sitter heuristics alone.
 
-### Indexing and Watching Files
+- **C and C++** use `scip-clang` and require a `compile_commands.json` compilation database. Generate one with CMake (`-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`) or tools such as [Bear](https://github.com/rizsotto/Bear).
+- **C#** uses `scip-dotnet` and requires a normal `.csproj` or `.sln` with a successful restore.
 
--   **To index a new project:**
-    -   "Please index the code in the `/path/to/my-project` directory."
-    OR
-    -   "Add the project at `~/dev/my-other-project` to the code graph."
+SCIP works independently of the selected graph backend.
 
+## Project Links
 
--   **To start watching a directory for live changes:**
-    -   "Watch the `/path/to/my-active-project` directory for changes."
-    OR
-    -   "Keep the code graph updated for the project I'm working on at `~/dev/main-app`."
-
-    When you ask to watch a directory, the system performs two actions at once:
-    1.  It kicks off a full scan to index all the code in that directory. This process runs in the background, and you'll receive a `job_id` to track its progress.
-    2.  It begins watching the directory for any file changes to keep the graph updated in real-time.
-
-    This means you can start by simply telling the system to watch a directory, and it will handle both the initial indexing and the continuous updates automatically.
-
-### Querying and Understanding Code
-
--   **Finding where code is defined:**
-    -   "Where is the `process_payment` function?"
-    -   "Find the `User` class for me."
-    -   "Show me any code related to 'database connection'."
-
--   **Analyzing relationships and impact:**
-    -   "What other functions call the `get_user_by_id` function?"
-    -   "If I change the `calculate_tax` function, what other parts of the code will be affected?"
-    -   "Show me the inheritance hierarchy for the `BaseController` class."
-    -   "What methods does the `Order` class have?"
-
--   **Exploring dependencies:**
-    -   "Which files import the `requests` library?"
-    -   "Find all implementations of the `render` method."
-
--   **Advanced Call Chain and Dependency Tracking (Spanning Hundreds of Files):**
-    The CodeGraphContext excels at tracing complex execution flows and dependencies across vast codebases. Leveraging the power of graph databases, it can identify direct and indirect callers and callees, even when a function is called through multiple layers of abstraction or across numerous files. This is invaluable for:
-    -   **Impact Analysis:** Understand the full ripple effect of a change to a core function.
-    -   **Debugging:** Trace the path of execution from an entry point to a specific bug.
-    -   **Code Comprehension:** Grasp how different parts of a large system interact.
-
-    -   "Show me the full call chain from the `main` function to `process_data`."
-    -   "Find all functions that directly or indirectly call `validate_input`."
-    -   "What are all the functions that `initialize_system` eventually calls?"
-    -   "Trace the dependencies of the `DatabaseManager` module."
-
--   **Code Quality and Maintenance:**
-    -   "Is there any dead or unused code in this project?"
-    -   "Calculate the cyclomatic complexity of the `process_data` function in `src/utils.py`."
-    -   "Find the 5 most complex functions in the codebase."
-
--   **Repository Management:**
-    -   "List all currently indexed repositories."
-    -   "Delete the indexed repository at `/path/to/old-project`."
-
----
+- Website: [codegraphcontext.vercel.app](https://codegraphcontext.vercel.app/)
+- CLI reference: [docs/CLI_COMPLETE_REFERENCE.md](docs/CLI_COMPLETE_REFERENCE.md)
+- Architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- Bundles: [docs/BUNDLES.md](docs/BUNDLES.md)
+- Roadmap: [ROADMAP.md](ROADMAP.md)
+- Security policy: [.github/SECURITY.md](.github/SECURITY.md)
 
 ## Contributing
 
-Contributions are welcome! 🎉  
-Please see our [CONTRIBUTING.md](.github/CONTRIBUTING.md) for detailed guidelines.
-If you have ideas for new features, integrations, or improvements, open an [issue](https://github.com/CodeGraphContext/CodeGraphContext/issues) or submit a Pull Request.
+Contributions are welcome. Read [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for setup, development, and pull request guidelines.
 
-Join discussions and help shape the future of CodeGraphContext.
+Useful local checks include:
+
+```bash
+python -m pytest
+python -m black --check .
+python -m ruff check .
+```
+
+For documentation changes, keep examples copyable and verify that referenced files and links exist.
+
+## Used By
+
+CodeGraphContext is being explored for static code analysis in AI assistants, graph-based project visualization, dead-code detection, complexity analysis, and repository onboarding.
+
+If you use CodeGraphContext in your project, open a pull request and add it here.
+
+## Maintainer
+
+CodeGraphContext is created and maintained by [Shashank Shekhar Singh](https://github.com/Shashankss1205).
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+
+## License
+
+CodeGraphContext is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- reorganize the README into clearer Overview, Features, Tech Stack, Installation, Usage, MCP Server, Configuration, Contributing, and License sections
- remove duplicated setup and command sections while keeping the existing badges, demos, translation links, supported languages, database backend notes, and project links
- make installation, quick-start, CLI usage, MCP setup, and local documentation links easier to scan

Closes #1030

## Tests
- `python3` README structure and local-link assertions
- `git diff --check`