### PR TITLE
feat: make watch startup sync opt-in

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -850,7 +850,12 @@ def stats_helper(path: str = None, context: Optional[str] = None):
         db_manager.close_driver()
 
 
-def watch_helper(path: str, context: Optional[str] = None, use_polling: Optional[bool] = None):
+def watch_helper(
+    path: str,
+    context: Optional[str] = None,
+    use_polling: Optional[bool] = None,
+    sync_on_start: bool = False,
+):
     """Watch a directory for changes and auto-update the graph (blocking mode)."""
     import logging
     from ..core.watcher import CodeWatcher
@@ -913,11 +918,17 @@ def watch_helper(path: str, context: Optional[str] = None, use_polling: Optional
         
         # Add the directory to watch
         if is_indexed:
-            console.print("[green]✓[/green] Already indexed. Synchronizing current files...")
+            if sync_on_start:
+                console.print("[green]✓[/green] Already indexed. Synchronizing current files...")
+            else:
+                console.print("[green]✓[/green] Already indexed. Watching for future changes only.")
+                console.print(
+                    "[dim]Use 'cgc index --force' or 'cgc watch --sync-on-start' to reconcile existing changes.[/dim]"
+                )
             watcher.watch_directory(
                 str(path_obj),
                 perform_initial_scan=False,
-                sync_on_start=True,
+                sync_on_start=sync_on_start,
                 cgcignore_path=ctx.cgcignore_path,
             )
         else:
@@ -960,7 +971,7 @@ def watch_helper(path: str, context: Optional[str] = None, use_polling: Optional
     finally:
         watcher.stop()
         db_manager.close_driver()
-        console.print("[green]✓[/green] Watcher stopped. Graph is up to date.")
+        console.print("[green]✓[/green] Watcher stopped.")
 
 
 

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -1565,6 +1565,14 @@ def watch(
         "--poll",
         help="Use watchdog's polling observer for Docker bind mounts and network filesystems.",
     ),
+    sync_on_start: bool = typer.Option(
+        False,
+        "--sync-on-start",
+        help=(
+            "Synchronize already-indexed files before watching. "
+            "Defaults off; use 'cgc index --force' for a full re-index."
+        ),
+    ),
 ):
     """
     Watch a directory for file changes and automatically update the code graph.
@@ -1575,6 +1583,7 @@ def watch(
     
     The watcher will:
     - Perform an initial scan if the directory is not yet indexed
+    - Attach immediately for already-indexed directories unless --sync-on-start is passed
     - Monitor for file creation, modification, deletion, and moves
     - Automatically re-index affected files and update relationships
     
@@ -1584,12 +1593,13 @@ def watch(
         cgc watch .                    # Watch current directory
         cgc watch /path/to/project     # Watch specific directory
         cgc watch --poll .             # Use polling for Docker/NFS/SMB mounts
+        cgc watch --sync-on-start .    # Reconcile current files before watching
         cgc w .                        # Using shortcut alias
 
     Set CGC_WATCH_POLLING=1 to use polling without passing --poll.
     """
     _load_credentials()
-    watch_helper(path, context, use_polling=poll or None)
+    watch_helper(path, context, use_polling=poll or None, sync_on_start=sync_on_start)
 
 @app.command()
 def unwatch(
@@ -2846,9 +2856,22 @@ def visualize_abbrev(
 def watch_abbrev(
     path: str = typer.Argument(".", help="Path to watch"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
+    poll: bool = typer.Option(
+        False,
+        "--poll",
+        help="Use watchdog's polling observer for Docker bind mounts and network filesystems.",
+    ),
+    sync_on_start: bool = typer.Option(
+        False,
+        "--sync-on-start",
+        help=(
+            "Synchronize already-indexed files before watching. "
+            "Defaults off; use 'cgc index --force' for a full re-index."
+        ),
+    ),
 ):
     """Shortcut for 'cgc watch'"""
-    watch(path, context=context)
+    watch(path, context=context, poll=poll, sync_on_start=sync_on_start)
 
 
 # ============================================================================

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -378,6 +378,27 @@ def _matrix_command_set(entries: list[list[str]]) -> set[tuple[str, str]]:
     return covered
 
 
+@pytest.mark.parametrize(
+    ("args", "expected_sync_on_start"),
+    [
+        (["watch", "."], False),
+        (["watch", "--sync-on-start", "."], True),
+        (["w", "."], False),
+        (["w", "--sync-on-start", "."], True),
+    ],
+)
+def test_watch_sync_on_start_flag_is_explicit(monkeypatch, args, expected_sync_on_start):
+    calls = []
+    monkeypatch.setattr(cli_main, "_load_credentials", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_main, "watch_helper", lambda *call_args, **kwargs: calls.append((call_args, kwargs)))
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 0, result.output
+    assert calls
+    assert calls[0][1]["sync_on_start"] is expected_sync_on_start
+
+
 def test_cli_inventory_grouped_from_source():
     inventory = _inventory_from_main_source()
 

--- a/tests/unit/core/test_watcher_startup_sync.py
+++ b/tests/unit/core/test_watcher_startup_sync.py
@@ -1,6 +1,10 @@
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
+from codegraphcontext.cli import cli_helpers
 from codegraphcontext.core.watcher import CodeWatcher, RepositoryEventHandler
 from codegraphcontext.tools.handlers import watcher_handlers
 from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
@@ -80,6 +84,42 @@ def test_code_watcher_forwards_startup_sync_option(tmp_path: Path):
         repo.resolve(),
         perform_initial_scan=False,
         sync_on_start=True,
+        cgcignore_path=None,
+    )
+
+
+@pytest.mark.parametrize("sync_on_start", [False, True])
+def test_cli_watch_helper_startup_sync_is_explicit_for_indexed_repo(tmp_path: Path, sync_on_start: bool):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    db_manager = MagicMock()
+    graph_builder = MagicMock()
+    code_finder = MagicMock()
+    code_finder.list_indexed_repositories.return_value = [{"path": str(repo)}]
+    watcher = MagicMock()
+
+    class StopAfterAttach:
+        def wait(self):
+            raise KeyboardInterrupt
+
+    with (
+        patch.object(
+            cli_helpers,
+            "_initialize_services",
+            return_value=(db_manager, graph_builder, code_finder, SimpleNamespace(cgcignore_path=None)),
+        ),
+        patch("codegraphcontext.core.watcher.CodeWatcher", return_value=watcher),
+        patch("threading.Event", return_value=StopAfterAttach()),
+    ):
+        if sync_on_start:
+            cli_helpers.watch_helper(str(repo), sync_on_start=True)
+        else:
+            cli_helpers.watch_helper(str(repo))
+
+    watcher.watch_directory.assert_called_once_with(
+        str(repo.resolve()),
+        perform_initial_scan=False,
+        sync_on_start=sync_on_start,
         cgcignore_path=None,
     )
 


### PR DESCRIPTION
This commit addresses [1268](https://github.com/CodeGraphContext/CodeGraphContext/issues/1268)

- Added explicit `--sync-on-start` opt-in to `cgc watch`
  - `CodeGraphContext/src/codegraphcontext/cli/main.py#L1559-L1599`
- Added the same option to the `cgc w`
  - `CodeGraphContext/src/codegraphcontext/cli/main.py#L2852-L2868`
- Changed `watch_helper`
  - `CodeGraphContext/src/codegraphcontext/cli/cli_helpers.py#L853-L933`
  - already-indexed repos now default to:
    - attach watcher immediately
    - skip startup reconciliation
    - only process future file events
- Preserved old startup-sync behavior behind `cgc watch --sync-on-start`.
- Removed the shutdown message’s unconditional “Graph is up to date” claim, since default watch no longer reconciles pre-existing changes

Amp-Thread-ID: https://ampcode.com/threads/T-019ecf16-9928-72d1-8fd5-e6627e7e0df5