### PR TITLE
fix: per-repo resolver must not overwrite explicit CGC_RUNTIME_DB_TYPE

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -922,7 +922,11 @@ def resolve_context(
     if local_cgc is not None:
         # Read local config.yaml if present
         local_yaml = local_cgc / "config.yaml"
-        local_db = load_config().get("DEFAULT_DATABASE", "falkordb")
+        local_db = (
+            os.environ.get("CGC_RUNTIME_DB_TYPE")
+            or os.environ.get("DEFAULT_DATABASE")
+            or load_config().get("DEFAULT_DATABASE", "falkordb")
+        )
         if local_yaml.exists():
             try:
                 with open(local_yaml, encoding="utf-8") as f:

--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -165,7 +165,7 @@ class MCPServer:
             ctx = resolve_context(cwd=self.cwd)
             self.resolved_context = ctx
 
-            if ctx.database:
+            if ctx.database and not os.environ.get('CGC_RUNTIME_DB_TYPE'):
                 os.environ['CGC_RUNTIME_DB_TYPE'] = ctx.database
 
             self.db_manager = get_database_manager(db_path=ctx.db_path)


### PR DESCRIPTION
## Problem

Two related bugs that combine to produce silent backend mis-routing — most visibly on Windows, where FalkorDB Lite (`database: falkordb`) is unavailable and the fallback to KuzuDB fails with `-32000 / Failed to reconnect` and leaves a zombie `cgc mcp start` process.

### Bug 1 — `server.py`: resolver verdict unconditionally overwrites process env

`MCPServer.__init__` does:
```python
if ctx.database:
    os.environ['CGC_RUNTIME_DB_TYPE'] = ctx.database
```

This overwrites any value the caller already placed in the process env — e.g. `CGC_RUNTIME_DB_TYPE=falkordb-remote` set by a project `.mcp.json` env block or a launcher wrapper — with whatever `resolve_context()` defaulted to. The user's explicit backend choice is silently discarded.

### Bug 2 — `config_manager.py`: per-repo branch ignores process env for the default

When `resolve_context()` takes the per-repo branch (a local `.codegraphcontext/` folder is present), it initialises `local_db` via:
```python
local_db = load_config().get("DEFAULT_DATABASE", "falkordb")
```
`load_config()` reads `.env` files from disk. It does **not** consult the current process environment. So `CGC_RUNTIME_DB_TYPE=falkordb-remote` in the MCP launcher env is invisible here and the resolver defaults to bare `"falkordb"`.

### Combined failure mode (Windows + per-repo folder)

A repo that has a `.codegraphcontext/` folder (common — e.g. for a repo-local `.cgcignore`) but no explicit `config.yaml` pin will:
1. Take the per-repo branch → `local_db = "falkordb"` (Bug 2)
2. Write that back to `CGC_RUNTIME_DB_TYPE` (Bug 1), discarding `falkordb-remote`
3. `get_database_manager()` picks up `"falkordb"` → FalkorDB Lite unavailable on Windows → silent KuzuDB fallback → single-writer lock crash → `-32000` and a zombie process

## Fix

**`server.py`** — only write when the variable is not already explicitly set:
```python
if ctx.database and not os.environ.get('CGC_RUNTIME_DB_TYPE'):
    os.environ['CGC_RUNTIME_DB_TYPE'] = ctx.database
```

**`config_manager.py`** — consult process env before file-based config:
```python
local_db = (
    os.environ.get("CGC_RUNTIME_DB_TYPE")
    or os.environ.get("DEFAULT_DATABASE")
    or load_config().get("DEFAULT_DATABASE", "falkordb")
)
```

An explicit `database:` key in the repo-local `config.yaml` still wins over all of the above (`local_raw.get("database", local_db)`), so per-repo config pins continue to work as documented.

## Workaround (until a release picks this up)

Add a `.codegraphcontext/config.yaml` pinning `database: falkordb-remote` to any repo using the remote backend that carries a local `.codegraphcontext/` folder. This makes `local_raw.get("database", local_db)` return `"falkordb-remote"` and bypasses both bugs.

## Tested against

Reproduced against v0.4.12 (PyPI). Fix validated end-to-end: MCP server connects to FalkorDB remote, `list_indexed_repositories` returns correct graph, no KuzuDB fallback log.
