### PR TITLE
Skip SCIP documents outside the project root instead of crashing ingest

### DIFF
--- a/src/codegraphcontext/tools/indexing/scip_pipeline.py
+++ b/src/codegraphcontext/tools/indexing/scip_pipeline.py
@@ -71,14 +71,15 @@ async def run_scip_index_async(
         warning_logger(f"Could not load/create .cgcignore for SCIP indexing: {e}")
 
     def should_skip_file(file_path: Path) -> bool:
+        # SCIP indexes can reference documents outside the project root,
+        # e.g. scip-go emits Go build cache paths for cgo/generated code.
+        if not file_path.is_relative_to(index_root):
+            return True
         if file_path.is_file() and file_path_has_ignore_dir_segment(file_path, index_root):
             return True
         if not ignore_spec:
             return False
-        try:
-            rel_path = file_path.relative_to(index_root).as_posix()
-        except ValueError:
-            return False
+        rel_path = file_path.relative_to(index_root).as_posix()
         return ignore_spec.match_file(rel_path)
 
     try:
@@ -98,12 +99,11 @@ async def run_scip_index_async(
             raise RuntimeError("SCIP parse returned empty result")
 
         files_data = scip_data.get("files", {})
-        if ignore_spec:
-            files_data = {
-                abs_path_str: file_data
-                for abs_path_str, file_data in files_data.items()
-                if not should_skip_file(Path(abs_path_str))
-            }
+        files_data = {
+            abs_path_str: file_data
+            for abs_path_str, file_data in files_data.items()
+            if not should_skip_file(Path(abs_path_str))
+        }
         file_paths = [Path(p) for p in files_data.keys() if Path(p).exists()]
 
         imports_map = pre_scan_for_imports(file_paths, parsers_keys, get_parser)

--- a/tests/unit/tools/test_scip_pipeline_cgcignore.py
+++ b/tests/unit/tools/test_scip_pipeline_cgcignore.py
@@ -100,3 +100,123 @@ async def test_scip_pipeline_respects_root_directory_cgcignore_pattern(tmp_path:
     ]
     assert str(tracked_file.resolve()) in indexed_paths
     assert str(ignored_file.resolve()) not in indexed_paths
+
+
+def _file_entry(path: Path) -> dict:
+    return {
+        "path": str(path),
+        "functions": [],
+        "classes": [],
+        "imports": [],
+        "function_calls_scip": [],
+        "module_level_calls_scip": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_scip_pipeline_skips_documents_outside_project_root(tmp_path: Path):
+    """SCIP indexes (e.g. scip-go with cgo) can reference files outside the
+    project root, such as Go build cache artifacts. These must be filtered
+    out instead of crashing the ingest with ValueError in relative_to()."""
+    repo = tmp_path / "repo"
+    src_dir = repo / "src"
+    src_dir.mkdir(parents=True)
+
+    tracked_file = src_dir / "app.py"
+    tracked_file.write_text("print('tracked')\n", encoding="utf-8")
+
+    # Simulates a cgo artifact in the Go build cache, outside the repo.
+    build_cache_dir = tmp_path / "go-build" / "6a"
+    build_cache_dir.mkdir(parents=True)
+    out_of_root_file = build_cache_dir / "6a390ec986-d"
+    out_of_root_file.write_text("// cgo generated\n", encoding="utf-8")
+
+    fake_parser_mod = SimpleNamespace(
+        ScipIndexer=_FakeScipIndexer,
+        ScipIndexParser=_FakeScipIndexParser,
+    )
+    _FakeScipIndexParser.files_data = {
+        str(tracked_file.resolve()): _file_entry(tracked_file.resolve()),
+        str(out_of_root_file.resolve()): _file_entry(out_of_root_file.resolve()),
+    }
+
+    writer = MagicMock()
+    job_manager = MagicMock()
+
+    with patch(
+        "codegraphcontext.tools.indexing.scip_pipeline.pre_scan_for_imports",
+        return_value={},
+    ):
+        await run_scip_index_async(
+            repo,
+            is_dependency=False,
+            job_id=None,
+            lang="python",
+            writer=writer,
+            job_manager=job_manager,
+            parsers_keys={".py"},
+            get_parser=lambda _suffix: _FakeParser(),
+            scip_indexer_mod=fake_parser_mod,
+        )
+
+    indexed_paths = [
+        call.args[0]["path"]
+        for call in writer.add_file_to_graph.call_args_list
+    ]
+    assert str(tracked_file.resolve()) in indexed_paths
+    assert str(out_of_root_file.resolve()) not in indexed_paths
+
+
+@pytest.mark.asyncio
+async def test_scip_pipeline_skips_out_of_root_documents_without_ignore_spec(tmp_path: Path):
+    """The out-of-root filter must apply even when no ignore spec could be
+    built (build_ignore_spec failed with OSError)."""
+    repo = tmp_path / "repo"
+    src_dir = repo / "src"
+    src_dir.mkdir(parents=True)
+
+    tracked_file = src_dir / "app.py"
+    tracked_file.write_text("print('tracked')\n", encoding="utf-8")
+
+    build_cache_dir = tmp_path / "go-build" / "5c"
+    build_cache_dir.mkdir(parents=True)
+    out_of_root_file = build_cache_dir / "5c1f2e3d4b-d"
+    out_of_root_file.write_text("// cgo generated\n", encoding="utf-8")
+
+    fake_parser_mod = SimpleNamespace(
+        ScipIndexer=_FakeScipIndexer,
+        ScipIndexParser=_FakeScipIndexParser,
+    )
+    _FakeScipIndexParser.files_data = {
+        str(tracked_file.resolve()): _file_entry(tracked_file.resolve()),
+        str(out_of_root_file.resolve()): _file_entry(out_of_root_file.resolve()),
+    }
+
+    writer = MagicMock()
+    job_manager = MagicMock()
+
+    with patch(
+        "codegraphcontext.tools.indexing.scip_pipeline.pre_scan_for_imports",
+        return_value={},
+    ), patch(
+        "codegraphcontext.tools.indexing.scip_pipeline.build_ignore_spec",
+        side_effect=OSError("cannot create .cgcignore"),
+    ):
+        await run_scip_index_async(
+            repo,
+            is_dependency=False,
+            job_id=None,
+            lang="python",
+            writer=writer,
+            job_manager=job_manager,
+            parsers_keys={".py"},
+            get_parser=lambda _suffix: _FakeParser(),
+            scip_indexer_mod=fake_parser_mod,
+        )
+
+    indexed_paths = [
+        call.args[0]["path"]
+        for call in writer.add_file_to_graph.call_args_list
+    ]
+    assert str(tracked_file.resolve()) in indexed_paths
+    assert str(out_of_root_file.resolve()) not in indexed_paths


### PR DESCRIPTION
This PR fixes an issue where the ingest process aborts and leaves the database nearly empty when SCIP indexes reference files outside the project root (such as Go build cache paths for cgo or generated code).

Fix by rejecting out-of-root paths at the ingest filter, and apply the filter unconditionally (previously it was skipped entirely when no ignore spec was built), since the out-of-root check is independent of .cgcignore. Follow-up to https://github.com/CodeGraphContext/CodeGraphContext/issues/1073, which fixed the adjacent ignored-directory bypass in the same filter.