### PR TITLE
fix: update Open Graph and Twitter meta tags

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -13,15 +13,15 @@
     <meta property="og:title" content="CodeGraphContext - AI-Powered Code Knowledge Graphs" />
     <meta property="og:description" content="Transform your codebase into an intelligent knowledge graph for AI assistants. Index Python code, analyze relationships, and provide context." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://codegraphcontext.vercel.app" />
-    <meta property="og:image" content="/preview-image.png" />
+    <meta property="og:url" content="https://cgc.codes" />
+    <meta property="og:image" content="https://cgc.codes/preview-image.png" />
 
     <!-- Twitter Card meta tags -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:url" content="https://codegraphcontext.vercel.app" />
+    <meta name="twitter:url" content="https://cgc.codes" />
     <meta name="twitter:title" content="CodeGraphContext - AI-Powered Code Knowledge Graphs" />
     <meta name="twitter:description" content="Transform your codebase into an intelligent knowledge graph for AI assistants. Index Python code, analyze relationships, and provide context." />
-    <meta name="twitter:image" content="/preview-image.png" />
+    <meta name="twitter:image" content="https://cgc.codes/preview-image.png" />
   </head>
 
   <body>


### PR DESCRIPTION
## Description

This PR updates the Open Graph and Twitter meta tags in `website/index.html`.

### Changes made
- Updated `og:url` to the current domain.
- Updated `twitter:url` to the current domain.
- Replaced the relative `og:image` URL with an absolute URL.
- Replaced the relative `twitter:image` URL with an absolute URL.

Fixes #1308