### PR TITLE
Fix #708: Add vercel analytics to our codegraphcontext.vercel.app website.

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Analytics } from "@vercel/analytics/react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
@@ -22,6 +23,7 @@ const App: React.FC = () => {
   return (
     <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <QueryClientProvider client={queryClient}>
+        <Analytics />
         <ThemeProvider
           attribute="class"
           defaultTheme="dark"

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -3,13 +3,9 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import "./scroll-performance.css";
-import { inject } from "@vercel/analytics";
 import { initScrollPerformance } from "./scrollPerformance";
 
 import "aos/dist/aos.css";
-
-// Inject Vercel Web Analytics
-inject();
 
 // Initialize scroll performance optimizations
 initScrollPerformance();


### PR DESCRIPTION
Fixes #708

Replaced the imperative `inject()` call in `main.tsx` with the React `<Analytics />` component from `@vercel/analytics/react` in `App.tsx`, matching the recommended React integration pattern for Vercel Analytics.

Local test infra unavailable in CI sandbox.

---
This change was prepared with AI assistance under human direction and review.