### PR TITLE
Fix CLI/core safety bugs: bundle unpack, hook git-absent, config data loss

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -897,12 +897,20 @@ def save_context_config(cfg: ContextConfig) -> None:
             "cgcignore_path": ctx.cgcignore_path,
         }
 
-    raw = {
-        "version": cfg.version,
-        "mode": cfg.mode,
-        "default_context": cfg.default_context,
-        "contexts": contexts_raw,
-    }
+    # Read-merge the existing file first so that unrelated top-level sections
+    # (e.g. ``workspace_mappings``) are preserved instead of being wiped out.
+    raw: Dict[str, Any] = {}
+    if CONTEXT_CONFIG_FILE.exists():
+        try:
+            with open(CONTEXT_CONFIG_FILE, "r", encoding="utf-8") as f:
+                raw = yaml.safe_load(f) or {}
+        except Exception:
+            raw = {}
+
+    raw["version"] = cfg.version
+    raw["mode"] = cfg.mode
+    raw["default_context"] = cfg.default_context
+    raw["contexts"] = contexts_raw
 
     try:
         _atomic_write_text(

--- a/src/codegraphcontext/cli/hook_manager.py
+++ b/src/codegraphcontext/cli/hook_manager.py
@@ -202,17 +202,39 @@ def _configure_merge_driver(repo_root: Path) -> None:
     _git_config(repo_root, "merge.cgc-bundle.driver", "cgc bundle merge %O %A %B")
 
 
+def _run_git(repo_root: Path, args: list[str], *, check: bool, **kwargs):
+    """Run a git command, translating a missing/failed git into HookError.
+
+    Callers only handle ``HookError``; without this a missing ``git`` binary
+    (``FileNotFoundError``) or a failed ``config`` call (``CalledProcessError``)
+    would crash the ``cgc hook`` commands with an uncaught exception.
+    """
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            check=check,
+            **kwargs,
+        )
+    except FileNotFoundError as exc:
+        raise HookError(
+            "Git executable not found. Install Git and ensure it is on PATH."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise HookError(f"git {' '.join(args)} failed: {exc}") from exc
+
+
 def _git_config(repo_root: Path, key: str, value: str) -> None:
-    subprocess.run(["git", "-C", str(repo_root), "config", key, value], check=True)
+    _run_git(repo_root, ["config", key, value], check=True)
 
 
 def _unset_git_config(repo_root: Path, key: str) -> None:
-    subprocess.run(["git", "-C", str(repo_root), "config", "--unset-all", key], check=False)
+    _run_git(repo_root, ["config", "--unset-all", key], check=False)
 
 
 def _has_git_config(repo_root: Path, key: str) -> bool:
-    result = subprocess.run(
-        ["git", "-C", str(repo_root), "config", "--get", key],
+    result = _run_git(
+        repo_root,
+        ["config", "--get", key],
         check=False,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/src/codegraphcontext/cli/registry_commands.py
+++ b/src/codegraphcontext/cli/registry_commands.py
@@ -407,7 +407,7 @@ def load_bundle_command(bundle_name: str, clear_existing: bool = False):
         if not all(services):
             return (False, "Failed to initialize database services", {})
         
-        db_manager, _, _ = services
+        db_manager, _, _, _ = services
         
         # Check if bundle exists locally
         bundle_path = Path(bundle_name)

--- a/tests/unit/cli/test_config_manager_encoding.py
+++ b/tests/unit/cli/test_config_manager_encoding.py
@@ -46,3 +46,39 @@ def test_context_config_files_are_opened_with_utf8(tmp_path, monkeypatch):
     loaded = config_manager.load_context_config()
 
     assert loaded.default_context == "global"
+
+
+def test_save_context_config_preserves_workspace_mappings(tmp_path, monkeypatch):
+    """save_context_config must not wipe unrelated top-level keys (data-loss guard)."""
+    import yaml
+
+    context_config = tmp_path / "config.yaml"
+
+    monkeypatch.setattr(config_manager, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config_manager, "CONTEXT_CONFIG_FILE", context_config)
+    monkeypatch.setattr(config_manager, "_LEGACY_CONTEXT_CONFIG_FILE", tmp_path / "cgc_config.yaml")
+
+    # Seed an existing config that already carries a workspace_mappings section.
+    mappings = {"/home/user/repo": {"context_path": "/ctx", "database": "falkordb"}}
+    context_config.write_text(
+        yaml.dump(
+            {
+                "version": 1,
+                "mode": "global",
+                "default_context": "",
+                "contexts": {},
+                "workspace_mappings": mappings,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    # Saving unrelated context config must leave workspace_mappings intact.
+    config_manager.save_context_config(config_manager.ContextConfig(default_context="global"))
+
+    with open(context_config, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+
+    assert raw["workspace_mappings"] == mappings
+    assert raw["default_context"] == "global"


### PR DESCRIPTION
## Summary

Fixes three CLI/core safety bugs, one of which causes silent config **data loss**.

### 1. `load_bundle_command` unpack bug + driver leak (`cli/registry_commands.py`)
`load_bundle_command` did `db_manager, _, _ = services`, but `_initialize_services()` returns a **4-tuple** `(db_manager, graph_builder, code_finder, resolved_context)`. This raised `ValueError: too many values to unpack (expected 3)` on every call, and because the failure happened before `db_manager` was bound, the DB driver leaked. Now unpacks 4 values; the driver is still closed in the `finally` block.

### 2. `cgc hook install` crash when git is absent (`cli/hook_manager.py`)
`_git_config` used `subprocess.run(..., check=True)`, and the `cgc hook install/uninstall/status` commands in `main.py` only catch `HookError`. When the `git` binary is missing, `FileNotFoundError` (or `CalledProcessError` on a failed `git config`) propagated uncaught and crashed the command. All git subprocess calls now route through a `_run_git` helper that translates `FileNotFoundError`/`CalledProcessError` into `HookError`, so the commands fail gracefully with a clear message. (Covers `install`, `uninstall`, and `status`, since status also shells out to git.)

### 3. `save_context_config` wipes `workspace_mappings` — **data loss** (`cli/config_manager.py`)
`save_context_config` rebuilt `config.yaml` from only `version` / `mode` / `default_context` / `contexts`, **erasing** any other top-level sections. In particular the entire `workspace_mappings` section was silently destroyed whenever context config was saved. It now read-merges the existing file first and only overrides its own keys, preserving all other top-level sections — mirroring the existing read-merge pattern in `_save_workspace_mappings`. A unit test (`test_save_context_config_preserves_workspace_mappings`) guards against regression.

## Testing
`pytest tests/unit -q` → **714 passed, 7 skipped**. The only failures are the pre-existing flaky `test_cgcignore_patterns.py` tests, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
