### PR TITLE
feat(security): optional API-key auth for HTTP endpoints (#1008)

### DIFF
--- a/src/codegraphcontext/api/app.py
+++ b/src/codegraphcontext/api/app.py
@@ -4,9 +4,14 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from .router import router
+from .auth import log_auth_status
 from .mcp_sse import handle_sse, handle_messages
 
 def create_app() -> FastAPI:
+    # Log whether API-key auth is active. Emits a prominent security warning
+    # when the gateway is running unauthenticated (CGC_API_KEY unset).
+    log_auth_status()
+
     app = FastAPI(
         title="CodeGraphContext Gateway",
         description="HTTP API gateway for CodeGraphContext MCP server. Enables integration with ChatGPT Actions, Claude, and web frontends.",

--- a/src/codegraphcontext/api/auth.py
+++ b/src/codegraphcontext/api/auth.py
@@ -1,0 +1,123 @@
+# src/codegraphcontext/api/auth.py
+"""Optional API-key authentication for the CodeGraphContext HTTP API.
+
+Backward-compatible and opt-in:
+
+* When **no** key is configured, the API behaves exactly as it did before
+  (every endpoint is unauthenticated) but a prominent security warning is
+  logged at startup so operators know the gateway is wide open.
+* When a key **is** configured (via the ``CGC_API_KEY`` environment variable
+  or the standard config mechanism), every protected router endpoint requires
+  it, supplied as either ``Authorization: Bearer <key>`` or ``X-API-Key: <key>``.
+  Missing/incorrect keys receive an HTTP ``401``.
+
+The comparison uses :func:`secrets.compare_digest` to avoid timing side
+channels.
+"""
+
+import logging
+import os
+import secrets
+from typing import Optional
+
+from fastapi import Header, HTTPException
+
+logger = logging.getLogger(__name__)
+
+# Config/env key that holds the API key. Reused as the config_manager key so
+# ``cgc config set CGC_API_KEY <value>`` works as well.
+API_KEY_ENV = "CGC_API_KEY"
+
+
+def get_configured_api_key() -> Optional[str]:
+    """Return the configured API key, or ``None`` when auth is disabled.
+
+    Resolution order (highest priority first):
+
+    1. The ``CGC_API_KEY`` environment variable (read directly so auth works
+       even when no config file is present).
+    2. The value stored via the existing config mechanism
+       (:func:`codegraphcontext.cli.config_manager.get_config_value`).
+
+    Empty / whitespace-only values are treated as "not configured".
+    """
+    env_val = os.getenv(API_KEY_ENV)
+    if env_val and env_val.strip():
+        return env_val.strip()
+
+    # Fall back to the existing config mechanism (global/local .env, defaults).
+    try:
+        from codegraphcontext.cli.config_manager import get_config_value
+
+        cfg_val = get_config_value(API_KEY_ENV)
+        if cfg_val and cfg_val.strip():
+            return cfg_val.strip()
+    except Exception:  # pragma: no cover - config lookup is best-effort here
+        pass
+
+    return None
+
+
+def _extract_provided_key(
+    authorization: Optional[str], x_api_key: Optional[str]
+) -> Optional[str]:
+    """Pull the caller-supplied key from the Authorization or X-API-Key header."""
+    if authorization:
+        value = authorization.strip()
+        if value.lower().startswith("bearer "):
+            return value[len("bearer ") :].strip()
+        # Accept a bare token in the Authorization header as a convenience.
+        return value or None
+    if x_api_key and x_api_key.strip():
+        return x_api_key.strip()
+    return None
+
+
+def _keys_match(provided: str, configured: str) -> bool:
+    """Constant-time comparison that never raises on non-ASCII input."""
+    try:
+        return secrets.compare_digest(
+            provided.encode("utf-8"), configured.encode("utf-8")
+        )
+    except (TypeError, AttributeError):
+        return False
+
+
+async def require_api_key(
+    authorization: Optional[str] = Header(default=None),
+    x_api_key: Optional[str] = Header(default=None, alias="X-API-Key"),
+) -> None:
+    """FastAPI dependency that enforces the API key when one is configured.
+
+    No-op (backward compatible) when no key is set; otherwise requires a valid
+    key via ``Authorization: Bearer <key>`` or ``X-API-Key: <key>``, returning
+    HTTP ``401`` on a missing or incorrect key.
+    """
+    configured = get_configured_api_key()
+    if not configured:
+        # Auth disabled -> preserve the pre-existing unauthenticated behavior.
+        return
+
+    provided = _extract_provided_key(authorization, x_api_key)
+    if not provided or not _keys_match(provided, configured):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or missing API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def log_auth_status() -> None:
+    """Log the authentication status at app startup.
+
+    Emits a prominent WARNING when the API is unauthenticated so the insecure
+    default is impossible to miss in logs.
+    """
+    if get_configured_api_key():
+        logger.info("API key authentication is ENABLED (CGC_API_KEY is set).")
+    else:
+        logger.warning(
+            "⚠️  CodeGraphContext API is running WITHOUT authentication. "
+            "Anyone who can reach this server can index code, run Cypher queries "
+            "and call tools. Set CGC_API_KEY to require a key."
+        )

--- a/src/codegraphcontext/api/router.py
+++ b/src/codegraphcontext/api/router.py
@@ -5,17 +5,21 @@ from typing import Dict, Any, List
 from pathlib import Path
 
 from .schemas import (
-    IndexRequest, 
-    QueryRequest, 
-    SearchRequest, 
-    ToolCallRequest, 
+    IndexRequest,
+    QueryRequest,
+    SearchRequest,
+    ToolCallRequest,
     ApiResponse
 )
+from .auth import require_api_key
 from codegraphcontext.server import MCPServer
 
 import socket
 
-router = APIRouter()
+# Optional API-key auth is enforced on every route below via require_api_key.
+# It is a no-op (backward compatible) unless CGC_API_KEY is configured, in
+# which case each request must supply the key. See codegraphcontext.api.auth.
+router = APIRouter(dependencies=[Depends(require_api_key)])
 
 # Global server instance (initialized on startup)
 _server_instance: MCPServer = None

--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -130,6 +130,11 @@ DEFAULT_CONFIG = {
     # Default LLM model names used for graph queries when no value is explicitly configured
     "OPENAI_MODEL": "gpt-4o",
     "ANTHROPIC_MODEL": "claude-3-5-sonnet-20241022",
+    # Optional API key for the HTTP API gateway. Empty = auth disabled
+    # (backward compatible). When set, HTTP endpoints require the key via
+    # `Authorization: Bearer <key>` or `X-API-Key`. May also be set via the
+    # CGC_API_KEY environment variable (which takes priority).
+    "CGC_API_KEY": "",
 }
 
 # Configuration key descriptions
@@ -207,6 +212,12 @@ CONFIG_DESCRIPTIONS = {
         "Default Anthropic model used for graph queries. "
         "Requires ANTHROPIC_API_KEY environment variable. "
         "Default: claude-3-5-sonnet-20241022"
+    ),
+    "CGC_API_KEY": (
+        "Optional API key protecting the HTTP API gateway. Empty = "
+        "unauthenticated (backward compatible). When set, HTTP endpoints "
+        "require it via `Authorization: Bearer <key>` or the `X-API-Key` "
+        "header. The CGC_API_KEY environment variable overrides this value."
     ),
 }
 
@@ -774,13 +785,17 @@ def show_config():
     for key in sorted(config_settings.keys()):
         value = config_settings[key]
         description = CONFIG_DESCRIPTIONS.get(key, "")
-        
+
+        # Never print secret-like values (e.g. the HTTP API key) in plaintext.
+        if "API_KEY" in key.upper() and value:
+            value = "********"
+
         # Highlight non-default values
         if value != DEFAULT_CONFIG.get(key):
             value_style = "[bold yellow]" + value + "[/bold yellow]"
         else:
             value_style = value
-        
+
         table.add_row(key, value_style, description)
     
     console.print(table)

--- a/tests/unit/api/test_api_auth.py
+++ b/tests/unit/api/test_api_auth.py
@@ -1,0 +1,129 @@
+"""Tests for optional API-key authentication on the HTTP API (issue #1008).
+
+Covers the opt-in, backward-compatible design:
+
+* When ``CGC_API_KEY`` is configured, protected router endpoints require the
+  key via ``Authorization: Bearer <key>`` or ``X-API-Key`` and return 401
+  otherwise.
+* When no key is configured, endpoints stay open (backward compatible) and a
+  prominent security warning is logged at startup.
+* ``/health`` and ``/`` stay unauthenticated regardless of configuration.
+"""
+
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from codegraphcontext.api.app import create_app
+from codegraphcontext.api.router import get_server
+
+API_KEY = "s3cret-key-123"
+PROTECTED_PATH = "/api/v1/repositories"
+
+
+class FakeServer:
+    """Minimal stand-in for MCPServer so protected endpoints can run."""
+
+    async def handle_tool_call(self, name, arguments):
+        return {"repositories": [], "tool": name}
+
+
+@pytest.fixture
+def client_factory(monkeypatch):
+    """Build a TestClient whose get_server dependency is stubbed out.
+
+    Callers pass the desired CGC_API_KEY (or None to leave it unset) so each
+    test controls whether auth is active.
+    """
+
+    def _make(api_key):
+        if api_key is None:
+            monkeypatch.delenv("CGC_API_KEY", raising=False)
+        else:
+            monkeypatch.setenv("CGC_API_KEY", api_key)
+        app = create_app()
+        app.dependency_overrides[get_server] = lambda: FakeServer()
+        return TestClient(app)
+
+    return _make
+
+
+# --- Key configured: auth is enforced ---------------------------------------
+
+def test_missing_header_returns_401(client_factory):
+    client = client_factory(API_KEY)
+    response = client.get(PROTECTED_PATH)
+    assert response.status_code == 401
+
+
+def test_correct_bearer_header_returns_200(client_factory):
+    client = client_factory(API_KEY)
+    response = client.get(
+        PROTECTED_PATH, headers={"Authorization": f"Bearer {API_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_correct_x_api_key_header_returns_200(client_factory):
+    client = client_factory(API_KEY)
+    response = client.get(PROTECTED_PATH, headers={"X-API-Key": API_KEY})
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_wrong_bearer_header_returns_401(client_factory):
+    client = client_factory(API_KEY)
+    response = client.get(
+        PROTECTED_PATH, headers={"Authorization": "Bearer wrong-key"}
+    )
+    assert response.status_code == 401
+
+
+def test_wrong_x_api_key_header_returns_401(client_factory):
+    client = client_factory(API_KEY)
+    response = client.get(PROTECTED_PATH, headers={"X-API-Key": "nope"})
+    assert response.status_code == 401
+
+
+def test_health_stays_open_when_key_configured(client_factory):
+    client = client_factory(API_KEY)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_root_stays_open_when_key_configured(client_factory):
+    client = client_factory(API_KEY)
+    response = client.get("/")
+    assert response.status_code == 200
+
+
+# --- No key configured: backward compatible + warning -----------------------
+
+def test_no_key_endpoint_works_without_header(client_factory):
+    client = client_factory(None)
+    response = client.get(PROTECTED_PATH)
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_no_key_emits_startup_warning(monkeypatch, caplog):
+    monkeypatch.delenv("CGC_API_KEY", raising=False)
+    with caplog.at_level(logging.WARNING, logger="codegraphcontext.api.auth"):
+        create_app()
+    assert any(
+        "without authentication" in record.getMessage().lower()
+        for record in caplog.records
+    ), "Expected a startup security warning when no API key is configured"
+
+
+def test_key_configured_does_not_emit_warning(monkeypatch, caplog):
+    monkeypatch.setenv("CGC_API_KEY", API_KEY)
+    with caplog.at_level(logging.WARNING, logger="codegraphcontext.api.auth"):
+        create_app()
+    assert not any(
+        "without authentication" in record.getMessage().lower()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary

Closes #1008. The HTTP API gateway (`src/codegraphcontext/api/`) currently exposes **every** endpoint with no authentication. `Depends(get_server)` is the only dependency on the routes, so anyone who can reach the server can:

- `POST /api/v1/index` — index arbitrary filesystem paths
- `POST /api/v1/query` — run **arbitrary Cypher** against the graph DB
- `POST /api/v1/tools/call` — invoke any MCP tool
- `GET /api/v1/status`, `/tools`, `/repositories` — enumerate config and indexed repos

This PR adds **opt-in, backward-compatible** API-key authentication.

## Design (opt-in, non-breaking)

- The key is read from **`CGC_API_KEY`** — the environment variable (highest priority) or the existing config mechanism (`get_config_value`, so `cgc config set CGC_API_KEY <key>` works too).
- New FastAPI dependency `require_api_key` is attached to the router (`APIRouter(dependencies=[Depends(require_api_key)])`), covering `/tools/call`, `/index`, `/query`, `/status`, `/tools`, `/repositories`.
- **When a key is configured:** every protected endpoint requires it via `Authorization: Bearer <key>` **or** `X-API-Key: <key>`. Missing/incorrect keys get **401**. Comparison uses `secrets.compare_digest` (constant-time, encoded to bytes so non-ASCII input can't raise).
- **When no key is configured:** behavior is unchanged (endpoints stay open) so existing deployments don't break — but a prominent security warning is logged at startup: `⚠️ CodeGraphContext API is running WITHOUT authentication ... Set CGC_API_KEY to require a key.`
- `/health` and `/` (root HTML) stay unauthenticated by design (they live on `app`, not the router).
- The key is masked (`********`) in `cgc config show`.

## Tests

`tests/unit/api/test_api_auth.py` (10 tests) covers: key set → 401 without header, 200 with correct Bearer, 200 with correct `X-API-Key`, 401 with wrong key (both header styles), `/health` and `/` stay open; no key → endpoint works without header and a startup warning is emitted; key set → no warning. Full `tests/unit/api` suite passes (19 passed).

## Note for maintainers

This is intentionally **auth-off-by-default** to preserve backward compatibility. If you'd prefer **auth-required-by-default** (fail-closed), that's a one-line policy change in `require_api_key` (treat "no key configured" as 401 instead of a no-op) plus docs — happy to flip it if the project prefers secure-by-default. The MCP-over-SSE endpoints (`/api/v1/mcp/*`) are mounted directly on `app` and are **not** covered here; protecting them can be a follow-up.

Security change — please review carefully; do not auto-merge.
