### PR TITLE
Fix decorator resolution when import source is missing

### DIFF
--- a/src/codegraphcontext/tools/indexing/resolution/inheritance.py
+++ b/src/codegraphcontext/tools/indexing/resolution/inheritance.py
@@ -324,7 +324,7 @@ def _resolve_decorator_path(
         return caller_path
     if decorator_name in local_imports:
         imported = local_imports[decorator_name]
-        if not imported:
+        if not isinstance(imported, str) or not imported:
             return caller_path
         lookup = imported.split(".")[-1]
         paths = imports_map.get(lookup, imports_map.get(imported, []))

--- a/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
+++ b/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
@@ -678,6 +678,41 @@ class TestCrossLangCallResolutionPatterns:
         )
         assert edge["line_number"] == 363
 
+    def test_python_decorator_resolution_handles_missing_import_source(self):
+        caller_path = "/tmp/repo/app/service.py"
+        decorator_path = "/tmp/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py"
+        file_data = {
+            "path": caller_path,
+            "lang": "python",
+            "functions": [
+                {
+                    "name": "fetch_data",
+                    "line_number": 12,
+                    "decorators": ["@retry(stop=stop_after_attempt(3))"],
+                }
+            ],
+            "classes": [],
+            "imports": [
+                {
+                    "name": "retry",
+                    "full_import_name": "tenacity.retry",
+                    "line_number": 1,
+                    "alias": None,
+                }
+            ],
+        }
+
+        edges = build_decorated_by_links(
+            [file_data],
+            {"retry": [decorator_path]},
+        )
+
+        assert len(edges) == 1
+        edge = edges[0]
+        assert edge["decorated_name"] == "fetch_data"
+        assert edge["decorator_name"] == "retry"
+        assert edge["decorator_path"] == str(Path(caller_path).resolve().as_posix())
+
     def test_python_metaclass_links(self, manager):
         wrapper = _parser(manager, "python")
         parser = PythonTreeSitterParser(wrapper)


### PR DESCRIPTION
## What does this PR do?

Fixes a `cgc index` crash during Python decorator relationship resolution when parsed import metadata contains a decorator/import name but no `source` value.

Previously, `build_decorated_by_links()` built `local_imports` from import metadata using `imp.get("source")` as the value. When `source` was missing, `_resolve_decorator_path()` could receive `None` for an imported decorator and then call `.split(".")`, aborting indexing.

This PR adds a guard in `_resolve_decorator_path()` so empty or non-string import values safely fall back to the caller file path instead of crashing.

## Type of change

- Bug fix

## Testing

- `.venv/bin/python -m pytest tests/unit/tools/test_cross_lang_call_resolution_patterns.py::TestCrossLangCallResolutionPatterns::test_python_decorator_resolution_handles_missing_import_source`

## Screenshots

N/A. Backend/indexing bug fix with no UI changes.