### PR TITLE
Detect TypeScript monorepo workspaces for scip-typescript

### DIFF
--- a/src/codegraphcontext/tools/scip_indexer.py
+++ b/src/codegraphcontext/tools/scip_indexer.py
@@ -121,6 +121,21 @@ def detect_project_lang(path: Path, scip_languages: List[str]) -> Optional[str]:
     return max(counts, key=counts.get)
 
 
+def _package_json_has_workspaces(package_json: Path) -> bool:
+    """True if package.json declares a `workspaces` field (yarn or npm workspaces).
+
+    yarn and npm share the same `workspaces` key (an array of globs, or an object
+    with a `packages` array). scip-typescript reads it via --yarn-workspaces;
+    there is no npm-specific flag. Fails closed on missing/invalid JSON.
+    """
+    try:
+        with open(package_json, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return False
+    return bool(isinstance(data, dict) and data.get("workspaces"))
+
+
 class ScipIndexer:
     """
     Handles running the external SCIP indexer binaries.
@@ -371,6 +386,14 @@ class ScipIndexer:
             return [binary, "index", ".", "--output", out]
 
         elif lang == "typescript":
+            # A monorepo has no root tsconfig.json — its packages are enumerated by
+            # pnpm-workspace.yaml or a package.json `workspaces` field — so the bare
+            # `index` fails and CGC silently falls back to Tree-sitter. Pass the
+            # matching workspace flag; single-project behaviour is unchanged.
+            if (project_path / "pnpm-workspace.yaml").exists():
+                return [binary, "index", "--pnpm-workspaces", "--output", out]
+            if _package_json_has_workspaces(project_path / "package.json"):
+                return [binary, "index", "--yarn-workspaces", "--output", out]
             return [binary, "index", "--output", out]
 
         elif lang == "javascript":

--- a/tests/unit/tools/test_scip_indexer_ts_workspaces.py
+++ b/tests/unit/tools/test_scip_indexer_ts_workspaces.py
@@ -1,0 +1,68 @@
+"""Unit tests for scip-typescript workspace detection in ScipIndexer._build_command."""
+
+import json
+from pathlib import Path
+
+from codegraphcontext.tools.scip_indexer import ScipIndexer
+
+
+def _ts_cmd(project_path: Path) -> list:
+    out = project_path / "index.scip"
+    return ScipIndexer()._build_command("typescript", "scip-typescript", project_path, out)
+
+
+# --- pnpm ------------------------------------------------------------------
+
+def test_pnpm_workspace(tmp_path: Path) -> None:
+    (tmp_path / "pnpm-workspace.yaml").write_text("packages:\n  - 'packages/*'\n")
+    assert "--pnpm-workspaces" in _ts_cmd(tmp_path)
+
+
+def test_pnpm_takes_precedence_over_root_tsconfig(tmp_path: Path) -> None:
+    (tmp_path / "pnpm-workspace.yaml").write_text("packages:\n  - 'packages/*'\n")
+    (tmp_path / "tsconfig.json").write_text("{}")
+    cmd = _ts_cmd(tmp_path)
+    assert "--pnpm-workspaces" in cmd
+    assert "--yarn-workspaces" not in cmd
+
+
+def test_pnpm_wins_over_package_json_workspaces(tmp_path: Path) -> None:
+    (tmp_path / "pnpm-workspace.yaml").write_text("packages:\n  - 'p/*'\n")
+    (tmp_path / "package.json").write_text(json.dumps({"workspaces": ["p/*"]}))
+    assert "--pnpm-workspaces" in _ts_cmd(tmp_path)
+
+
+# --- yarn / npm (shared `workspaces` field) --------------------------------
+
+def test_yarn_npm_workspaces_array_form(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(json.dumps({"workspaces": ["packages/*"]}))
+    assert "--yarn-workspaces" in _ts_cmd(tmp_path)
+
+
+def test_yarn_workspaces_object_form(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(json.dumps({"workspaces": {"packages": ["a"]}}))
+    assert "--yarn-workspaces" in _ts_cmd(tmp_path)
+
+
+# --- single project --------------------------------------------------------
+
+def test_single_project_with_tsconfig(tmp_path: Path) -> None:
+    (tmp_path / "tsconfig.json").write_text("{}")
+    out = tmp_path / "index.scip"
+    assert _ts_cmd(tmp_path) == ["scip-typescript", "index", "--output", str(out)]
+
+
+def test_package_json_without_workspaces_is_not_a_monorepo(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(json.dumps({"name": "app", "version": "1.0.0"}))
+    (tmp_path / "tsconfig.json").write_text("{}")
+    cmd = _ts_cmd(tmp_path)
+    assert "--yarn-workspaces" not in cmd
+    assert "--pnpm-workspaces" not in cmd
+
+
+# --- robustness ------------------------------------------------------------
+
+def test_malformed_package_json_fails_closed(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text("{ this is not valid json ")
+    out = tmp_path / "index.scip"
+    assert _ts_cmd(tmp_path) == ["scip-typescript", "index", "--output", str(out)]


### PR DESCRIPTION
This PR detects the workspace layout (like pnpm-workspace.yaml or package.json workspaces) to automatically pass the correct flags (--pnpm-workspaces / --yarn-workspaces), enabling proper SCIP indexing for TypeScript monorepos.
In my case, I was trying to use this on a TypeScript monorepo, but the bare index command failed and it silently fell back to Tree-sitter, which was quite problematic. This change seems absolutely correct to me, but could you please verify if this is the intended direction?