### PR TITLE
test(api): fix SSE disconnect test after #1319 (restore green main)

### DIFF
--- a/tests/unit/api/test_mcp_sse_disconnect.py
+++ b/tests/unit/api/test_mcp_sse_disconnect.py
@@ -10,6 +10,9 @@ def mock_request():
     request.scope = {}
     request.receive = AsyncMock()
     request._send = AsyncMock()
+    # handle_messages() now buffers the body up front (PR #1319), so the mock
+    # must expose an awaitable body() returning a valid JSON-RPC payload.
+    request.body = AsyncMock(return_value=b'{"jsonrpc": "2.0", "method": "ping", "id": 1}')
     return request
 
 


### PR DESCRIPTION
#1319 added `await request.body()` to `handle_messages`; the disconnect test mock did not expose an awaitable `body()`, breaking `test_handle_messages_exits_cleanly_on_disconnect`. Adds an AsyncMock body() so the test exercises the disconnect path again. Verified: 9 api tests pass.