### PR TITLE
Fix imported decorator and metaclass resolution

### DIFF
--- a/src/codegraphcontext/tools/indexing/resolution/inheritance.py
+++ b/src/codegraphcontext/tools/indexing/resolution/inheritance.py
@@ -353,7 +353,7 @@ def build_decorated_by_links(
             if item.get("name")
         }
         local_imports = {
-            imp.get("alias") or imp.get("name"): imp.get("source")
+            imp.get("alias") or imp.get("name"): imp.get("full_import_name") or imp.get("name")
             for imp in file_data.get("imports", [])
             if imp.get("name") or imp.get("alias")
         }
@@ -409,7 +409,7 @@ def build_metaclass_links(
         caller_file_path = str(Path(file_data["path"]).resolve().as_posix())
         local_class_names = {c["name"] for c in file_data.get("classes", [])}
         local_imports = {
-            imp.get("alias") or imp.get("name"): imp.get("source")
+            imp.get("alias") or imp.get("name"): imp.get("full_import_name") or imp.get("name")
             for imp in file_data.get("imports", [])
             if imp.get("name") or imp.get("alias")
         }

--- a/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
+++ b/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
@@ -699,6 +699,43 @@ class TestCrossLangCallResolutionPatterns:
             for row in links
         )
 
+    def test_python_imported_decorator_resolution(self):
+        caller_path = str(Path("/tmp/example.py").resolve())
+        decorator_path = str(Path("/tmp/dataclasses.py").resolve().as_posix())
+
+        file_data = {
+            "path": caller_path,
+            "lang": "python",
+            "functions": [
+                {
+                    "name": "hello",
+                    "line_number": 10,
+                    "decorators": ["@dataclass"],
+                    "class_context": None,
+                }
+            ],
+            "classes": [],
+            "imports": [
+                {
+                    "name": "dataclass",
+                    "alias": None,
+                    "full_import_name": "dataclasses.dataclass",
+                }
+            ],
+        }
+
+        imports_map = {
+            "dataclass": [decorator_path]
+        }
+
+        links = build_decorated_by_links([file_data], imports_map)
+
+        assert len(links) == 1
+
+        assert links[0]["decorated_name"] == "hello"
+        assert links[0]["decorator_name"] == "dataclass"
+        assert links[0]["decorator_path"] == decorator_path
+
     def test_kotlin_companion_of_links(self, manager):
         wrapper = _parser(manager, "kotlin")
         parser = KotlinTreeSitterParser(wrapper)


### PR DESCRIPTION
Closes #1362 

## Summary

This PR fixes imported decorator and metaclass resolution.

Previously, `build_decorated_by_links()` and `build_metaclass_links()` attempted to read the non-existent `source` field from parser imports. Since the parser emits `full_import_name` instead, imported decorators and metaclasses could not be resolved correctly.

## Changes

- Replaced `source` with `full_import_name` in:
  - `build_decorated_by_links()`
  - `build_metaclass_links()`
- Added a regression test for imported decorator resolution.

## Testing

```bash
python -m pytest tests/unit/tools/test_cross_lang_call_resolution_patterns.py -k imported_decorator_resolution -v
```

Result:

```
PASSED
```