### PR TITLE
fix: parser robustness (unguarded parse, dotfile indexing, cpp toolkit keys)

### DIFF
--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -99,11 +99,13 @@ class GraphBuilder:
         
         # Files that should be added to the graph as minimal File nodes, even if not parsed
         self.generic_extensions = {
-            ".toml", ".sh", ".yaml", ".yml", ".json", ".ini", ".cfg", ".md", ".txt", ".env",
-            ".bat", ".ps1", ".dockerignore", ".gitignore"
+            ".toml", ".sh", ".yaml", ".yml", ".json", ".ini", ".cfg", ".md", ".txt",
+            ".bat", ".ps1"
         }
+        # Literal dotfiles/config filenames have no suffix (e.g. Path(".gitignore").suffix == ""),
+        # so they must be matched by name rather than extension.
         self.generic_filenames = {
-            "Dockerfile", "Makefile"
+            "Dockerfile", "Makefile", ".gitignore", ".dockerignore", ".env"
         }
         
         import threading

--- a/src/codegraphcontext/tools/indexing/discovery.py
+++ b/src/codegraphcontext/tools/indexing/discovery.py
@@ -13,9 +13,13 @@ from .constants import DEFAULT_IGNORE_PATTERNS
 # Must stay in sync with GraphBuilder.generic_extensions / generic_filenames.
 _GENERIC_EXTENSIONS: FrozenSet[str] = frozenset({
     ".toml", ".sh", ".yaml", ".yml", ".json", ".ini", ".cfg",
-    ".md", ".txt", ".env", ".bat", ".ps1", ".dockerignore", ".gitignore",
+    ".md", ".txt", ".bat", ".ps1",
 })
-_GENERIC_FILENAMES: FrozenSet[str] = frozenset({"Dockerfile", "Makefile"})
+# Literal dotfiles/config filenames have no suffix (e.g. Path(".gitignore").suffix == ""),
+# so they must be matched by name rather than extension.
+_GENERIC_FILENAMES: FrozenSet[str] = frozenset({
+    "Dockerfile", "Makefile", ".gitignore", ".dockerignore", ".env",
+})
 
 
 def safe_walk(

--- a/src/codegraphcontext/tools/languages/javascript.py
+++ b/src/codegraphcontext/tools/languages/javascript.py
@@ -184,30 +184,34 @@ class JavascriptTreeSitterParser:
     def parse(self, path: Path, is_dependency: bool = False, index_source: bool = False) -> Dict[str, Any]:
         """Parses a file and returns its structure in a standardized dictionary format."""
         self.index_source = index_source
-        with open(path, "r", encoding="utf-8") as f:
-            source_code = f.read()
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                source_code = f.read()
 
-        tree = self.parser.parse(bytes(source_code, "utf8"))
-        root_node = tree.root_node
+            tree = self.parser.parse(bytes(source_code, "utf8"))
+            root_node = tree.root_node
 
-        functions = self._find_functions(root_node)
-        classes = self._find_classes(root_node)
-        imports = self._find_imports(root_node)
-        function_calls = self._find_calls(root_node)
-        variables = self._find_variables(root_node)
-        components = self._find_react_components(root_node)
+            functions = self._find_functions(root_node)
+            classes = self._find_classes(root_node)
+            imports = self._find_imports(root_node)
+            function_calls = self._find_calls(root_node)
+            variables = self._find_variables(root_node)
+            components = self._find_react_components(root_node)
 
-        return {
-            "path": str(path),
-            "functions": functions,
-            "classes": classes,
-            "variables": variables,
-            "imports": imports,
-            "function_calls": function_calls,
-            "components": components,
-            "is_dependency": is_dependency,
-            "lang": self.language_name,
-        }
+            return {
+                "path": str(path),
+                "functions": functions,
+                "classes": classes,
+                "variables": variables,
+                "imports": imports,
+                "function_calls": function_calls,
+                "components": components,
+                "is_dependency": is_dependency,
+                "lang": self.language_name,
+            }
+        except Exception as e:
+            error_logger(f"Failed to parse JavaScript file {path}: {e}")
+            return {"path": str(path), "error": str(e)}
 
     def _find_functions(self, root_node):
         functions = []

--- a/src/codegraphcontext/tools/languages/typescript.py
+++ b/src/codegraphcontext/tools/languages/typescript.py
@@ -178,31 +178,35 @@ class TypescriptTreeSitterParser:
 
     def parse(self, path: Path, is_dependency: bool = False, index_source: bool = False) -> Dict:
         self.index_source = index_source
-        with open(path, "r", encoding="utf-8") as f:
-            source_code = f.read()
-        tree = self.parser.parse(bytes(source_code, "utf8"))
-        root_node = tree.root_node
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                source_code = f.read()
+            tree = self.parser.parse(bytes(source_code, "utf8"))
+            root_node = tree.root_node
 
-        functions = self._find_functions(root_node)
-        classes = self._find_classes(root_node)
-        interfaces = self._find_interfaces(root_node)
-        type_aliases = self._find_type_aliases(root_node)
-        imports = self._find_imports(root_node)
-        function_calls = self._find_calls(root_node)
-        variables = self._find_variables(root_node)
+            functions = self._find_functions(root_node)
+            classes = self._find_classes(root_node)
+            interfaces = self._find_interfaces(root_node)
+            type_aliases = self._find_type_aliases(root_node)
+            imports = self._find_imports(root_node)
+            function_calls = self._find_calls(root_node)
+            variables = self._find_variables(root_node)
 
-        return {
-            "path": str(path),
-            "functions": functions,
-            "classes": classes,
-            "interfaces": interfaces,
-            "type_aliases": type_aliases,
-            "variables": variables,
-            "imports": imports,
-            "function_calls": function_calls,
-            "is_dependency": is_dependency,
-            "lang": self.language_name,
-        }
+            return {
+                "path": str(path),
+                "functions": functions,
+                "classes": classes,
+                "interfaces": interfaces,
+                "type_aliases": type_aliases,
+                "variables": variables,
+                "imports": imports,
+                "function_calls": function_calls,
+                "is_dependency": is_dependency,
+                "lang": self.language_name,
+            }
+        except Exception as e:
+            error_logger(f"Failed to parse TypeScript file {path}: {e}")
+            return {"path": str(path), "error": str(e)}
 
 
     def _find_functions(self, root_node):

--- a/src/codegraphcontext/tools/query_tool_languages/cpp_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/cpp_toolkit.py
@@ -1,25 +1,29 @@
 # src/codegraphcontext/tools/query_tool_languages/cpp_toolkit.py
 class CppToolkit:
     """Handles Neo4j queries for C++ file graph."""
-    def get_cypher_query(query: str) -> str:
+    def get_cypher_query(self, query: str) -> str:
         """
         Returns a Cypher query string based on the query type requested.
 
+        The caller (``advanced_language_query_tool``) passes the capitalized,
+        singular node label (e.g. ``Function``, ``Class``, ``Module``), so match
+        that form directly, mirroring the elisp/java toolkit convention.
+
         Supported query types:
-        - functions
-        - classes
-        - imports
-        - structs
-        - enums
-        - unions
-        - macros
-        - variables
+        - Function
+        - Class
+        - Module
+        - Struct
+        - Enum
+        - Union
+        - Macro
+        - Variable
         """
 
 
-        query = query.strip().lower()
+        query = query.strip()
 
-        if query == "functions":
+        if query == "Function":
             return """
                 MATCH (f:Function)
                 RETURN f.name AS name, f.path AS path, 
@@ -27,7 +31,7 @@ class CppToolkit:
                 ORDER BY f.path, f.line_number
             """
 
-        elif query == "classes":
+        elif query == "Class":
             return """
                 MATCH (c:Class)
                 RETURN c.name AS name, c.path AS path, 
@@ -35,7 +39,7 @@ class CppToolkit:
                 ORDER BY c.path, c.line_number
             """
 
-        elif query == "imports":
+        elif query == "Module":
             return """
                 MATCH (f:File)-[i:IMPORTS]->(m:Module)
                 RETURN f.name AS file_name, m.name AS module_name, 
@@ -43,7 +47,7 @@ class CppToolkit:
                 ORDER BY f.name
             """
 
-        elif query == "structs":
+        elif query == "Struct":
             return """
                 MATCH (s:Struct)
                 RETURN s.name AS name, s.path AS path, 
@@ -51,7 +55,7 @@ class CppToolkit:
                 ORDER BY s.path, s.line_number
             """
 
-        elif query == "enums":
+        elif query == "Enum":
             return """
                 MATCH (e:Enum)
                 RETURN e.name AS name, e.path AS path, 
@@ -59,7 +63,7 @@ class CppToolkit:
                 ORDER BY e.path, e.line_number
             """
 
-        elif query == "unions":
+        elif query == "Union":
             return """
                 MATCH (u:Union)
                 RETURN u.name AS name, u.path AS path, 
@@ -67,7 +71,7 @@ class CppToolkit:
                 ORDER BY u.path, u.line_number
             """
 
-        elif query == "macros":
+        elif query == "Macro":
             return """
                 MATCH (m:Macro)
                 RETURN m.name AS name, m.path AS path, 
@@ -75,7 +79,7 @@ class CppToolkit:
                 ORDER BY m.path, m.line_number
             """
 
-        elif query == "variables":
+        elif query == "Variable":
             return """
                 MATCH (v:Variable)
                 RETURN v.name AS name, v.path AS path, 


### PR DESCRIPTION
From bugs.md: TS/JS parse() no longer crashes on bad bytes/parse errors; literal dotfiles now indexed; cpp toolkit label mismatch fixed. Unit green + all 21 goldens pass.