### PR TITLE
fix(env): honor CGC_RUNTIME_DB_PATH env var in _default_global_db_path to fix MCP start failure

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -727,10 +727,17 @@ def _default_global_db_path(database: str) -> str:
 
     New layout: ``~/.codegraphcontext/global/db/<backend>/``
     For backward-compat, we check:
-    1. FALKORDB_PATH in config (if database is falkordb)
-    2. Legacy flat path
-    3. New layout default
+    1. CGC_RUNTIME_DB_PATH environment variable (highest priority — works for all DBs)
+    2. FALKORDB_PATH in config (if database is falkordb)
+    3. Legacy flat path
+    4. New layout default
     """
+    # Generic env var override — highest priority for any backend.
+    # Useful for relocating the global DB to a path that avoids platform-specific
+    # encoding issues (e.g. non-ASCII characters in the Windows user profile path).
+    env_override = os.environ.get("CGC_RUNTIME_DB_PATH")
+    if env_override:
+        return env_override
     if database == "falkordb":
         custom_path = load_config().get("FALKORDB_PATH")
         if custom_path:


### PR DESCRIPTION
The KuzuDB C++ engine cannot handle paths with non-ASCII characters, mirroring the same Windows limitation that already affects the LadybugDB engine in GitNexus.

## Root cause

The MCP server resolves its database path via `_default_global_db_path()`, which:

1. Only consulted `FALKORDB_PATH` for the falkordb backend.
2. Otherwise hardcoded `CONFIG_DIR / "global" / "db" / <backend>`, where `CONFIG_DIR` defaults to `~/.codegraphcontext` (i.e. `C:\Users\<name>\.codegraphcontext` on Windows).

Meanwhile, the CLI commands (`cgc index`, `cgc stats`) already honored `CGC_RUNTIME_DB_PATH` in `_initialize_services()` as the highest-priority override. The MCP server simply didn't check it, so even users who had relocated the DB via `.env` saw MCP crash on the default Chinese path.

## Fix

Read `CGC_RUNTIME_DB_PATH` first in `_default_global_db_path()`, before any backend-specific lookup. This keeps the MCP server consistent with the CLI's existing resolution order.

```python
env_override = os.environ.get("CGC_RUNTIME_DB_PATH")
if env_override:
    return env_override