### PR TITLE
Fix Python graph builder crash: NoneType split during relationship resolution

### DIFF
--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -528,8 +528,9 @@ class GraphBuilder:
             func_names = {f['name'] for f in file_data.get('functions', [])}
             class_names = {c['name'] for c in file_data.get('classes', [])}
             local_names = func_names | class_names
-            local_imports = {imp.get('alias') or imp['name'].split('.')[-1]: imp['name'] 
-                            for imp in file_data.get('imports', [])}
+            local_imports = {imp.get('alias') or (imp.get('name') or '').split('.')[-1]: imp.get('name')
+                            for imp in file_data.get('imports', [])
+                            if imp.get('name')}
             
             for call in file_data.get('function_calls', []):
                 resolved = self._resolve_function_call(

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -1751,9 +1751,9 @@ def build_function_call_groups(
 
     def file_local_imports(fd: Dict[str, Any]) -> Dict[str, str]:
         return {
-            imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
+            imp.get("alias") or (imp.get("name") or "").split(".")[-1]: imp.get("name")
             for imp in fd.get("imports", [])
-            if not imp["name"].endswith(".*")
+            if imp.get("name") and not imp["name"].endswith(".*")
         }
 
     def file_package(fd: Dict[str, Any]) -> Optional[str]:
@@ -2142,9 +2142,9 @@ def build_function_call_groups(
             if c.get("trait_method_map")
         }
         local_imports = {
-            imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
+            imp.get("alias") or (imp.get("name") or "").split(".")[-1]: imp.get("name")
             for imp in file_data.get("imports", [])
-            if not imp["name"].endswith(".*")
+            if imp.get("name") and not imp["name"].endswith(".*")
         }
         wildcard_imports = [
             imp["name"][:-2]

--- a/src/codegraphcontext/tools/indexing/resolution/inheritance.py
+++ b/src/codegraphcontext/tools/indexing/resolution/inheritance.py
@@ -92,8 +92,9 @@ def build_inheritance_and_csharp_files(
                 local_class_names.add(item["name"])
 
         local_imports = {
-            imp.get("alias") or imp["name"].split(".")[-1]: imp["name"]
+            imp.get("alias") or (imp.get("name") or "").split(".")[-1]: imp.get("name")
             for imp in file_data.get("imports", [])
+            if imp.get("name")
         }
 
         for key in ["classes", "structs", "traits", "interfaces", "mixins", "enums", "extensions", "variables"]:
@@ -323,6 +324,8 @@ def _resolve_decorator_path(
         return caller_path
     if decorator_name in local_imports:
         imported = local_imports[decorator_name]
+        if not imported:
+            return caller_path
         lookup = imported.split(".")[-1]
         paths = imports_map.get(lookup, imports_map.get(imported, []))
         if len(paths) == 1:

--- a/src/codegraphcontext/tools/indexing/resolution/inheritance.py
+++ b/src/codegraphcontext/tools/indexing/resolution/inheritance.py
@@ -19,6 +19,9 @@ def resolve_inheritance_link(
     if base_class_str == "object":
         return None
 
+    if not base_class_str:
+        return None
+
     # Unwrap JS/TS mixins like Swimmable(Flyable(Person)) -> Person
     m = re.search(r'([A-Za-z0-9_.]+)(?:\s*\))*$', base_class_str)
     if m:
@@ -493,6 +496,8 @@ def build_embeds_links(
             if not struct_name:
                 continue
             for base in struct.get("bases") or []:
+                if not base:
+                    continue
                 base_name = base.split(".")[-1]
                 if base_name not in struct_names:
                     continue

--- a/src/codegraphcontext/tools/languages/python.py
+++ b/src/codegraphcontext/tools/languages/python.py
@@ -73,6 +73,8 @@ class PythonTreeSitterParser:
         self.parser = generic_parser_wrapper.parser
 
     def _get_node_text(self, node) -> str:
+        if node is None or node.text is None:
+            return ""
         return node.text.decode('utf-8')
 
     def _get_parent_context(self, node, types=('function_definition', 'class_definition')):


### PR DESCRIPTION
## Description

Fixes issue #1334 where the Python graph builder crashes with `'NoneType' object has no attribute 'split'` during post-parse relationship resolution.

## Root Cause

`_get_node_text()` in `tools/languages/python.py` returns `None` instead of `""` when a node's text is unavailable. This `None` propagates into the `bases` list in `_find_classes()`, then into inheritance resolution code.

## Changes

1. **`tools/languages/python.py`** — `_get_node_text()` now returns `""` instead of `None` when node text is unavailable
2. **`tools/indexing/resolution/inheritance.py`** — Added guard in `resolve_inheritance_link()` for `None` base_class_str before `.split()`
3. **`tools/indexing/resolution/inheritance.py`** — Added guard in `build_embeds_links()` for `None` entries in bases list

## Testing

- Wrote and ran direct unit tests on all 3 guards
- Cleared old KuzuDB index and re-indexed a 277-file Python project — no crash, indexing completes successfully
- `codegraphcontext stats` shows correct file/function/class counts
- Caller graph edges now populate correctly

Fixes #1334