### PR TITLE
docs: Removed `--file` option from `find variable` command.

### DIFF
--- a/docs/CLI_COMPLETE_REFERENCE.md
+++ b/docs/CLI_COMPLETE_REFERENCE.md
@@ -65,7 +65,7 @@
 | `cgc find name` | `<name>` `--type` `--fuzzy/--no-fuzzy` | Find code elements by name. Fuzzy matching is on by default (configurable via `FUZZY_SEARCH`). |
 | `cgc find pattern` | `<pattern>` `--case-sensitive` | Find elements using fuzzy substring matching. |
 | `cgc find type` | `<type>` `--limit` | List all nodes of a specific type (function, class, module). |
-| `cgc find variable` | `<name>` `--file` | Find variables by name across the codebase. |
+| `cgc find variable` | `<name>` | Find variables by name across the codebase. |
 | `cgc find content` | `<text>` `--case-sensitive` | Search for text content within code (docstrings, comments). |
 | `cgc find decorator` | `<name>` | Find all functions/classes with a specific decorator. |
 | `cgc find argument` | `<name>` | Find all functions that have a specific argument name. |


### PR DESCRIPTION
### Summary

This PR removes the unsupported `--file` option from the `cgc find variable` command in the CLI documentation.

### Background

The current documentation incorrectly suggests that `cgc find variable` supports a `--file` option.
However, the actual CLI help output does not include this option.
 
```
$ uv run cgc version
CodeGraphContext 0.5.1

$ uv run cgc find variable --help
                                                                                                                      
 Usage: cgc find variable [OPTIONS] NAME                                                                              
                                                                                                                      
 Find variables by name.                                                                                              
                                                                                                                      
 Examples:                                                                                                            
 cgc find variable MAX_RETRIES                                                                                        
 cgc find variable config                                                                                             
                                                                                                                      
╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ *    name      TEXT  Variable name to search for [required]                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --context  -c      TEXT  Specific context to use                                                                   │
│ --help                   Show this message and exit.                                                               │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```