### PR TITLE
fix-issue-#1309: Improve tree-sitter parser dispatch errors

### DIFF
--- a/src/codegraphcontext/tools/tree_sitter_parser.py
+++ b/src/codegraphcontext/tools/tree_sitter_parser.py
@@ -2,117 +2,62 @@
 """Tree-sitter parser dispatch by language name."""
 
 from pathlib import Path
+from importlib import import_module
 from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     from tree_sitter import Language
 
-from ..utils.tree_sitter_manager import get_tree_sitter_manager
+from ..utils.tree_sitter_manager import LANGUAGE_ALIASES, get_tree_sitter_manager
+
+
+LANGUAGE_PARSER_CLASSES = {
+    "python": ("codegraphcontext.tools.languages.python", "PythonTreeSitterParser"),
+    "javascript": ("codegraphcontext.tools.languages.javascript", "JavascriptTreeSitterParser"),
+    "go": ("codegraphcontext.tools.languages.go", "GoTreeSitterParser"),
+    "typescript": ("codegraphcontext.tools.languages.typescript", "TypescriptTreeSitterParser"),
+    "tsx": ("codegraphcontext.tools.languages.typescriptjsx", "TypescriptJSXTreeSitterParser"),
+    "cpp": ("codegraphcontext.tools.languages.cpp", "CppTreeSitterParser"),
+    "rust": ("codegraphcontext.tools.languages.rust", "RustTreeSitterParser"),
+    "c": ("codegraphcontext.tools.languages.c", "CTreeSitterParser"),
+    "java": ("codegraphcontext.tools.languages.java", "JavaTreeSitterParser"),
+    "ruby": ("codegraphcontext.tools.languages.ruby", "RubyTreeSitterParser"),
+    "c_sharp": ("codegraphcontext.tools.languages.csharp", "CSharpTreeSitterParser"),
+    "php": ("codegraphcontext.tools.languages.php", "PhpTreeSitterParser"),
+    "lua": ("codegraphcontext.tools.languages.lua", "LuaTreeSitterParser"),
+    "kotlin": ("codegraphcontext.tools.languages.kotlin", "KotlinTreeSitterParser"),
+    "scala": ("codegraphcontext.tools.languages.scala", "ScalaTreeSitterParser"),
+    "swift": ("codegraphcontext.tools.languages.swift", "SwiftTreeSitterParser"),
+    "haskell": ("codegraphcontext.tools.languages.haskell", "HaskellTreeSitterParser"),
+    "dart": ("codegraphcontext.tools.languages.dart", "DartTreeSitterParser"),
+    "perl": ("codegraphcontext.tools.languages.perl", "PerlTreeSitterParser"),
+    "elixir": ("codegraphcontext.tools.languages.elixir", "ElixirTreeSitterParser"),
+    "elisp": ("codegraphcontext.tools.languages.elisp", "ElispTreeSitterParser"),
+    "html": ("codegraphcontext.tools.languages.html", "HTMLTreeSitterParser"),
+    "css": ("codegraphcontext.tools.languages.css", "CSSTreeSitterParser"),
+}
 
 
 class TreeSitterParser:
     """A generic parser wrapper for a specific language using tree-sitter."""
 
     def __init__(self, language_name: str):
-        self.language_name = language_name
+        self.language_name = LANGUAGE_ALIASES.get(language_name.lower())
+        if self.language_name not in LANGUAGE_PARSER_CLASSES:
+            supported_languages = ", ".join(sorted(LANGUAGE_PARSER_CLASSES))
+            raise ValueError(
+                f"Unsupported language parser: {language_name}. "
+                f"Supported languages: {supported_languages}"
+            )
+
         self.ts_manager = get_tree_sitter_manager()
 
         self.language: "Language" = self.ts_manager.get_language_safe(language_name)
         self.parser = self.ts_manager.create_parser(language_name)
 
-        self.language_specific_parser = None
-        if self.language_name == "python":
-            from .languages.python import PythonTreeSitterParser
-
-            self.language_specific_parser = PythonTreeSitterParser(self)
-        elif self.language_name == "javascript":
-            from .languages.javascript import JavascriptTreeSitterParser
-
-            self.language_specific_parser = JavascriptTreeSitterParser(self)
-        elif self.language_name == "go":
-            from .languages.go import GoTreeSitterParser
-
-            self.language_specific_parser = GoTreeSitterParser(self)
-        elif self.language_name == "typescript":
-            from .languages.typescript import TypescriptTreeSitterParser
-
-            self.language_specific_parser = TypescriptTreeSitterParser(self)
-        elif self.language_name == "tsx":
-            from .languages.typescriptjsx import TypescriptJSXTreeSitterParser
-
-            self.language_specific_parser = TypescriptJSXTreeSitterParser(self)
-        elif self.language_name == "cpp":
-            from .languages.cpp import CppTreeSitterParser
-
-            self.language_specific_parser = CppTreeSitterParser(self)
-        elif self.language_name == "rust":
-            from .languages.rust import RustTreeSitterParser
-
-            self.language_specific_parser = RustTreeSitterParser(self)
-        elif self.language_name == "c":
-            from .languages.c import CTreeSitterParser
-
-            self.language_specific_parser = CTreeSitterParser(self)
-        elif self.language_name == "java":
-            from .languages.java import JavaTreeSitterParser
-
-            self.language_specific_parser = JavaTreeSitterParser(self)
-        elif self.language_name == "ruby":
-            from .languages.ruby import RubyTreeSitterParser
-
-            self.language_specific_parser = RubyTreeSitterParser(self)
-        elif self.language_name == "c_sharp":
-            from .languages.csharp import CSharpTreeSitterParser
-
-            self.language_specific_parser = CSharpTreeSitterParser(self)
-        elif self.language_name == "php":
-            from .languages.php import PhpTreeSitterParser
-
-            self.language_specific_parser = PhpTreeSitterParser(self)
-        elif self.language_name == "lua":
-            from .languages.lua import LuaTreeSitterParser
-
-            self.language_specific_parser = LuaTreeSitterParser(self)
-        elif self.language_name == "kotlin":
-            from .languages.kotlin import KotlinTreeSitterParser
-
-            self.language_specific_parser = KotlinTreeSitterParser(self)
-        elif self.language_name == "scala":
-            from .languages.scala import ScalaTreeSitterParser
-
-            self.language_specific_parser = ScalaTreeSitterParser(self)
-        elif self.language_name == "swift":
-            from .languages.swift import SwiftTreeSitterParser
-
-            self.language_specific_parser = SwiftTreeSitterParser(self)
-        elif self.language_name == "haskell":
-            from .languages.haskell import HaskellTreeSitterParser
-
-            self.language_specific_parser = HaskellTreeSitterParser(self)
-        elif self.language_name == "dart":
-            from .languages.dart import DartTreeSitterParser
-
-            self.language_specific_parser = DartTreeSitterParser(self)
-        elif self.language_name == "perl":
-            from .languages.perl import PerlTreeSitterParser
-
-            self.language_specific_parser = PerlTreeSitterParser(self)
-        elif self.language_name == "elixir":
-            from .languages.elixir import ElixirTreeSitterParser
-
-            self.language_specific_parser = ElixirTreeSitterParser(self)
-        elif self.language_name == "elisp":
-            from .languages.elisp import ElispTreeSitterParser
-
-            self.language_specific_parser = ElispTreeSitterParser(self)
-        elif self.language_name == "html":
-            from .languages.html import HTMLTreeSitterParser
-
-            self.language_specific_parser = HTMLTreeSitterParser(self)
-        elif self.language_name == "css":
-            from .languages.css import CSSTreeSitterParser
-
-            self.language_specific_parser = CSSTreeSitterParser(self)
+        module_name, class_name = LANGUAGE_PARSER_CLASSES[self.language_name]
+        parser_class = getattr(import_module(module_name), class_name)
+        self.language_specific_parser = parser_class(self)
 
     def parse(self, path: Path, is_dependency: bool = False, **kwargs) -> Dict:
         """Dispatches parsing to the language-specific parser."""

--- a/tests/unit/parsers/test_tree_sitter_parser_dispatch.py
+++ b/tests/unit/parsers/test_tree_sitter_parser_dispatch.py
@@ -1,0 +1,9 @@
+import pytest
+
+from codegraphcontext.tools.tree_sitter_parser import TreeSitterParser
+
+
+def test_tree_sitter_parser_rejects_unknown_language_before_loading_grammar():
+    with pytest.raises(ValueError, match="Unsupported language parser: pythno"):
+        TreeSitterParser("pythno")
+


### PR DESCRIPTION
## What does this PR do?
Improves error handling and dispatch logic for tree-sitter language parsers.

Closes #1309 

Previously, `TreeSitterParser` used a long `if/elif` chain to choose the language-specific parser. If an unsupported or mistyped language name reached this dispatch layer, `language_specific_parser` could remain `None`, causing the failure to happen later with a less direct error.

This PR replaces the branch chain with a dictionary-based parser mapping and raises a clear `ValueError` when the language name is not supported. It also reuses the existing language alias normalization, so aliases like `py`, `ts`, and `c#` resolve consistently before parser dispatch.

## Type of change
- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [x] Other

## Checklist
- [ ] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Testing
- [x] Ran `.\.venv\Scripts\python.exe -m pytest tests\unit\parsers\test_tree_sitter_parser_dispatch.py`
- [x] Ran `.\.venv\Scripts\python.exe -m py_compile src\codegraphcontext\tools\tree_sitter_parser.py tests\unit\parsers\test_tree_sitter_parser_dispatch.py`
- [x] Ran `.\.venv\Scripts\python.exe -m ruff check src\codegraphcontext\tools\tree_sitter_parser.py tests\unit\parsers\test_tree_sitter_parser_dispatch.py`

Note: broader tree-sitter parser tests were limited locally because the current environment is Python 3.13 without the optional `tree_sitter` dependency available.

## Screenshots (if UI change)
Not applicable.