### PR TITLE
fix: read COMPLEXITY_THRESHOLD from config instead of hardcoded default

### DIFF
--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -2508,7 +2508,7 @@ def analyze_inheritance_tree(
 @analyze_app.command("complexity")
 def analyze_complexity(
     path: Optional[str] = typer.Argument(None, help="Function name or file path to analyze"),
-    threshold: int = typer.Option(10, "--threshold", "-t", help="Complexity threshold for warnings"),
+    threshold: Optional[int] = typer.Option(None, "--threshold", "-t", help="Complexity threshold for warnings (default: from config or 10)"),
     limit: int = typer.Option(20, "--limit", "-l", help="Maximum results to show"),
     file: Optional[str] = typer.Option(None, "--file", "-f", help="Specific file path to scope analysis"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
@@ -2530,6 +2530,17 @@ def analyze_complexity(
     if not all(services[:3]):
         raise typer.Exit(code=1)
     db_manager, graph_builder, code_finder = services[:3]
+
+    # Read threshold from config if not explicitly provided via CLI
+    if threshold is None:
+        configured = config_manager.get_config_value("COMPLEXITY_THRESHOLD")
+        if configured is not None:
+            try:
+                threshold = int(configured)
+            except (ValueError, TypeError):
+                threshold = 10
+        else:
+            threshold = 10
 
     _FILE_EXTENSIONS = ('.py', '.js', '.ts', '.jsx', '.tsx', '.go', '.rs', '.rb',
                         '.java', '.cpp', '.c', '.cs', '.swift', '.kt', '.scala',


### PR DESCRIPTION
## Summary

The `cgc analyze complexity` command's `--threshold` option ignored the `COMPLEXITY_THRESHOLD` config value, always defaulting to hardcoded `10`.

## Root Cause

In `cli/main.py` line 2511, the threshold parameter was defined as:
```python
threshold: int = typer.Option(10, "--threshold", "-t", help="Complexity threshold for warnings")
```

The function body never called `config_manager.get_config_value("COMPLEXITY_THRESHOLD")` to override this default. So even if a user ran `cgc config set COMPLEXITY_THRESHOLD 15`, the CLI would still use `10`.

## Fix

Changed the default to `None` (making it `Optional[int]`) and added config-reading logic:

```python
threshold: Optional[int] = typer.Option(None, "--threshold", "-t",
    help="Complexity threshold for warnings (default: from config or 10)")
```

In the function body, when `threshold is None`:
1. Read `COMPLEXITY_THRESHOLD` from config
2. Parse to int, falling back to 10 on `ValueError`/`TypeError`
3. Default to 10 if config value is also missing

## Testing

- `py_compile` passes
- `cgc analyze complexity --help` shows updated description
- Manual verification: `cgc config set COMPLEXITY_THRESHOLD 15` now takes effect

## Impact

- Users who set `COMPLEXITY_THRESHOLD` via `cgc config set` will now see it applied
- Explicit `--threshold N` CLI flag still takes precedence (not `None`)
- Backward compatible: if neither config nor CLI flag is set, behavior is identical (default 10)
