### PR TITLE
feat: add Python 3.14 parser compatibility to allow use of latest stable tree-sitter-language-pack

### DIFF
--- a/.github/workflows/db-parity-check.yml
+++ b/.github/workflows/db-parity-check.yml
@@ -29,13 +29,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "tree-sitter==0.25.2" "tree-sitter-language-pack==0.13.0"
-          pip install .[dev]
+          pip install .[dev,parsing]
 
       - name: Wait for Neo4j
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
+        python-version: '3.14'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install system deps
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,22 +12,25 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build
-          pip install "tree-sitter==0.25.2" "tree-sitter-language-pack==0.13.0"
-          pip install .[dev]
+          pip install .[dev,parsing]
 
       - name: Build package
         run: python -m build

--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ _If you’re using CodeGraphContext in your project, feel free to open a PR and 
 - `rich>=13.7.0`
 - `inquirerpy>=0.3.4`
 - `python-dotenv>=1.0.0`
-- `tree-sitter>=0.21.0` (not installed on Python 3.13)
-- `tree-sitter-language-pack>=0.6.0` (not installed on Python 3.13)
+- `tree-sitter>=0.24.0,<0.26.0`
+- `tree-sitter-language-pack>=1.6,<2.0`
 - `pyyaml`
 - `pathspec>=0.12.1`
 - `falkordb>=1.0,<1.6`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,11 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 3 - Alpha",
@@ -22,9 +27,9 @@ dependencies = [
     "rich>=13.7.0",
     "inquirerpy>=0.3.4",
     "python-dotenv>=1.0.0",
-    "tree-sitter>=0.21.0,<0.26.0; python_version != '3.13'",
-    "tree-sitter-language-pack>=0.6.0,<1.0.0; python_version != '3.13'",
-    "tree-sitter-c-sharp>=0.21.0; python_version != '3.13'",
+    "tree-sitter>=0.24.0,<0.26.0",
+    "tree-sitter-language-pack>=1.6,<2.0",
+    "tree-sitter-c-sharp>=0.21.0",
     "pyyaml",
     "nbformat",
     "nbconvert>=7.16.6",
@@ -62,9 +67,9 @@ dependencies = [
 
 [project.optional-dependencies]
 parsing = [
-    "tree-sitter>=0.21.0,<0.26.0; python_version != '3.13'",
-    "tree-sitter-language-pack>=0.6.0,<1.0.0; python_version != '3.13'",
-    "tree-sitter-c-sharp>=0.21.0; python_version != '3.13'",
+    "tree-sitter>=0.24.0,<0.26.0",
+    "tree-sitter-language-pack>=1.6,<2.0",
+    "tree-sitter-c-sharp>=0.21.0",
 ]
 # Named backend extras let users (and CI) opt into a single, tested driver
 # triple instead of inheriting whatever the default install pulls. They


### PR DESCRIPTION
Update tree-sitter dependency constraints to use tree-sitter-language-pack 1.x across supported Python versions, including Python 3.13 and 3.14.

Expand CI coverage to exercise Python 3.12, 3.13, and 3.14, install the parsing extra in workflows, and document the new dependency bounds while leaving the backend driver pins from main intact.

Amp-Thread-ID: https://ampcode.com/threads/T-019ec9fc-a435-7370-844d-7b114747334e

Solves Issue [913](https://github.com/CodeGraphContext/CodeGraphContext/issues/913)