### PR TITLE
fix(cgcignore): honour user negations and stop `**` crossing segment boundaries

### DIFF
--- a/src/codegraphcontext/core/cgcignore.py
+++ b/src/codegraphcontext/core/cgcignore.py
@@ -83,8 +83,9 @@ def read_cgcignore_patterns(path: Path, default_patterns: list[str]) -> list[str
         return list(default_patterns)
 
     user_patterns = parse_cgcignore_lines(path.read_text(encoding="utf-8").splitlines())
-    # User patterns first so explicit repo rules take precedence.
-    return user_patterns + list(default_patterns)
+    # Defaults first, user patterns last: matching is last-match-wins, so the
+    # trailing list is the one that takes precedence.
+    return list(default_patterns) + user_patterns
 
 class CGCIgnoreMatcher:
     def __init__(self, patterns: list[str], root_dir: Path):
@@ -150,15 +151,28 @@ class CGCIgnoreMatcher:
             if is_root_anchored:
                 pat = pat[1:]
 
-            segments = [seg.strip('/') for seg in pat.split('**')]
-            translated_segments = []
-            for seg in segments:
-                if seg:
-                    translated_segments.append(self._translate_segment(seg))
+            # `**` spans whole path segments, never part of one. Joining the
+            # translated pieces with a bare `.*` lets the wildcard match inside a
+            # segment, so `docs/**` would swallow `docstring.py` and `**/build`
+            # would swallow `rebuild/`. Join with a separator-aware bridge instead.
+            raw_segments = pat.split('**')
+            segments = [seg.strip('/') for seg in raw_segments]
+            translated_segments = [self._translate_segment(seg) if seg else ''
+                                   for seg in segments]
+
+            parts = [translated_segments[0]]
+            for left, right in zip(translated_segments, translated_segments[1:]):
+                if not left:
+                    # leading `**/` — match any number of leading segments
+                    parts.append(r'(?:.*/)?' if right else '.*')
+                elif not right:
+                    # trailing `/**` — must have at least one child segment
+                    parts.append('/.*')
                 else:
-                    translated_segments.append('')
-            
-            regex_str = '.*'.join(translated_segments)
+                    # `a/**/b` — zero or more whole segments between the two
+                    parts.append(r'/(?:.*/)?')
+                parts.append(right)
+            regex_str = ''.join(parts)
             
             if is_root_anchored:
                 regex_str = r'\A' + regex_str
@@ -241,5 +255,9 @@ def build_ignore_spec(
             parse_cgcignore_lines(explicit_cgcignore_path.read_text(encoding="utf-8").splitlines())
         )
 
-    all_patterns = merged_user_patterns + list(default_patterns)
+    # Defaults first, user patterns last: matching is last-match-wins (see
+    # CGCIgnoreMatcher.match_file), so appending the defaults would make them
+    # unconditionally override the user's rules and leave `!build/` with no way
+    # to re-include a directory the built-in list ignores.
+    all_patterns = list(default_patterns) + merged_user_patterns
     return CGCIgnoreMatcher(all_patterns, ignore_root), local_cgcignore_path

--- a/tests/unit/core/test_cgcignore_core.py
+++ b/tests/unit/core/test_cgcignore_core.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from codegraphcontext.core.cgcignore import (
     CGCIgnoreMatcher,
     build_ignore_spec,
@@ -63,7 +65,47 @@ def test_read_cgcignore_patterns_merges_defaults_with_user_patterns(tmp_path: Pa
 
     merged = read_cgcignore_patterns(cgcignore, ["*.png", "*.json"])
 
-    assert merged == ["*.txt", "*.log", "*.png", "*.json"]
+    # Defaults come first and user patterns last: matching is last-match-wins,
+    # so the trailing entries are the ones that win.
+    assert merged == ["*.png", "*.json", "*.txt", "*.log"]
+
+
+def test_user_negation_overrides_default_pattern(tmp_path: Path):
+    """A `!pattern` in .cgcignore must be able to re-include a default-ignored path."""
+    cgcignore = tmp_path / ".cgcignore"
+    cgcignore.write_text("!build/\n!*.svg\n", encoding="utf-8")
+
+    spec, _ = build_ignore_spec(tmp_path, ["build/", "dist/", "*.svg"])
+
+    assert not spec.match_file("build/foo.py")
+    assert not spec.match_file("assets/logo.svg")
+    # Defaults the user did not negate still apply.
+    assert spec.match_file("dist/bundle.js")
+
+
+@pytest.mark.parametrize(
+    "pattern,path,ignored",
+    [
+        # `**` spans whole segments, so it must not match inside one.
+        ("docs/**", "docstring.py", False),
+        ("docs/**", "docs_helper/x.py", False),
+        ("**/build", "rebuild/x.py", False),
+        ("**/build", "xbuild", False),
+        ("vendor/**/*.go", "vendorabc.go", False),
+        ("src/**/test", "src_foo_test", False),
+        # ...but it must still match across whole segments.
+        ("docs/**", "docs/a.py", True),
+        ("docs/**", "docs/deep/nested/a.py", True),
+        ("**/build", "build", True),
+        ("**/build", "a/b/build", True),
+        ("vendor/**/*.go", "vendor/x.go", True),
+        ("vendor/**/*.go", "vendor/a/b.go", True),
+        ("src/**/test", "src/test", True),
+        ("src/**/test", "src/a/test", True),
+    ],
+)
+def test_double_star_respects_path_segment_boundaries(pattern, path, ignored):
+    assert CGCIgnoreMatcher([pattern], Path("/repo")).match_file(path) is ignored
 
 
 def test_find_cgcignore_does_not_escape_non_git_root(tmp_path: Path):


### PR DESCRIPTION
Fixes two independent `.cgcignore` matching bugs found in an end-to-end audit of 0.5.2. Both cause files to silently vanish from the graph with no diagnostic.

### 1. Built-in defaults override user patterns (audit ID `I-M07`)

`build_ignore_spec` and `read_cgcignore_patterns` both appended the defaults **after** the user's patterns. Matching is last-match-wins, so the defaults won unconditionally and a `!build/` negation could never re-include a directory the default list ignores.

```python
# before — core/cgcignore.py:244
all_patterns = merged_user_patterns + list(default_patterns)   # defaults LAST → defaults win
```

Source under `build/`, `dist/`, `out/`, `target/` and `env/` was unindexable with **no escape hatch** — and `env/` and `out/` are real source directories in plenty of projects. The comment above `read_cgcignore_patterns` ("User patterns first so explicit repo rules take precedence") asserted the opposite of what the ordering achieved.

Reproduced before the fix, with `.cgcignore` containing `!build/` and `!*.svg`:

```
'build/foo.py'     ignored=True   ← should be False
'assets/logo.svg'  ignored=True   ← should be False
```

### 2. `**` matched inside a path segment (audit ID `I-M08`)

`**` was translated by splitting on the literal token, stripping the surrounding slashes, and re-joining with a bare `.*` — which lets the wildcard match *within* a segment.

| Pattern | Path | Before | Correct |
|---|---|---|---|
| `docs/**` | `docstring.py` | ignored | not ignored |
| `docs/**` | `docs_helper/x.py` | ignored | not ignored |
| `**/build` | `rebuild/x.py` | ignored | not ignored |
| `**/build` | `xbuild` | ignored | not ignored |
| `vendor/**/*.go` | `vendorabc.go` | ignored | not ignored |
| `src/**/test` | `src_foo_test` | ignored | not ignored |

`**` now joins with a separator-aware bridge — leading `**/` → `(?:.*/)?`, trailing `/**` requires at least one child segment, interior `/**/` matches zero or more whole segments.

### Tests

- New parametrized test covering both directions for `**`: the six over-matches above must **not** match, and 8 legitimate cases (`docs/a.py`, `docs/deep/nested/a.py`, `vendor/x.go`, `src/test`, …) must **still** match.
- New test asserting a user negation overrides a default, while un-negated defaults still apply.
- `test_read_cgcignore_patterns_merges_defaults_with_user_patterns` updated: it asserted the old (incorrect) precedence. Its patterns contain no negations, so the *matching* behaviour of that case is unchanged — only the documented order.

Full unit suite: **748 passed, 7 skipped, 0 failed** (baseline on `main` was 733 passed + the 15 tests added here).

<sub>From an end-to-end audit of CGC 0.5.2. Related filed findings: #1382–#1402.</sub>