### PR TITLE
fix: guard against None import names causing AttributeError crashes

### DIFF
--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -529,7 +529,8 @@ class GraphBuilder:
             class_names = {c['name'] for c in file_data.get('classes', [])}
             local_names = func_names | class_names
             local_imports = {imp.get('alias') or imp['name'].split('.')[-1]: imp['name'] 
-                            for imp in file_data.get('imports', [])}
+                            for imp in file_data.get('imports', [])
+                            if imp.get('name') and not imp['name'].endswith('.*')}
             
             for call in file_data.get('function_calls', []):
                 resolved = self._resolve_function_call(

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -1753,7 +1753,7 @@ def build_function_call_groups(
         return {
             imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
             for imp in fd.get("imports", [])
-            if not imp["name"].endswith(".*")
+            if imp.get("name") and not imp["name"].endswith(".*")
         }
 
     def file_package(fd: Dict[str, Any]) -> Optional[str]:
@@ -2144,12 +2144,12 @@ def build_function_call_groups(
         local_imports = {
             imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
             for imp in file_data.get("imports", [])
-            if not imp["name"].endswith(".*")
+            if imp.get("name") and not imp["name"].endswith(".*")
         }
         wildcard_imports = [
             imp["name"][:-2]
             for imp in file_data.get("imports", [])
-            if imp["name"].endswith(".*")
+            if imp.get("name") and imp["name"].endswith(".*")
         ]
         if wildcard_imports:
             local_imports["__wildcards__"] = wildcard_imports

--- a/src/codegraphcontext/tools/indexing/resolution/inheritance.py
+++ b/src/codegraphcontext/tools/indexing/resolution/inheritance.py
@@ -91,6 +91,7 @@ def build_inheritance_and_csharp_files(
         local_imports = {
             imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
             for imp in file_data.get("imports", [])
+            if imp.get("name")
         }
 
         for key in ["classes", "structs", "traits", "interfaces", "mixins", "enums", "extensions", "variables"]:
@@ -320,10 +321,12 @@ def _resolve_decorator_path(
         return caller_path
     if decorator_name in local_imports:
         imported = local_imports[decorator_name]
-        lookup = imported.split(".")[-1]
-        paths = imports_map.get(lookup, imports_map.get(imported, []))
-        if len(paths) == 1:
-            return str(Path(paths[0]).resolve().as_posix())
+        # imported can be None when the import entry lacks both "source" and "full_import_name"
+        if imported:
+            lookup = imported.split(".")[-1]
+            paths = imports_map.get(lookup, imports_map.get(imported, []))
+            if len(paths) == 1:
+                return str(Path(paths[0]).resolve().as_posix())
     paths = imports_map.get(decorator_name, [])
     if len(paths) == 1:
         return str(Path(paths[0]).resolve().as_posix())
@@ -347,7 +350,7 @@ def build_decorated_by_links(
             if item.get("name")
         }
         local_imports = {
-            imp.get("alias") or imp.get("name"): imp.get("source")
+            imp.get("alias") or imp.get("name"): imp.get("source") or imp.get("full_import_name")
             for imp in file_data.get("imports", [])
             if imp.get("name") or imp.get("alias")
         }
@@ -403,7 +406,7 @@ def build_metaclass_links(
         caller_file_path = str(Path(file_data["path"]).resolve().as_posix())
         local_class_names = {c["name"] for c in file_data.get("classes", [])}
         local_imports = {
-            imp.get("alias") or imp.get("name"): imp.get("source")
+            imp.get("alias") or imp.get("name"): imp.get("source") or imp.get("full_import_name")
             for imp in file_data.get("imports", [])
             if imp.get("name") or imp.get("alias")
         }

--- a/src/codegraphcontext/tools/languages/elisp.py
+++ b/src/codegraphcontext/tools/languages/elisp.py
@@ -682,7 +682,7 @@ def pre_scan_elisp(files: list[Path], parser_wrapper) -> dict:
                     imports_map.setdefault(variable["name"], []).append(resolved_path)
 
             for imp in parser._find_imports(tree.root_node, is_dependency=False):
-                if imp.get("import_type") == "provide":
+                if imp.get("import_type") == "provide" and imp.get("name"):
                     imports_map.setdefault(imp["name"], []).append(resolved_path)
         except Exception as e:
             warning_logger(


### PR DESCRIPTION
## Summary

When `imp["name"]` is `None` (which can occur with certain relative/star/aliased import forms produced by tree-sitter parsers), calling `.split()` or `.endswith()` on it raises `AttributeError: 'NoneType' object has no attribute 'split'`, crashing indexing and `cgc watch`.

## Root Cause

Multiple locations across the codebase build `local_imports` dictionaries using dict comprehensions like:

```python
{imp.get("alias") or imp["name"].split(".")[-1]: imp["name"] for imp in file_data.get("imports", [])}
```

When an import entry has `"name": None`, the `.split()` call crashes. This affects:
- `graph_builder.py` — function call resolution
- `inheritance.py` — inheritance links and decorator path resolution
- `calls.py` — function call groups (both `file_local_imports` and inline comprehension)

Additionally, `_resolve_decorator_path` in `inheritance.py` accesses `local_imports[decorator_name]` and calls `.split()` on the value without a None guard. The `build_decorated_by_links` and `build_metaclass_links` functions construct `local_imports` using `imp.get("source")`, but Python parser imports lack a `"source"` field — so `imported` is always `None` for Python decorators/metaclasses.

## Changes

| File | Change |
|------|--------|
| `graph_builder.py` | Add `if imp.get('name')` guard + `not imp['name'].endswith('.*')` wildcard filter to `local_imports` |
| `inheritance.py` L91 | Add `if imp.get("name")` guard to `local_imports` dict comprehension |
| `inheritance.py` L322 | Guard `_resolve_decorator_path`: wrap `imported.split()` in `if imported:` block, fall through to `imports_map` lookup |
| `inheritance.py` L351, L407 | Use `imp.get("source") or imp.get("full_import_name")` as value in `local_imports` for `build_decorated_by_links` and `build_metaclass_links` — this fixes decorator/metaclass resolution for Python (which has `full_import_name` but not `source`) |
| `calls.py` L1754 | Add `imp.get("name") and` to `file_local_imports` filter condition |
| `calls.py` L2145, L2152 | Add `imp.get("name") and` to `local_imports` and `wildcard_imports` filter conditions |
| `elisp.py` L685 | Add defensive `and imp.get("name")` guard to `imports_map` pre-scan |

## Testing

- All 4 modified files pass `python -m py_compile` syntax checks
- The fix prevents `AttributeError` crashes on projects where parsers produce `None` import names
- The `full_import_name` fallback improves decorator/metaclass path resolution accuracy for Python projects

## Related Issues

- Fixes #1272 — `cgc watch` incremental indexing NoneType split crash
- Fixes #1285 — decorator path NoneType split crash
