### PR TITLE
Fix watch-mode imports map race

### DIFF
--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -2068,7 +2068,8 @@ def build_function_call_groups(
                 _lang_imports_cache[caller_lang] = imports_map
             else:
                 filtered: dict = {}
-                for name, paths in imports_map.items():
+                # Snapshot so concurrent indexer updates cannot resize the map mid-iteration.
+                for name, paths in list(imports_map.items()):
                     same_lang = [p for p in paths if Path(p).suffix in exts]
                     if same_lang:
                         filtered[name] = same_lang

--- a/tests/unit/tools/test_imports_map_race.py
+++ b/tests/unit/tools/test_imports_map_race.py
@@ -20,10 +20,13 @@ def test_language_import_filter_snapshots_imports_map_during_concurrent_update(
         def as_posix(self):
             return self._path.as_posix()
 
+        def __getattr__(self, name):
+            return getattr(self._path, name)
+
         @property
         def suffix(self):
             suffix_started.set()
-            assert mutated.wait(2)
+            assert mutated.wait(10)
             return self._path.suffix
 
     monkeypatch.setattr(calls_module, "Path", SlowPath)
@@ -43,7 +46,7 @@ def test_language_import_filter_snapshots_imports_map_during_concurrent_update(
     ]
 
     def mutate_imports_map():
-        assert suffix_started.wait(2)
+        assert suffix_started.wait(10)
         imports_map["NewSymbol"] = ["/repo/deps/new_symbol.py"]
         mutated.set()
 
@@ -52,6 +55,6 @@ def test_language_import_filter_snapshots_imports_map_during_concurrent_update(
     try:
         calls_module.build_function_call_groups(all_file_data, imports_map)
     finally:
-        mutator.join(timeout=2)
+        mutator.join(timeout=10)
 
     assert mutated.is_set()

--- a/tests/unit/tools/test_imports_map_race.py
+++ b/tests/unit/tools/test_imports_map_race.py
@@ -1,0 +1,57 @@
+import pathlib
+import threading
+
+from codegraphcontext.tools.indexing.resolution import calls as calls_module
+
+
+def test_language_import_filter_snapshots_imports_map_during_concurrent_update(
+    monkeypatch,
+):
+    suffix_started = threading.Event()
+    mutated = threading.Event()
+
+    class SlowPath:
+        def __init__(self, value):
+            self._path = pathlib.Path(value)
+
+        def resolve(self):
+            return self
+
+        def as_posix(self):
+            return self._path.as_posix()
+
+        @property
+        def suffix(self):
+            suffix_started.set()
+            assert mutated.wait(2)
+            return self._path.suffix
+
+    monkeypatch.setattr(calls_module, "Path", SlowPath)
+
+    imports_map = {
+        "ExistingSymbol": ["/repo/deps/existing.py"],
+    }
+    all_file_data = [
+        {
+            "path": "/repo/caller.py",
+            "lang": "python",
+            "functions": [],
+            "classes": [],
+            "function_calls": [],
+            "imports": [],
+        }
+    ]
+
+    def mutate_imports_map():
+        assert suffix_started.wait(2)
+        imports_map["NewSymbol"] = ["/repo/deps/new_symbol.py"]
+        mutated.set()
+
+    mutator = threading.Thread(target=mutate_imports_map)
+    mutator.start()
+    try:
+        calls_module.build_function_call_groups(all_file_data, imports_map)
+    finally:
+        mutator.join(timeout=2)
+
+    assert mutated.is_set()


### PR DESCRIPTION
## Summary

- Snapshot `imports_map.items()` before the language-specific call-resolution filter iterates it.
- Add a regression test that mutates the same imports map from another thread while call resolution is reading it.

## Why

This is a read/write race on shared mutable state.

Watch mode can schedule overlapping debounce handlers via `threading.Timer`. Those handlers share `self.imports_map`: one path may rebuild or update the map while another path is resolving calls and filtering imports by language.

Before this change, `_get_lang_imports` iterated the live dictionary:

```python
for name, paths in imports_map.items():
```

If another handler changes the dictionary size during that loop, the reader raises:

```text
RuntimeError: dictionary changed size during iteration
```

Because the exception is raised in the timer thread, it does not fail the watcher process. Unless stderr is being monitored, the process can continue running while the incremental update that hit the race is silently dropped. The watcher keeps logging `Monitoring for file changes`, the graph drifts out of sync, and queries can return stale results until a manual `cgc index --force`.

The race can be triggered when edits land close together under typical watch-mode workload such as save-all, branch switch, or format-on-save. Observed on an actively-edited repo.

## Fix

The reader now snapshots the dictionary items before filtering:

```python
for name, paths in list(imports_map.items()):
```

This matches the existing writer-side pattern that snapshots keys before mutating the same map. It keeps the change focused on the crash without changing the broader watch scheduling behavior.

Related watch-mode scheduling context: #792.

## Test plan

- `python -m pytest tests/unit/tools/test_imports_map_race.py -q`
- `python -m pytest tests/unit/tools/test_imports_map_race.py tests/unit/tools/test_calls_resolution_tiers.py tests/unit/tools/test_python_call_resolution_patterns.py -q`
- `ruff check src/codegraphcontext/tools/indexing/resolution/calls.py tests/unit/tools/test_imports_map_race.py`
- `black --check --target-version py312 tests/unit/tools/test_imports_map_race.py`
