### PR TITLE
fix(security): restrict apoc procedures to a minimal allowlist (#1006)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,10 @@ services:
     environment:
       - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:?Set NEO4J_PASSWORD in .env}
       - NEO4J_PLUGINS=["apoc"]
-      - NEO4J_dbms_security_procedures_unrestricted=apoc.*
+      # APOC is installed but intentionally NOT granted unrestricted access.
+      # CGC uses no apoc procedures and blocks `CALL apoc` in user queries,
+      # so the previous `apoc.*` unrestricted grant was an unnecessary attack
+      # surface (e.g. apoc.load.json SSRF/file read, apoc.export file write). See #1006.
       - NEO4J_dbms_memory_heap_max__size=2G
     volumes:
       - neo4j-data:/data

--- a/k8s/neo4j-deployment.yaml
+++ b/k8s/neo4j-deployment.yaml
@@ -30,8 +30,10 @@ spec:
               key: auth
         - name: NEO4J_PLUGINS
           value: '["apoc"]'
-        - name: NEO4J_dbms_security_procedures_unrestricted
-          value: "apoc.*"
+        # APOC is installed but intentionally NOT granted unrestricted access.
+        # CGC uses no apoc procedures and blocks `CALL apoc` in user queries,
+        # so the previous `apoc.*` unrestricted grant was an unnecessary attack
+        # surface (e.g. apoc.load.json SSRF/file read, apoc.export file write). See #1006.
         - name: NEO4J_dbms_memory_heap_max__size
           value: "2G"
         resources:


### PR DESCRIPTION
## Summary

Closes #1006.

The Neo4j service was configured with `NEO4J_dbms_security_procedures_unrestricted=apoc.*`, which grants **every** APOC procedure unrestricted (sandbox-bypassing) privileges — including dangerous ones like `apoc.load.json` (SSRF / arbitrary URL + `file://` reads), `apoc.export.*` (arbitrary file writes), and `apoc.cypher.runFile`. This is far broader than CodeGraphContext needs.

## What APOC procedures does CGC actually use?

**None.** I audited the whole repository:

- `grep -rniE "apoc\.[a-z.]+" src/` → no APOC procedure calls anywhere in the source.
- Every `CALL` that CGC issues uses only Neo4j built-ins: `db.labels()`, `db.relationshipTypes()`, `db.index.fulltext.queryNodes(...)`, and schema creation. None of these require the `unrestricted` grant.
- CGC actively **blocks** APOC in user-supplied Cypher as a security measure (`src/codegraphcontext/tools/system.py`, `src/codegraphcontext/utils/cypher_readonly.py`, `src/codegraphcontext/viz/server.py`), with tests covering it.
- No APOC usage in `docker-compose.yml`, `k8s/neo4j-deployment.yaml`, `Dockerfile`, docs, or any `.cypher` files.

Since CGC calls zero APOC procedures, the minimal allowlist is the empty set. Per the principle of least privilege I **removed the `unrestricted` grant entirely** rather than allowlisting procedures that are never used. This is both the smallest and the most secure change.

## Changes

- **`docker-compose.yml`** — removed `NEO4J_dbms_security_procedures_unrestricted=apoc.*`.
- **`k8s/neo4j-deployment.yaml`** — removed the `NEO4J_dbms_security_procedures_unrestricted` env var (`value: "apoc.*"`).
- Added an explanatory comment in both files documenting why APOC is installed but not granted unrestricted access.

`NEO4J_PLUGINS=["apoc"]` is **kept as-is** — the plugin still loads; it simply no longer runs with elevated, sandbox-bypassing privileges. Core APOC procedures still work under the default sandbox if ever needed, and CGC's own functionality (fulltext search via `db.index.fulltext.*`, label/relationship introspection) is unaffected because it uses only Neo4j built-ins.

> Note: `docker-compose.template.yml` mentioned in the issue does not exist in the repo, so no change there.

## Validation

- Both YAML files parse cleanly (`docker-compose.yml`: 1 doc; `k8s/neo4j-deployment.yaml`: 3 docs, multi-document manifest).
- Verified programmatically that `NEO4J_PLUGINS` is retained and `NEO4J_dbms_security_procedures_unrestricted` is absent in both files.

## Security note — do not merge without review

This is a security-hardening change to the deployment configuration. Please review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
