### PR TITLE
perf(calls): make CALLS resolution linear instead of quadratic

### DIFF
--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -2,6 +2,7 @@
 """Heuristic resolution of function calls into CALLS edge payloads (no DB I/O)."""
 
 from collections import defaultdict
+from functools import lru_cache
 from pathlib import Path
 import re
 from typing import Any, Dict, List, Optional, Tuple
@@ -9,6 +10,20 @@ from typing import Any, Dict, List, Optional, Tuple
 from ....cli.config_manager import get_config_value
 from ...type_utils import strip_type_modifiers
 from ....utils.debug_log import info_logger
+
+
+@lru_cache(maxsize=None)
+def _resolved_posix(path: str) -> str:
+    """Memoized ``Path(path).resolve().as_posix()``.
+
+    The CALLS pass resolves the same handful of paths hundreds of thousands of
+    times; ``Path.resolve()`` hits the filesystem (``realpath``/``lstat``) on
+    every call. The mapping from a path string to its resolved POSIX form is
+    deterministic for the duration of an index run, so memoizing it is exact.
+    ``build_function_call_groups`` clears this cache on entry to stay fresh
+    across runs in long-lived processes.
+    """
+    return Path(path).resolve().as_posix()
 
 
 # Confidence score for each resolution tier.
@@ -679,7 +694,7 @@ def resolve_function_call(
         if not path:
             return line_hint, context_hint, False
 
-        candidates = function_index.get((Path(path).resolve().as_posix(), method_name), [])
+        candidates = function_index.get((_resolved_posix(path), method_name), [])
         if not candidates:
             return line_hint, context_hint, False
 
@@ -759,7 +774,7 @@ def resolve_function_call(
             return line_hint, False
 
         class_key = simple_type_key(class_name) or class_name
-        candidates = class_index.get((Path(path).resolve().as_posix(), class_key), [])
+        candidates = class_index.get((_resolved_posix(path), class_key), [])
         if not candidates:
             return None, False
 
@@ -1092,7 +1107,7 @@ def resolve_function_call(
         and called_name
         and (is_rust_super or call.get("caller_module_context"))
     ):
-        caller_fp = Path(caller_file_path).resolve().as_posix()
+        caller_fp = _resolved_posix(caller_file_path)
         candidates = function_index.get((caller_fp, called_name), [])
         if is_rust_super:
             caller_mod = call.get("caller_module_context") or ""
@@ -1114,7 +1129,7 @@ def resolve_function_call(
                 mod_matches = [mod_matches[0]]
         if len(mod_matches) == 1:
             match = mod_matches[0]
-            resolved_path = Path(match["path"]).resolve().as_posix()
+            resolved_path = _resolved_posix(match["path"])
             resolved_called_line_number = match.get("line_number")
             resolved_called_context = match.get("module_context")
             resolved_called_name = called_name
@@ -1188,11 +1203,11 @@ def resolve_function_call(
         and function_index
         and called_name == "specialized_action"
     ):
-        caller_fp = Path(caller_file_path).resolve().as_posix()
+        caller_fp = _resolved_posix(caller_file_path)
         candidates = function_index.get((caller_fp, called_name), [])
         if len(candidates) > 1:
             match = max(candidates, key=lambda c: c.get("line_number", 0))
-            resolved_path = Path(match["path"]).resolve().as_posix()
+            resolved_path = _resolved_posix(match["path"])
             resolved_called_line_number = match.get("line_number")
             resolved_called_context = match.get("module_context")
             resolved_called_name = called_name
@@ -1538,7 +1553,7 @@ def resolve_function_call(
     class_target_key = simple_type_key(resolved_called_name) or resolved_called_name
     target_is_class = bool(
         resolved_path
-        and class_index.get((Path(resolved_path).resolve().as_posix(), class_target_key), [])
+        and class_index.get((_resolved_posix(resolved_path), class_target_key), [])
     )
     if target_is_class:
         (
@@ -1586,7 +1601,7 @@ def resolve_function_call(
     if caller_context and len(caller_context) == 3 and caller_context[0] is not None:
         caller_name, caller_type, caller_line_number = caller_context
         if caller_type == "nested_call":
-            fp = Path(caller_file_path).resolve().as_posix()
+            fp = _resolved_posix(caller_file_path)
             candidates = function_index.get((fp, caller_name), [])
             if candidates:
                 lines = [
@@ -1645,6 +1660,10 @@ def build_function_call_groups(
     """
     skip_external = (get_config_value("SKIP_EXTERNAL_RESOLUTION") or "false").lower() == "true"
 
+    # Resolved-path memoization is keyed by raw path string; clear it per run so a
+    # long-lived process never serves stale results if files move between indexes.
+    _resolved_posix.cache_clear()
+
     if file_class_lookup is None:
         file_class_lookup = {}
 
@@ -1653,7 +1672,7 @@ def build_function_call_groups(
     # Symbols absent from this map are assumed to be Function nodes.
     file_symbol_labels: Dict[str, Dict[str, str]] = {}
     for fd in all_file_data:
-        fp = Path(fd["path"]).resolve().as_posix()
+        fp = _resolved_posix(fd["path"])
         sym_labels: Dict[str, str] = {}
         targets = {c["name"] for c in fd.get("classes", [])}
         for name in targets:
@@ -1911,7 +1930,7 @@ def build_function_call_groups(
         return list(dict.fromkeys(context_names))
 
     for fd in all_file_data:
-        file_path = Path(fd["path"]).resolve().as_posix()
+        file_path = _resolved_posix(fd["path"])
         package_name = file_package(fd)
         fd_local_imports = file_local_imports(fd)
         for class_data in fd.get("classes", []) + fd.get("interfaces", []) + fd.get("objects", []):
@@ -2082,16 +2101,21 @@ def build_function_call_groups(
         Tuple[str, str, str], List[Tuple[str, str, Optional[int]]]
     ] = defaultdict(list)
 
+    # Precompute name -> [(file_path, func)] once (O(F)). Previously functions_named
+    # scanned the entire function_index per call, making the callback-argument
+    # pre-pass O(total_calls x distinct_functions) -- the dominant cost on large
+    # repos. The build order matches the old per-call scan order exactly, so the
+    # resolved output is identical.
+    _functions_by_name: Dict[str, List[Tuple[str, Dict[str, Any]]]] = defaultdict(list)
+    for (_fpath, _fname), _funcs in function_index.items():
+        for _func in _funcs:
+            _functions_by_name[_fname].append((_fpath, _func))
+
     def functions_named(name: str) -> List[Tuple[str, Dict[str, Any]]]:
-        matches: List[Tuple[str, Dict[str, Any]]] = []
-        for (fpath, fname), funcs in function_index.items():
-            if fname == name:
-                for func in funcs:
-                    matches.append((fpath, func))
-        return matches
+        return _functions_by_name.get(name, [])
 
     for fd in all_file_data:
-        caller_fp = Path(fd["path"]).resolve().as_posix()
+        caller_fp = _resolved_posix(fd["path"])
         for call in fd.get("function_calls", []):
             callee_name = call.get("name")
             if not callee_name:
@@ -2118,7 +2142,7 @@ def build_function_call_groups(
                         )
 
     for idx, file_data in enumerate(all_file_data):
-        caller_file_path = Path(file_data["path"]).resolve().as_posix()
+        caller_file_path = _resolved_posix(file_data["path"])
         func_names = {f["name"] for f in file_data.get("functions", [])}
         class_names = {c["name"] for c in file_data.get("classes", [])}
         # Pre-sort functions by line range for O(log n) scope lookup via bisect.
@@ -2954,12 +2978,12 @@ def build_function_call_groups(
             if resolved["type"] == "function":
                 caller_fp_raw = resolved["caller_file_path"]
                 if caller_fp_raw.endswith(_CPP_EXTS):
-                    caller_fp = Path(caller_fp_raw).resolve().as_posix()
+                    caller_fp = _resolved_posix(caller_fp_raw)
                     caller_name = resolved["caller_name"]
                     resolved["caller_label"] = file_symbol_labels.get(caller_fp, {}).get(caller_name, "Function")
             called_fp_raw = resolved.get("called_file_path") or ""
             if called_fp_raw.endswith(_CPP_EXTS):
-                called_fp = Path(called_fp_raw).resolve().as_posix()
+                called_fp = _resolved_posix(called_fp_raw)
                 called_name = resolved["called_name"]
                 resolved["called_label"] = file_symbol_labels.get(called_fp, {}).get(called_name, "Function")
 
@@ -2977,7 +3001,7 @@ def build_function_call_groups(
                                 [],
                             )
                         for impl_fn in impl_entries:
-                            impl_path = Path(impl_fn["path"]).resolve().as_posix()
+                            impl_path = _resolved_posix(impl_fn["path"])
                             impl_line = impl_fn.get("line_number")
                             if (
                                 impl_path == resolved.get("called_file_path")
@@ -3015,11 +3039,11 @@ def build_function_call_groups(
         # Normalize paths for DB consistency (Windows: backslash → forward slash)
         caller_fp = edge.get("caller_file_path")
         if caller_fp:
-            edge["caller_file_path"] = Path(caller_fp).resolve().as_posix()
+            edge["caller_file_path"] = _resolved_posix(caller_fp)
         called_fp = edge.get("called_file_path")
         if called_fp:
-            edge["called_file_path"] = Path(called_fp).resolve().as_posix()
-        called_path = Path(edge.get("called_file_path", "")).resolve().as_posix()
+            edge["called_file_path"] = _resolved_posix(called_fp)
+        called_path = _resolved_posix(edge.get("called_file_path", ""))
         called_name = edge.get("called_name")
         target_label = file_symbol_labels.get(called_path, {}).get(called_name)
 


### PR DESCRIPTION
## Summary

`build_function_call_groups` (the CALLS-resolution pass) is **O(total_calls × distinct_functions)** on large repos, which makes it the dominant cost of indexing — on a 1,491-file Python repo this single pass took ~4.3 min of pure compute (and grows quadratically; larger repos effectively never finish). This PR makes it **linear** in repo size with **byte-identical output**.

`cProfile` on a 300-file slice (21s total) pinned two hot spots:

1. **`functions_named()` — ~48% of runtime.** It scanned the entire `function_index` on *every* call inside the callback-argument pre-pass → the quadratic. Fixed by precomputing a `name -> [(file_path, func)]` dict **once** (O(F)) and turning `functions_named` into a dict lookup. The dict is built by iterating `function_index.items()` in the same order the old per-call scan used, so results are order-for-order identical.
2. **`Path(x).resolve().as_posix()` — ~18%.** Called ~172k times, hitting the filesystem (`realpath`/`lstat`) repeatedly on the same handful of paths. Fixed by memoizing through a module-level `lru_cache` (`_resolved_posix`), cleared at the entry of `build_function_call_groups` so long-lived processes stay fresh if files move between runs.

Both changes are confined to `resolution/calls.py`, language-agnostic, and add no new dependencies (only `functools.lru_cache`).

## Benchmark

`build_function_call_groups` only (parsing excluded), real Python repo:

| files | before | after | speedup |
|------:|-------:|------:|--------:|
| 300   | 13.6s  | 1.4s  | ~10×    |
| 600   | 31.6s  | 2.4s  | ~12×    |
| 1,491 | 257.6s | 6.5s  | **39.5×** |

Before: 13.6 → 31.6 → 257s (quadratic). After: 1.4 → 2.4 → 6.5s (linear).

## Correctness

The parse phase is mildly nondeterministic, so equivalence was proven by parsing **once** and running the old vs. new `build_function_call_groups` on the **same in-memory input**. Every resolved edge — `type`, caller/called name + file + line, `called_context`, `resolution_tier`, `confidence`, `confidence_label`, and the C++ `caller_label`/`called_label` — is **identical** before and after.

Verified on **Python, JavaScript, and Java** samples (all IDENTICAL). The project's `tests/odoo/` suite (112 tests) passes; the pre-existing parser-golden failures in my working tree are unrelated (they fail identically without this change).

## Risk

Low. No behavioral change to resolution logic — only memoization of a pure path transform and a one-time precompute replacing a repeated linear scan.
