### PR TITLE
fix: add missing `self` parameter to get_cypher_query() in placeholder language toolkits

### DIFF
--- a/src/codegraphcontext/tools/query_tool_languages/c_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/c_toolkit.py
@@ -2,5 +2,5 @@
 class CToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/csharp_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/csharp_toolkit.py
@@ -2,5 +2,5 @@
 class CSharpToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/dart_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/dart_toolkit.py
@@ -2,5 +2,5 @@
 class DartToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/go_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/go_toolkit.py
@@ -2,5 +2,5 @@
 class GoToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/haskell_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/haskell_toolkit.py
@@ -1,6 +1,6 @@
 # src/codegraphcontext/tools/query_tool_languages/haskell_toolkit.py
 class HaskellToolkit:
-    """ Template placeholder for future implementation."""
-    
-    def get_cypher_query(query: str) -> str:
+    """Template placeholder for future implementation."""
+
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/javascript_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/javascript_toolkit.py
@@ -2,5 +2,5 @@
 class JavascriptToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/perl_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/perl_toolkit.py
@@ -2,5 +2,5 @@
 class PerlToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/python_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/python_toolkit.py
@@ -2,5 +2,5 @@
 class PythonToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/ruby_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/ruby_toolkit.py
@@ -2,5 +2,5 @@
 class RubyToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/rust_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/rust_toolkit.py
@@ -2,5 +2,5 @@
 class RustToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/scala_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/scala_toolkit.py
@@ -2,5 +2,5 @@
 class ScalaToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/swift_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/swift_toolkit.py
@@ -2,5 +2,5 @@
 class SwiftToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/src/codegraphcontext/tools/query_tool_languages/typescript_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/typescript_toolkit.py
@@ -2,5 +2,5 @@
 class TypescriptToolkit:
     """Template placeholder for future implementation."""
 
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")

--- a/tests/unit/tools/test_placeholder_toolkits.py
+++ b/tests/unit/tools/test_placeholder_toolkits.py
@@ -1,0 +1,68 @@
+# tests/unit/tools/test_placeholder_toolkits.py
+"""
+Regression tests for issue #1281.
+
+Placeholder language toolkits previously defined get_cypher_query() without
+a `self` parameter, causing TypeError when called as an instance method.
+"""
+import pytest
+
+from codegraphcontext.tools.query_tool_languages.c_toolkit import CToolkit
+from codegraphcontext.tools.query_tool_languages.python_toolkit import PythonToolkit
+from codegraphcontext.tools.query_tool_languages.go_toolkit import GoToolkit
+from codegraphcontext.tools.query_tool_languages.rust_toolkit import RustToolkit
+from codegraphcontext.tools.query_tool_languages.ruby_toolkit import RubyToolkit
+from codegraphcontext.tools.query_tool_languages.typescript_toolkit import TypescriptToolkit
+from codegraphcontext.tools.query_tool_languages.javascript_toolkit import JavascriptToolkit
+from codegraphcontext.tools.query_tool_languages.csharp_toolkit import CSharpToolkit
+from codegraphcontext.tools.query_tool_languages.dart_toolkit import DartToolkit
+from codegraphcontext.tools.query_tool_languages.perl_toolkit import PerlToolkit
+
+
+PLACEHOLDER_TOOLKITS = [
+    CToolkit,
+    PythonToolkit,
+    GoToolkit,
+    RustToolkit,
+    RubyToolkit,
+    TypescriptToolkit,
+    JavascriptToolkit,
+    CSharpToolkit,
+    DartToolkit,
+    PerlToolkit,
+]
+
+
+@pytest.mark.parametrize("toolkit_class", PLACEHOLDER_TOOLKITS)
+def test_get_cypher_query_raises_not_implemented_not_type_error(toolkit_class):
+    """
+    Before the fix, calling instance.get_cypher_query('Function') raised:
+        TypeError: get_cypher_query() takes 1 positional argument but 2 were given
+    After the fix it must raise NotImplementedError instead.
+    """
+    instance = toolkit_class()
+    with pytest.raises(NotImplementedError):
+        instance.get_cypher_query("Function")
+
+
+@pytest.mark.parametrize("toolkit_class", PLACEHOLDER_TOOLKITS)
+def test_get_cypher_query_error_message(toolkit_class):
+    """NotImplementedError message must contain the expected text."""
+    instance = toolkit_class()
+    with pytest.raises(NotImplementedError, match="AdvancedLanguageQuery is not implemented yet"):
+        instance.get_cypher_query("Class")
+
+
+@pytest.mark.parametrize("toolkit_class", PLACEHOLDER_TOOLKITS)
+def test_toolkit_instantiates_without_arguments(toolkit_class):
+    """Placeholder toolkits must be instantiable with no arguments."""
+    instance = toolkit_class()
+    assert instance is not None
+
+
+def test_all_placeholder_toolkits_have_get_cypher_query():
+    """Every placeholder toolkit must define get_cypher_query as an attribute."""
+    for toolkit_class in PLACEHOLDER_TOOLKITS:
+        assert hasattr(toolkit_class, "get_cypher_query"), (
+            f"{toolkit_class.__name__} is missing get_cypher_query"
+        )


### PR DESCRIPTION
## Summary
Closes #1281

## Bug

Placeholder language toolkit classes defined `get_cypher_query()` without
a `self` parameter:

```python
# BEFORE — broken
def get_cypher_query(query: str) -> str:
    raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")
```

When `Advanced_language_query.advanced_language_query()` calls
`self.toolkit.get_cypher_query(label)`, Python automatically passes the
instance as the first argument — but with no `self` in the signature, this
crashes immediately with:
TypeError: get_cypher_query() takes 1 positional argument but 2 were given

This means every language except Java (which has a full implementation)
was completely broken at runtime.

## Fix

Added `self` to `get_cypher_query()` in all 13 affected placeholder files:
`c_toolkit.py`, `python_toolkit.py`, `go_toolkit.py`, `rust_toolkit.py`,
`ruby_toolkit.py`, `typescript_toolkit.py`, `javascript_toolkit.py`,
`csharp_toolkit.py`, `dart_toolkit.py`, `perl_toolkit.py`,
`haskell_toolkit.py`, `scala_toolkit.py`, `swift_toolkit.py`

```python
# AFTER - fixed
def get_cypher_query(self, query: str) -> str:
    raise NotImplementedError("AdvancedLanguageQuery is not implemented yet.")
```

The fully-implemented `JavaToolkit`, `CppToolkit`, and `ElispToolkit`
already had correct signatures and are unchanged.

## Tests

Added `tests/unit/tools/test_placeholder_toolkits.py` with 31 parametrized
tests across all 10 toolkits registered in the `TOOLKITS` dict:
- `instance.get_cypher_query()` raises `NotImplementedError`, not `TypeError`
- Error message matches expected text
- Toolkit instantiates without arguments
- All toolkits expose `get_cypher_query`

All 31 tests pass locally.