### PR TITLE
fix(indexing): wire PARALLEL_WORKERS config to indexing concurrency

### DIFF
--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -30,6 +30,24 @@ from .resolution.inheritance import (
 )
 
 
+DEFAULT_PARALLEL_WORKERS = 10
+
+
+def get_parallel_workers() -> int:
+    """Resolve the indexing concurrency limit from the PARALLEL_WORKERS config.
+
+    Falls back to DEFAULT_PARALLEL_WORKERS when the value is unset or not a
+    usable positive integer, so a bad config never breaks indexing.
+    """
+    from ...cli.config_manager import get_config_value
+
+    try:
+        workers = int(get_config_value("PARALLEL_WORKERS") or "")
+    except (TypeError, ValueError):
+        return DEFAULT_PARALLEL_WORKERS
+    return workers if workers > 0 else DEFAULT_PARALLEL_WORKERS
+
+
 def build_index_summary(
     files: List[Path],
     parsers: Dict[str, str],
@@ -108,7 +126,7 @@ async def run_tree_sitter_index_async(
     resolved_repo_path_str = path.resolve().as_posix() if path.is_dir() else path.parent.resolve().as_posix()
 
     processed_count = 0
-    concurrency_limit = 10
+    concurrency_limit = get_parallel_workers()
     semaphore = asyncio.Semaphore(concurrency_limit)
     
     async def process_file(file: Path) -> Optional[Dict[str, Any]]:

--- a/tests/unit/tools/test_pipeline_parallel_workers.py
+++ b/tests/unit/tools/test_pipeline_parallel_workers.py
@@ -1,0 +1,27 @@
+"""Tests that the PARALLEL_WORKERS config drives indexing concurrency (#1340)."""
+from unittest import mock
+
+import pytest
+
+from codegraphcontext.tools.indexing import pipeline
+
+
+@pytest.mark.parametrize(
+    "config_value,expected",
+    [
+        ("32", 32),
+        ("1", 1),
+        ("4", 4),
+        (None, pipeline.DEFAULT_PARALLEL_WORKERS),
+        ("", pipeline.DEFAULT_PARALLEL_WORKERS),
+        ("not-a-number", pipeline.DEFAULT_PARALLEL_WORKERS),
+        ("0", pipeline.DEFAULT_PARALLEL_WORKERS),
+        ("-5", pipeline.DEFAULT_PARALLEL_WORKERS),
+    ],
+)
+def test_get_parallel_workers(config_value, expected):
+    with mock.patch(
+        "codegraphcontext.cli.config_manager.get_config_value",
+        return_value=config_value,
+    ):
+        assert pipeline.get_parallel_workers() == expected


### PR DESCRIPTION
Fixes #1340.

`PARALLEL_WORKERS` is defined and validated in `config_manager.py` (default 4, range 1-32, "Number of parallel indexing workers"), but `run_tree_sitter_index_async` hardcoded `concurrency_limit = 10`, so setting it had no effect on indexing.

This reads the value through a small `get_parallel_workers()` helper that falls back to the previous limit of 10 when the config is unset or not a usable positive integer, so a missing or malformed value never breaks indexing.

Tests: `tests/unit/tools/test_pipeline_parallel_workers.py` covers valid values and each fallback case (unset, empty, non-numeric, zero, negative) — 8 passed; the module fails to import on `main` without the change.
