### PR TITLE
Fix decorator import resolution without source

### DIFF
--- a/src/codegraphcontext/tools/indexing/resolution/inheritance.py
+++ b/src/codegraphcontext/tools/indexing/resolution/inheritance.py
@@ -308,6 +308,17 @@ def _parse_decorator_name(dec_raw: str) -> str:
     return dec.split("(")[0].strip()
 
 
+def _build_local_imports_for_decorators(file_data: Dict[str, Any]) -> Dict[str, str]:
+    """Return alias/name -> import target across parser import shapes."""
+    local_imports: Dict[str, str] = {}
+    for imp in file_data.get("imports", []):
+        key = imp.get("alias") or imp.get("name")
+        target = imp.get("source") or imp.get("full_import_name") or imp.get("name")
+        if key and target:
+            local_imports[key] = target
+    return local_imports
+
+
 def _resolve_decorator_path(
     decorator_name: str,
     caller_file_path: str,
@@ -320,10 +331,11 @@ def _resolve_decorator_path(
         return caller_path
     if decorator_name in local_imports:
         imported = local_imports[decorator_name]
-        lookup = imported.split(".")[-1]
-        paths = imports_map.get(lookup, imports_map.get(imported, []))
-        if len(paths) == 1:
-            return str(Path(paths[0]).resolve().as_posix())
+        if imported:
+            lookup = str(imported).split(".")[-1]
+            paths = imports_map.get(lookup, imports_map.get(imported, []))
+            if len(paths) == 1:
+                return str(Path(paths[0]).resolve().as_posix())
     paths = imports_map.get(decorator_name, [])
     if len(paths) == 1:
         return str(Path(paths[0]).resolve().as_posix())
@@ -346,11 +358,7 @@ def build_decorated_by_links(
             for item in file_data.get(key, [])
             if item.get("name")
         }
-        local_imports = {
-            imp.get("alias") or imp.get("name"): imp.get("source")
-            for imp in file_data.get("imports", [])
-            if imp.get("name") or imp.get("alias")
-        }
+        local_imports = _build_local_imports_for_decorators(file_data)
 
         for entity_key, context_field in (("functions", "class_context"), ("classes", None)):
             for item in file_data.get(entity_key, []):
@@ -402,11 +410,7 @@ def build_metaclass_links(
             continue
         caller_file_path = str(Path(file_data["path"]).resolve().as_posix())
         local_class_names = {c["name"] for c in file_data.get("classes", [])}
-        local_imports = {
-            imp.get("alias") or imp.get("name"): imp.get("source")
-            for imp in file_data.get("imports", [])
-            if imp.get("name") or imp.get("alias")
-        }
+        local_imports = _build_local_imports_for_decorators(file_data)
 
         for class_item in file_data.get("classes", []):
             meta_name = class_item.get("metaclass")

--- a/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
+++ b/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
@@ -678,6 +678,50 @@ class TestCrossLangCallResolutionPatterns:
         )
         assert edge["line_number"] == 363
 
+    def test_python_decorated_by_handles_imports_without_source(self, tmp_path):
+        caller_path = tmp_path / "models.py"
+        decorator_path = tmp_path / "decorators.py"
+        caller_path.write_text("from decorators import model_decorator\n\n@model_decorator\nclass Model:\n    pass\n")
+        decorator_path.write_text("def model_decorator(cls):\n    return cls\n")
+
+        file_data = {
+            "path": str(caller_path.resolve()),
+            "lang": "python",
+            "functions": [],
+            "classes": [
+                {
+                    "name": "Model",
+                    "line_number": 3,
+                    "decorators": ["@model_decorator"],
+                }
+            ],
+            "imports": [
+                {
+                    "name": "model_decorator",
+                    "full_import_name": "decorators.model_decorator",
+                    "alias": None,
+                    "line_number": 1,
+                    "lang": "python",
+                }
+            ],
+        }
+
+        edges = build_decorated_by_links(
+            [file_data], {"model_decorator": [str(decorator_path.resolve())]}
+        )
+
+        assert edges == [
+            {
+                "decorated_name": "Model",
+                "decorated_path": str(caller_path.resolve()),
+                "decorated_line": 3,
+                "decorated_context": "",
+                "decorator_name": "model_decorator",
+                "decorator_path": str(decorator_path.resolve()),
+                "line_number": 3,
+            }
+        ]
+
     def test_python_metaclass_links(self, manager):
         wrapper = _parser(manager, "python")
         parser = PythonTreeSitterParser(wrapper)


### PR DESCRIPTION
Resolves [1272(https://github.com/CodeGraphContext/CodeGraphContext/issues/1272)

**Root cause**: `build_decorated_by_links()` assumed every parsed import had a source field. Python parser imports use `full_import_name instead`, so an imported decorator like `@dataclass` produced `local_imports["dataclass"] = None`, then crashed at `None.split(".")`

**What changed**:

Added shared import normalization for decorator/metaclass resolution in `CodeGraphContext/src/codegraphcontext/tools/indexing/resolution/inheritance.py#L311-L342`

- Uses `source` when present.
- Falls back to `full_import_name`.
- Falls back to `name`.
- Skips empty targets.

Reused that normalization for both `DECORATED_BY` and Python `METACLASS` link building in `CodeGraphContext/src/codegraphcontext/tools/indexing/resolution/inheritance.py#L353-L413`.

Added a regression test for Python imports without source in `CodeGraphContext/tests/unit/tools/test_cross_lang_call_resolution_patterns.py#L681-L723`

Amp-Thread-ID: https://ampcode.com/threads/T-019ed3c3-1f34-7278-87d8-1b741154a281