### PR TITLE
fix: cleanup deprecations + stale fork URLs + null-guards

### DIFF
--- a/docs/BUNDLE_QUICKREF.md
+++ b/docs/BUNDLE_QUICKREF.md
@@ -55,7 +55,7 @@ cgc load numpy  # Will download numpy.cgc
 
 ```bash
 # From GitHub Releases
-wget https://github.com/Shashankss1205/CodeGraphContext/releases/latest/download/numpy-1.26.4.cgc
+wget https://github.com/CodeGraphContext/CodeGraphContext/releases/latest/download/numpy-1.26.4.cgc
 
 # Load it
 cgc load numpy-1.26.4.cgc
@@ -275,7 +275,7 @@ pip install --upgrade codegraphcontext
 | **requests** | HTTP library | ~10MB |
 | **flask** | Web framework | ~12MB |
 
-Download from: [GitHub Releases](https://github.com/Shashankss1205/CodeGraphContext/releases)
+Download from: [GitHub Releases](https://github.com/CodeGraphContext/CodeGraphContext/releases)
 
 ## 🔗 Related Commands
 
@@ -314,4 +314,4 @@ cgc analyze deps <mod>   # Analyze dependencies
 
 ---
 
-**Questions?** Open an issue on [GitHub](https://github.com/Shashankss1205/CodeGraphContext/issues)
+**Questions?** Open an issue on [GitHub](https://github.com/CodeGraphContext/CodeGraphContext/issues)

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -11,7 +11,7 @@
 - 🇯🇵 [日本語](README.ja.md)
 - 🇪🇸 Español (準備中)
 
-🌍 **CodeGraphContext をあなたの言語に翻訳することにご協力ください！ https://github.com/Shashankss1205/CodeGraphContext/issues で Issue と PR を作成してください！**
+🌍 **CodeGraphContext をあなたの言語に翻訳することにご協力ください！ https://github.com/CodeGraphContext/CodeGraphContext/issues で Issue と PR を作成してください！**
 
 <p align="center">
   <br>

--- a/docs/translations/README.kor.md
+++ b/docs/translations/README.kor.md
@@ -11,7 +11,7 @@
 - 🇯🇵 [日本語](README.ja.md)
 - 🇪🇸 Español (준비 중)
 
-🌍 **CodeGraphContext를 여러분의 언어로 번역하는 데 도움을 주세요! https://github.com/Shashankss1205/CodeGraphContext/issues 에서 이슈와 PR을 생성해 주세요!**
+🌍 **CodeGraphContext를 여러분의 언어로 번역하는 데 도움을 주세요! https://github.com/CodeGraphContext/CodeGraphContext/issues 에서 이슈와 PR을 생성해 주세요!**
 
 <p align="center">
   <br>

--- a/docs/translations/README.ru-RU.md
+++ b/docs/translations/README.ru-RU.md
@@ -11,7 +11,7 @@
 - 🇯🇵 [日本語](README.ja.md)
 - 🇪🇸 Español (Скоро)
 
-🌍 **Помогите перевести CodeGraphContext на ваш язык — создайте issue и Pull Request на https://github.com/Shashankss1205/CodeGraphContext/issues!**
+🌍 **Помогите перевести CodeGraphContext на ваш язык — создайте issue и Pull Request на https://github.com/CodeGraphContext/CodeGraphContext/issues!**
 
 <p align="center">
   <br>

--- a/docs/translations/README.uk.md
+++ b/docs/translations/README.uk.md
@@ -11,7 +11,7 @@
 - 🇯🇵 [日本語](README.ja.md)
 - 🇪🇸 Español (Незабаром)
 
-🌍 **Допоможіть перекласти CodeGraphContext вашою мовою, створивши issue та PR на https://github.com/Shashankss1205/CodeGraphContext/issues!**
+🌍 **Допоможіть перекласти CodeGraphContext вашою мовою, створивши issue та PR на https://github.com/CodeGraphContext/CodeGraphContext/issues!**
 
 <p align="center">
   <br>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,8 @@ datasources = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/Shashankss1205/CodeGraphContext"
-"Bug Tracker" = "https://github.com/Shashankss1205/CodeGraphContext/issues"
+"Homepage" = "https://github.com/CodeGraphContext/CodeGraphContext"
+"Bug Tracker" = "https://github.com/CodeGraphContext/CodeGraphContext/issues"
 
 [project.scripts]
 cgc = "codegraphcontext.cli.main:app"

--- a/src/codegraphcontext/api/app.py
+++ b/src/codegraphcontext/api/app.py
@@ -61,7 +61,7 @@ def create_app() -> FastAPI:
                     <a href="/docs" class="btn">View API Docs</a>
                     <div class="links">
                         <a href="/openapi.json">OpenAPI Spec</a>
-                        <a href="https://github.com/Shashankss1205/CodeGraphContext" target="_blank">GitHub</a>
+                        <a href="https://github.com/CodeGraphContext/CodeGraphContext" target="_blank">GitHub</a>
                     </div>
                 </div>
             </body>

--- a/src/codegraphcontext/cli/registry_commands.py
+++ b/src/codegraphcontext/cli/registry_commands.py
@@ -112,7 +112,7 @@ def list_bundles(verbose: bool = False, unique: bool = False):
         table.add_column("Download URL", style="blue", no_wrap=False)
     
     # Sort by full_name to group versions together
-    bundles.sort(key=lambda b: (b.get('name', ''), b.get('full_name', '')))
+    bundles.sort(key=lambda b: ((b.get('name') or ''), (b.get('full_name') or '')))
     
     for bundle in bundles:
         # Use full_name for display (includes version info)
@@ -163,10 +163,10 @@ def search_bundles(query: str):
     query_lower = query.lower()
     matching_bundles = [
         b for b in bundles
-        if query_lower in b.get('name', '').lower() or
-           query_lower in b.get('full_name', '').lower() or
-           query_lower in b.get('repo', '').lower() or
-           query_lower in b.get('description', '').lower()
+        if query_lower in (b.get('name') or '').lower() or
+           query_lower in (b.get('full_name') or '').lower() or
+           query_lower in (b.get('repo') or '').lower() or
+           query_lower in (b.get('description') or '').lower()
     ]
     
     if not matching_bundles:

--- a/src/codegraphcontext/tools/indexing/embeddings.py
+++ b/src/codegraphcontext/tools/indexing/embeddings.py
@@ -260,6 +260,14 @@ class EmbeddingPipeline:
                 batch_num += 1
                 continue
 
+            if len(vectors) != len(batch):
+                warning_logger(
+                    f"[EMBED] Batch {batch_num + 1}/{n_batches} length mismatch: "
+                    f"got {len(vectors)} vectors for {len(batch)} inputs; skipping batch"
+                )
+                batch_num += 1
+                continue
+
             write_rows = [
                 {
                     "path": path,

--- a/src/codegraphcontext/tools/report_generator.py
+++ b/src/codegraphcontext/tools/report_generator.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 import textwrap
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -403,7 +403,7 @@ def generate_report(
         The full report as a markdown string.
     """
     driver = db_manager.get_driver()
-    now = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     if repo_path is None:
         repo_path = resolve_report_repo_scope(db_manager)
 


### PR DESCRIPTION
Small safe fixes from bugs.md: deprecated datetime.utcnow(); stale Shashankss1205 fork URLs -> org; None-guards in registry search/list; embedding batch length guard. Unit green (only pre-existing flaky cgcignore).