### PR TITLE
Make local SCIP indexer subprocess timeout configurable

### DIFF
--- a/docs/docs/reference/config.md
+++ b/docs/docs/reference/config.md
@@ -104,6 +104,7 @@ cgc config reset
 | :--- | :--- | :--- |
 | **`SCIP_INDEXER`** | `false` | When `true`, enables SCIP-based symbol resolution. |
 | **`SCIP_LANGUAGES`** | `python,typescript,go,rust,java` | List of target languages to process via SCIP. |
+| **`SCIP_LOCAL_INDEXER_TIMEOUT_SECONDS`** | `300` | Timeout for the local SCIP indexer subprocess. Raise it for large repositories whose indexer runs longer than 5 minutes. Values `<= 0` or non-numeric fall back to `300`. |
 
 ---
 

--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -72,6 +72,7 @@ DEFAULT_CONFIG = {
     # SCIP indexer feature flag (default off — existing Tree-sitter behaviour unchanged)
     "SCIP_INDEXER": "false",
     "SCIP_LANGUAGES": "python,typescript,javascript,go,rust,java,dart,cpp,c,csharp",
+    "SCIP_LOCAL_INDEXER_TIMEOUT_SECONDS": "300",
     "SKIP_EXTERNAL_RESOLUTION": "false",
     # 0 = unlimited; any positive integer caps MCP tool response size.
     "MAX_TOOL_RESPONSE_TOKENS": "0",
@@ -113,6 +114,7 @@ CONFIG_DESCRIPTIONS = {
     "INDEX_SOURCE": "Store full source code in graph database (for faster indexing use false, for better performance use true)",
     "SCIP_INDEXER": "Use SCIP-based indexing for higher accuracy call/inheritance resolution (requires scip-<lang> tools installed)",
     "SCIP_LANGUAGES": "Comma-separated languages to index via SCIP when SCIP_INDEXER=true (python,typescript,javascript,go,rust,java,dart,cpp,c,csharp)",
+    "SCIP_LOCAL_INDEXER_TIMEOUT_SECONDS": "Timeout in seconds for the local SCIP indexer subprocess (default 300). Raise it for large repositories whose indexer runs longer than 5 minutes; a value <= 0 or non-numeric falls back to 300.",
     "SKIP_EXTERNAL_RESOLUTION": "Skip resolution attempts for external library method calls (recommended for enterprise large Java/Spring codebases)",
     "MAX_TOOL_RESPONSE_TOKENS": "Maximum tokens per MCP tool response (0 = unlimited). Truncates oversized payloads and appends a notice.",
     "TOOL_RESULT_LIMITS": "JSON object mapping tool names to max result counts, e.g. {\"find_code\": 20, \"analyze_code_relationships\": 10}. Missing keys use built-in defaults.",

--- a/src/codegraphcontext/tools/scip_indexer.py
+++ b/src/codegraphcontext/tools/scip_indexer.py
@@ -84,6 +84,25 @@ EXTENSION_TO_SCIP: Dict[str, Tuple[str, str, str, str]] = {
 }
 
 
+def _resolve_scip_timeout(default: int = 300) -> int:
+    """Return the timeout (seconds) for the local SCIP indexer subprocess.
+
+    Reads ``SCIP_LOCAL_INDEXER_TIMEOUT_SECONDS`` from the CGC config at call time (so live
+    config changes are respected without a server restart). Falls back to
+    *default* when the value is unset, non-numeric, or not positive.
+    """
+    from ..cli.config_manager import get_config_value
+
+    raw = get_config_value("SCIP_LOCAL_INDEXER_TIMEOUT_SECONDS")
+    if raw is None:
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (ValueError, TypeError):
+        return default
+    return value if value > 0 else default
+
+
 def is_scip_available(lang: str) -> bool:
     """Check whether the SCIP indexer (binary or docker) for this language is available."""
     has_docker = shutil.which("docker") is not None
@@ -149,7 +168,7 @@ class ScipIndexer:
                     cwd=str(project_path),
                     capture_output=True,
                     text=True,
-                    timeout=300,
+                    timeout=_resolve_scip_timeout(),
                 )
                 if result.returncode == 0 and output_file.exists():
                     info_logger(f"SCIP index written to {output_file}")


### PR DESCRIPTION
The local SCIP indexer subprocess was capped at a hardcoded 300s. Large repositories whose indexer runs longer than 5 minutes were killed and silently fell back to Tree-sitter.
This PR adds a new timeout config key (default 300, so existing behaviour is unchanged)
I've been trying to index a large repository, but it kept failing due to this 5-minute hardcoded timeout, which was quite blocking for me. I'm really glad to see this PR introduce the timeout so I can finally customize it.