### PR TITLE
feat: Add Standardized ASCII Markdown Execution Summary Grid to CLI Indexing Success Exit  #1226

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -9,6 +9,7 @@ import time
 import os
 from typing import Optional, List, Dict, Any
 import typer
+from rich import box
 from rich.console import Console
 from rich.table import Table
 from rich.progress import (
@@ -82,6 +83,42 @@ def _print_call_resolution_diagnostics(graph_builder: GraphBuilder, limit: int =
             str(diagnostic.get("reason") or ""),
             f"{diagnostic.get('caller_file_path')}:{diagnostic.get('line_number')}",
         )
+    console.print(table)
+
+
+def _format_extension_counts(files_by_extension: Dict[str, int]) -> str:
+    if not files_by_extension:
+        return "None"
+    return ", ".join(
+        f"{extension}: {count}" for extension, count in files_by_extension.items()
+    )
+
+
+def _print_index_execution_summary(graph_builder: GraphBuilder) -> None:
+    summary = getattr(graph_builder, "last_index_summary", None)
+    if not summary:
+        return
+
+    table = Table(
+        title="CGC Index Execution Summary",
+        show_header=True,
+        header_style="bold cyan",
+        box=box.ASCII,
+    )
+    table.add_column("Metric", style="cyan", no_wrap=True)
+    table.add_column("Value", style="green", overflow="fold")
+    table.add_row("Total scanned files", str(summary.get("total_scanned_files", 0)))
+    table.add_row(
+        "Files by extension",
+        _format_extension_counts(summary.get("files_by_extension", {})),
+    )
+    table.add_row("Function nodes", str(summary.get("function_nodes", 0)))
+    table.add_row("Class nodes", str(summary.get("class_nodes", 0)))
+    table.add_row("CALLS edges", str(summary.get("call_edges", 0)))
+    table.add_row(
+        "Serialization seconds",
+        f"{summary.get('serialization_seconds', 0.0):.2f}",
+    )
     console.print(table)
 
 
@@ -315,6 +352,7 @@ def index_helper(path: str, context: Optional[str] = None):
         time_end = time.time()
         elapsed = time_end - time_start
         _print_call_resolution_diagnostics(graph_builder)
+        _print_index_execution_summary(graph_builder)
         console.print(f"[green]Successfully finished indexing: {path} in {elapsed:.2f} seconds[/green]")
         
         # Check if auto-watch is enabled
@@ -363,6 +401,7 @@ def add_package_helper(package_name: str, language: str, context: Optional[str] 
     try:
         asyncio.run(_run_index_with_progress(graph_builder, package_path, is_dependency=True, cgcignore_path=ctx.cgcignore_path))
         _print_call_resolution_diagnostics(graph_builder)
+        _print_index_execution_summary(graph_builder)
         console.print(f"[green]Successfully finished indexing package: {package_name}[/green]")
     except Exception as e:
         console.print(f"[bold red]An error occurred during package indexing:[/bold red] {e}")
@@ -666,6 +705,7 @@ def reindex_helper(path: str, context: Optional[str] = None):
         time_end = time.time()
         elapsed = time_end - time_start
         _print_call_resolution_diagnostics(graph_builder)
+        _print_index_execution_summary(graph_builder)
         console.print(f"[green]Successfully re-indexed: {path} in {elapsed:.2f} seconds[/green]")
     except Exception as e:
         console.print(f"[bold red]An error occurred during re-indexing:[/bold red] {e}")

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -57,6 +57,7 @@ class GraphBuilder:
         self.driver = self.db_manager.get_driver()
         self._writer = GraphWriter(self.driver, db_manager=self.db_manager)
         self.last_call_resolution_diagnostics: list[Dict[str, Any]] = []
+        self.last_index_summary: Dict[str, Any] = {}
         self.parsers = {
             ".py": "python",
             ".ipynb": "python",
@@ -1163,6 +1164,7 @@ class GraphBuilder:
                     )
 
             self.last_call_resolution_diagnostics = []
+            self.last_index_summary = {}
             await run_tree_sitter_index_async(
                 path,
                 is_dependency,
@@ -1175,6 +1177,7 @@ class GraphBuilder:
                 self.parse_file,
                 self.add_minimal_file_node,
                 call_resolution_diagnostics=self.last_call_resolution_diagnostics,
+                index_summary=self.last_index_summary,
             )
         except Exception as e:
             error_message = str(e)

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -29,6 +30,34 @@ from .resolution.inheritance import (
 )
 
 
+def build_index_summary(
+    files: List[Path],
+    parsers: Dict[str, str],
+    all_file_data: List[Dict[str, Any]],
+    resolved_call_groups: tuple,
+    serialization_seconds: float,
+) -> Dict[str, Any]:
+    """Build CLI-facing metrics for a completed Tree-sitter indexing run."""
+    extension_counts = Counter()
+    for file in files:
+        extension = file.suffix or file.name
+        language = parsers.get(file.suffix, "generic")
+        extension_counts[f"{extension} ({language})"] += 1
+
+    function_nodes = sum(len(file_data.get("functions", [])) for file_data in all_file_data)
+    class_nodes = sum(len(file_data.get("classes", [])) for file_data in all_file_data)
+    call_edges = sum(len(group) for group in resolved_call_groups)
+
+    return {
+        "total_scanned_files": len(files),
+        "files_by_extension": dict(sorted(extension_counts.items())),
+        "function_nodes": function_nodes,
+        "class_nodes": class_nodes,
+        "call_edges": call_edges,
+        "serialization_seconds": serialization_seconds,
+    }
+
+
 async def run_tree_sitter_index_async(
     path: Path,
     is_dependency: bool,
@@ -41,6 +70,7 @@ async def run_tree_sitter_index_async(
     parse_file: Callable[[Path, Path, bool], Dict[str, Any]],
     add_minimal_file_node: Callable[[Path, Path, bool], None],
     call_resolution_diagnostics: Optional[List[Dict[str, Any]]] = None,
+    index_summary: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Parse all discovered files, write symbols, then inheritance + CALLS."""
     if job_id:
@@ -101,6 +131,8 @@ async def run_tree_sitter_index_async(
         
         if processed_count % 50 == 0:
             info_logger(f"Processed {processed_count}/{len(files)} files...")
+
+    serialization_start = time.time()
 
     # Parsing remains concurrent, but graph writes are ordered so shared nodes
     # such as imported modules receive deterministic canonical metadata.
@@ -280,6 +312,18 @@ async def run_tree_sitter_index_async(
             info_logger(f"[INHERIT-RESOLVE] Post-resolution complete: {improved} edges improved")
         except Exception as _ie:
             info_logger(f"[INHERIT-RESOLVE] Post-resolution failed (skipping): {_ie}")
+
+    if index_summary is not None:
+        index_summary.clear()
+        index_summary.update(
+            build_index_summary(
+                files,
+                parsers,
+                all_file_data,
+                resolved_calls,
+                time.time() - serialization_start,
+            )
+        )
 
     if job_id:
         job_manager.update_job(job_id, status=JobStatus.COMPLETED, end_time=datetime.now())


### PR DESCRIPTION
## What does this PR do?
Adds a standardized ASCII execution summary grid after successful CLI indexing.

When developers run `cgc index .`, the CLI currently finishes with sequential plaintext logs. This PR adds a Rich-powered ASCII table at the successful indexing exit so users can quickly inspect key parsing metrics.
Closes #1226 

The summary includes:
- Total scanned files
- Scanned files grouped by extension and language
- Generated Function nodes
- Generated Class nodes
- Generated CALLS edges
- Serialization/write elapsed time in seconds

The metrics are collected from the Tree-sitter indexing lifecycle and rendered only from the normal CLI success path, keeping background/programmatic indexing paths unaffected.

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [x] Other

## Checklist
- [ ] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Testing
- [x] Ran `.\.venv\Scripts\python.exe -m py_compile src\codegraphcontext\tools\indexing\pipeline.py src\codegraphcontext\tools\graph_builder.py src\codegraphcontext\cli\cli_helpers.py`
- [x] Ran `.\.venv\Scripts\python.exe -m ruff check src\codegraphcontext\tools\indexing\pipeline.py`

Note: running Ruff across all touched files surfaces pre-existing unrelated lint issues in `cli_helpers.py` and `graph_builder.py`, so this PR avoids unrelated cleanup churn.

## Screenshots (if UI change)
Not applicable.