### PR TITLE
chore(release): bump version to 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.5.1"
+version = "0.5.2"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
Bumps version 0.5.1 → 0.5.2. **Already published to PyPI**: https://pypi.org/project/codegraphcontext/0.5.2/

Merge to record the bump on main; then tag `v0.5.2`.