### PR TITLE
feat: add critical_logger() to debug_log.py for complete log level coverage

### DIFF
--- a/src/codegraphcontext/utils/debug_log.py
+++ b/src/codegraphcontext/utils/debug_log.py
@@ -89,3 +89,8 @@ def debug_logger(msg):
     """Log debug message if log level allows"""
     if _should_log('DEBUG'):
         return logger.debug(msg)
+
+def critical_logger(msg):
+    """Log critical message if log level allows"""
+    if _should_log('CRITICAL'):
+        return logger.critical(msg)

--- a/tests/unit/utils/test_debug_log.py
+++ b/tests/unit/utils/test_debug_log.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+from codegraphcontext.utils.debug_log import (
+    critical_logger,
+    info_logger,
+    error_logger,
+    warning_logger,
+    debug_logger,
+)
+
+
+def test_critical_logger_exists():
+    assert callable(critical_logger)
+
+
+def test_critical_logger_calls_logger_critical():
+    with patch("codegraphcontext.utils.debug_log.logger") as mock_logger:
+        with patch("codegraphcontext.utils.debug_log._should_log", return_value=True):
+            critical_logger("test critical message")
+    mock_logger.critical.assert_called_once_with("test critical message")
+
+
+def test_critical_logger_respects_should_log_false():
+    with patch("codegraphcontext.utils.debug_log.logger") as mock_logger:
+        with patch("codegraphcontext.utils.debug_log._should_log", return_value=False):
+            critical_logger("should not be logged")
+    mock_logger.critical.assert_not_called()
+
+
+def test_critical_logger_checks_correct_level():
+    with patch("codegraphcontext.utils.debug_log._should_log", return_value=False) as mock_should_log:
+        with patch("codegraphcontext.utils.debug_log.logger"):
+            critical_logger("test")
+    mock_should_log.assert_called_once_with("CRITICAL")
+
+
+def test_critical_logger_returns_none_when_suppressed():
+    with patch("codegraphcontext.utils.debug_log._should_log", return_value=False):
+        result = critical_logger("suppressed")
+    assert result is None
+
+
+def test_all_loggers_consistent_pattern():
+    with patch("codegraphcontext.utils.debug_log.logger") as mock_logger:
+        with patch("codegraphcontext.utils.debug_log._should_log", return_value=True):
+            critical_logger("c")
+            info_logger("i")
+            error_logger("e")
+            warning_logger("w")
+    mock_logger.critical.assert_called_once_with("c")
+    mock_logger.info.assert_called_once_with("i")
+    mock_logger.error.assert_called_once_with("e")
+    mock_logger.warning.assert_called_once_with("w")


### PR DESCRIPTION
## Summary
Closes #1232

`src/codegraphcontext/utils/debug_log.py` already defines `LOG_LEVELS` with
`CRITICAL` included and provides `info_logger()`, `error_logger()`,
`warning_logger()`, and `debug_logger()` — but `critical_logger()` was missing,
leaving the log level coverage incomplete.

## Changes
- Added `critical_logger(msg)` to `debug_log.py` following the exact same
  pattern as all existing logger functions: `_should_log('CRITICAL')` guard
  then `logger.critical(msg)`
- Added `tests/unit/utils/test_debug_log.py` with 6 unit tests covering:
  - Function is callable
  - Calls `logger.critical()` with the correct message
  - Respects `_should_log()` returning `False` (nothing logged)
  - Passes `'CRITICAL'` level string to `_should_log()`
  - Returns `None` when suppressed
  - Consistent behaviour with `info_logger`, `error_logger`, `warning_logger`

## Testing
All 6 new unit tests pass locally. No existing tests affected.