### PR TITLE
fix(cgcignore): anchor directory patterns to path-segment boundaries

### DIFF
--- a/src/codegraphcontext/core/cgcignore.py
+++ b/src/codegraphcontext/core/cgcignore.py
@@ -163,7 +163,10 @@ class CGCIgnoreMatcher:
             if is_root_anchored:
                 regex_str = r'\A' + regex_str
             else:
-                regex_str = r'(?:.*/)?' + regex_str
+                # Anchor to a path-segment boundary so a directory pattern like
+                # `out/` matches the segment `out`, not the substring inside
+                # `layout/` / `checkout/` (match_file applies the regex via re.search).
+                regex_str = r'(?:\A|.*/)' + regex_str
                 
             if is_dir_only:
                 # Must match a directory (so it must have trailing slash, or children)

--- a/tests/unit/core/test_cgcignore_core.py
+++ b/tests/unit/core/test_cgcignore_core.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from codegraphcontext.core.cgcignore import (
+    CGCIgnoreMatcher,
     build_ignore_spec,
     parse_cgcignore_lines,
     read_cgcignore_patterns,
@@ -176,3 +177,23 @@ def test_safe_walk_directory_pruning_and_error_handling(tmp_path: Path, monkeypa
     recovered_names = {f.name for f in files_with_error}
     assert "main.py" in recovered_names
 
+
+def test_directory_pattern_requires_segment_boundary():
+    """Regression: a directory pattern like ``out/`` must match the path
+    *segment* ``out`` only, not the substring inside ``layout/`` /
+    ``checkout/`` etc. ``match_file`` applies the compiled regex via
+    ``re.search``, so the anchor must require a segment boundary.
+    """
+    matcher = CGCIgnoreMatcher(["out/", "build/", "target/"], Path("/repo"))
+
+    # Genuine directory matches still work.
+    assert matcher.match_file("out/")
+    assert matcher.match_file("apps/out/x/")
+    assert matcher.match_file("dist/build/")
+
+    # Substring false-positives must NOT be ignored.
+    assert not matcher.match_file("layout/")
+    assert not matcher.match_file("checkout/")
+    assert not matcher.match_file("apps/web/src/components/layout/Header.tsx")
+    assert not matcher.match_file("rebuild/")
+    assert not matcher.match_file("retarget/")


### PR DESCRIPTION
# Fix: anchor `.cgcignore` directory patterns to segment boundaries

Fixes #1366.

## Problem

`CGCIgnoreMatcher` compiled non-root-anchored patterns with an optional
`(?:.*/)?` prefix and matched them with `re.search`. That let a directory
pattern match a **substring** of a path segment, so the built-in default `out/`
silently ignored `layout/`, `checkout/`, `workout/`, `logout/`, …; `build/`
ignored `rebuild/`; `target/` ignored `retarget/`. Directories matching these
false positives were pruned by `discover_files_to_index`, dropping their files
from the graph with no warning (logs are off at `WARNING`+).

## Change

One line in `_compile_patterns`:

```diff
-                regex_str = r'(?:.*/)?' + regex_str
+                # Anchor to a path-segment boundary so a directory pattern like
+                # `out/` matches the segment `out`, not the substring inside
+                # `layout/` / `checkout/` (match_file applies the regex via re.search).
+                regex_str = r'(?:\A|.*/)' + regex_str
```

`(?:\A|.*/)` requires the token to sit at the start of the path or immediately
after a `/`, i.e. a real path-segment boundary — matching gitignore semantics.

## Behavior

| pattern | path | before | after |
|---|---|---|---|
| `out/` | `out/` | ignored | ignored |
| `out/` | `apps/out/x/` | ignored | ignored |
| `out/` | `dist/out/` | ignored | ignored |
| `out/` | `layout/` | ignored ❌ | not ignored ✅ |
| `out/` | `apps/web/src/components/layout/Header.tsx` | ignored ❌ | not ignored ✅ |
| `build/` | `rebuild/` | ignored ❌ | not ignored ✅ |
| `target/` | `retarget/` | ignored ❌ | not ignored ✅ |

Root-anchored (`/out/`), file (`*.png`) and wildcard patterns are unaffected —
the change only tightens the implicit "any depth" prefix. Also confirmed: file
patterns like `foo*` no longer spuriously match `xfoobar` for the same reason.

## Test

Add to the `CGCIgnoreMatcher` tests:

```python
def test_dir_pattern_requires_segment_boundary():
    m = CGCIgnoreMatcher(["out/", "build/", "target/"], Path("."))
    # genuine matches
    assert m.match_file("out/")
    assert m.match_file("apps/out/x/")
    assert m.match_file("dist/build/")
    # substring false-positives must NOT match
    assert not m.match_file("layout/")
    assert not m.match_file("checkout/")
    assert not m.match_file("apps/web/src/components/layout/Header.tsx")
    assert not m.match_file("rebuild/")
    assert not m.match_file("retarget/")
```
