### PR TITLE
fix(security): enforce read-only at session level for user Cypher queries (#1010)

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -519,7 +519,13 @@ def cypher_helper(query: str, context: Optional[str] = None):
         raise typer.Exit(code=1)
 
     backend = getattr(db_manager, "get_backend_type", lambda: "neo4j")()
-    session_kwargs = {"default_access_mode": "READ"} if backend == "neo4j" else {}
+    # Neo4j honours default_access_mode natively; FalkorDB routes READ sessions
+    # through GRAPH.RO_QUERY for server-enforced read-only execution.
+    session_kwargs = (
+        {"default_access_mode": "READ"}
+        if backend in ("neo4j", "falkordb", "falkordb-remote")
+        else {}
+    )
 
     try:
         with db_manager.get_driver().session(**session_kwargs) as session:

--- a/src/codegraphcontext/core/database_falkordb.py
+++ b/src/codegraphcontext/core/database_falkordb.py
@@ -494,11 +494,21 @@ class FalkorDBDriverWrapper:
     
     def __init__(self, graph):
         self.graph = graph
-    
+
     def session(self, **kwargs):
-        """Returns a session-like object for FalkorDB."""
-        return FalkorDBSessionWrapper(self.graph)
-    
+        """Returns a session-like object for FalkorDB.
+
+        Neo4j-specific kwargs are accepted and ignored, except
+        ``default_access_mode``: when it requests READ access we route the
+        session through FalkorDB's server-enforced read-only command
+        (``GRAPH.RO_QUERY``). This gives the user-facing query path real
+        write protection at the database layer instead of relying solely on
+        the regex guard.
+        """
+        access_mode = kwargs.get("default_access_mode")
+        read_only = isinstance(access_mode, str) and access_mode.strip().upper() in ("READ", "R")
+        return FalkorDBSessionWrapper(self.graph, read_only=read_only)
+
     def close(self):
         """FalkorDB Lite doesn't need explicit close for sessions."""
         pass
@@ -508,14 +518,35 @@ class FalkorDBSessionWrapper:
     """
     Wrapper class to provide Neo4j session-like interface for FalkorDB Lite.
     """
-    
-    def __init__(self, graph):
+
+    def __init__(self, graph, read_only: bool = False):
         self.graph = graph
-    
+        self.read_only = read_only
+
     def run(self, query, **parameters):
         """
         Execute a Cypher query on FalkorDB.
+
+        Read-only sessions use ``graph.ro_query`` (GRAPH.RO_QUERY), which the
+        FalkorDB server refuses to run for any write operation. This is the
+        session-level enforcement layer for user-facing read queries; the
+        write-oriented constraint/schema translation below is skipped entirely
+        so that a smuggled write cannot be silently rewritten into a success.
         """
+        if self.read_only:
+            try:
+                ro_query = getattr(self.graph, "ro_query", None)
+                if callable(ro_query):
+                    result = ro_query(query, parameters)
+                else:
+                    # Older FalkorDB clients lack ro_query; fall back to the
+                    # normal path. The regex guard is still the gate here.
+                    result = self.graph.query(query, parameters)
+                return FalkorDBResultWrapper(result)
+            except Exception as e:
+                error_logger(f"FalkorDB read-only query failed: {query[:100]}... Error: {e}")
+                raise
+
         constraint_command = self._translate_constraint_command(query)
         if constraint_command is not None:
             try:

--- a/src/codegraphcontext/tools/handlers/query_handlers.py
+++ b/src/codegraphcontext/tools/handlers/query_handlers.py
@@ -16,8 +16,10 @@ def execute_cypher_query(db_manager, **args) -> Dict[str, Any]:
     """
     Tool implementation for executing a read-only Cypher query.
 
-    Write protection uses keyword validation on every backend. Neo4j sessions
-    also request READ access mode at the protocol layer.
+    Write protection is layered: the regex guard rejects write keywords on
+    every backend, and the session is additionally opened in READ access mode
+    so the database itself refuses writes. Neo4j honours ``default_access_mode``
+    natively; FalkorDB routes READ sessions through ``GRAPH.RO_QUERY``.
     """
     cypher_query = args.get("cypher_query")
     graph_name = args.get("graph_name")
@@ -33,7 +35,10 @@ def execute_cypher_query(db_manager, **args) -> Dict[str, Any]:
 
     backend = getattr(db_manager, "get_backend_type", lambda: "neo4j")()
     session_kwargs: Dict[str, Any] = {}
-    if backend == "neo4j":
+    # Backends that enforce read access at the session/protocol layer.
+    # Neo4j honours default_access_mode natively; the FalkorDB wrapper routes
+    # READ sessions through GRAPH.RO_QUERY (see FalkorDBSessionWrapper).
+    if backend in ("neo4j", "falkordb", "falkordb-remote"):
         session_kwargs["default_access_mode"] = "READ"
 
     try:

--- a/src/codegraphcontext/tools/system.py
+++ b/src/codegraphcontext/tools/system.py
@@ -86,23 +86,20 @@ class SystemTools:
         if not cypher_query:
             return {"error": "Cypher query cannot be empty."}
 
-        import re as _re
-        forbidden_keywords = ['CREATE', 'MERGE', 'DELETE', 'DETACH', 'SET', 'REMOVE', 'DROP', 'LOAD', 'FOREACH']
-        forbidden_patterns = [r'CALL\s+apoc\b', r'CALL\s*\{']
-        string_literal_pattern = r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\''
-        query_without_strings = _re.sub(string_literal_pattern, '', cypher_query)
-        for keyword in forbidden_keywords:
-            if _re.search(r'\b' + keyword + r'\b', query_without_strings, _re.IGNORECASE):
-                return {"error": "This tool only supports read-only queries. Prohibited keywords like CREATE, MERGE, DELETE, SET, etc., are not allowed."}
-        for pattern in forbidden_patterns:
-            if _re.search(pattern, query_without_strings, _re.IGNORECASE):
-                return {"error": "This tool only supports read-only queries. Prohibited keywords like CREATE, MERGE, DELETE, SET, etc., are not allowed."}
+        # Use the shared, hardened guard (word-boundary keywords, string/comment
+        # stripping, multi-statement blocking, dbms/db.*/write-apoc coverage)
+        # rather than a local blocklist that can drift out of sync.
+        from ..utils.cypher_readonly import is_read_only_cypher, read_only_rejection_message
+        if not is_read_only_cypher(cypher_query):
+            return {"error": read_only_rejection_message()}
 
-        # Only the Neo4j driver understands default_access_mode; other
-        # backends' session shims reject it.
+        # Defense in depth: also open the session in READ access mode so the
+        # database refuses writes even if a payload slips past the regex guard.
+        # Neo4j honours default_access_mode natively; the FalkorDB wrapper routes
+        # READ sessions through GRAPH.RO_QUERY.
         backend = getattr(self.db_manager, "get_backend_type", lambda: "neo4j")()
         session_kwargs: Dict[str, Any] = {}
-        if backend == "neo4j":
+        if backend in ("neo4j", "falkordb", "falkordb-remote"):
             session_kwargs["default_access_mode"] = "READ"
 
         try:

--- a/src/codegraphcontext/utils/cypher_readonly.py
+++ b/src/codegraphcontext/utils/cypher_readonly.py
@@ -27,6 +27,11 @@ _FORBIDDEN_PATTERNS = (
     re.compile(r"CALL\s+db\.[a-z0-9_.]*\.(?:create|drop|delete|set|add|remove|alter)\b", re.IGNORECASE),
     re.compile(r"CALL\s+db\.[a-z0-9_.]*create", re.IGNORECASE),
     re.compile(r"CALL\s*\{"),
+    # Write-side APOC procedures are blocked explicitly (not only via the bare
+    # `CALL apoc` rule above) so they are also caught when invoked inline, with
+    # a yield/where clause, or in any spacing the `CALL apoc` rule might miss.
+    # These namespaces mutate the graph and must never run on a read path.
+    re.compile(r"\bapoc\.(?:create|merge|refactor|periodic)\b", re.IGNORECASE),
 )
 _STRING_LITERAL_RE = re.compile(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
 _LINE_COMMENT_RE = re.compile(r"//[^\n]*")

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -24,6 +24,20 @@ from ..utils.cypher_readonly import is_read_only_cypher as _is_read_only_cypher,
 app = FastAPI()
 
 
+def _read_session_kwargs(manager) -> dict:
+    """Session kwargs that request READ access for read-only endpoints.
+
+    Neo4j honours ``default_access_mode`` natively; the FalkorDB wrapper routes
+    READ sessions through ``GRAPH.RO_QUERY`` for server-enforced read-only
+    execution. Other backends' session shims ignore unknown kwargs, so this is
+    safe to pass unconditionally for those we know enforce it.
+    """
+    backend = getattr(manager, "get_backend_type", lambda: "neo4j")()
+    if backend in ("neo4j", "falkordb", "falkordb-remote"):
+        return {"default_access_mode": "READ"}
+    return {}
+
+
 def _static_root() -> Path:
     if not _static_dir:
         raise HTTPException(status_code=500, detail="Static directory not configured")
@@ -123,7 +137,10 @@ async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str]
 
         print(f"DEBUG: Starting get_graph with repo_path={repo_path}", flush=True)
 
-        with db_manager.get_driver().session() as session:
+        # This endpoint only ever reads. Open the session in READ access mode so
+        # the database enforces read-only (Neo4j default_access_mode / FalkorDB
+        # GRAPH.RO_QUERY) in addition to the regex guard on any user query.
+        with db_manager.get_driver().session(**_read_session_kwargs(db_manager)) as session:
             if cypher_query:
                 if not _is_read_only_cypher(cypher_query):
                     raise HTTPException(
@@ -563,8 +580,8 @@ Respond ONLY with a JSON object in this format:
         nodes_dict = {}
         edges = []
         records_data = []
-        
-        with db_manager.get_driver().session() as session:
+
+        with db_manager.get_driver().session(**_read_session_kwargs(db_manager)) as session:
             result = session.run(cypher_query)
             for record in result:
                 # Store truncated record data for explanation phase

--- a/tests/unit/tools/test_cypher_readonly_enforcement.py
+++ b/tests/unit/tools/test_cypher_readonly_enforcement.py
@@ -1,0 +1,128 @@
+"""
+Defense-in-depth tests for read-only enforcement of user Cypher queries (#1010).
+
+The regex guard (is_read_only_cypher) is only the first layer. These tests
+assert the *session-level* enforcement that the guard cannot provide:
+
+  - Neo4j: the read path opens a session with default_access_mode="READ", so
+    the server rejects writes at the protocol layer.
+  - FalkorDB: FalkorDB ignores default_access_mode, so the wrapper routes READ
+    sessions through graph.ro_query (GRAPH.RO_QUERY), which the FalkorDB server
+    refuses to run for any write operation.
+"""
+
+from codegraphcontext.core.database_falkordb import (
+    FalkorDBDriverWrapper,
+    FalkorDBSessionWrapper,
+)
+
+
+# --------------------------------------------------------------------------
+# A mock FalkorDB graph that records which command (query vs ro_query) ran.
+# --------------------------------------------------------------------------
+
+class _MockResult:
+    header = [("COL", "n")]
+    result_set = [[1]]
+
+
+class MockFalkorGraph:
+    name = "test"
+
+    def __init__(self):
+        self.query_calls = []
+        self.ro_query_calls = []
+
+    def query(self, q, params=None, timeout=None):
+        self.query_calls.append(q)
+        return _MockResult()
+
+    def ro_query(self, q, params=None, timeout=None):
+        self.ro_query_calls.append(q)
+        return _MockResult()
+
+
+class MockFalkorDBManager:
+    def __init__(self, graph):
+        self._graph = graph
+
+    def get_backend_type(self):
+        return "falkordb"
+
+    def get_driver(self, graph_name=None):
+        return FalkorDBDriverWrapper(self._graph)
+
+
+# --------------------------------------------------------------------------
+# Wrapper-level: READ sessions must use ro_query; default sessions use query.
+# --------------------------------------------------------------------------
+
+def test_falkordb_read_session_uses_ro_query():
+    graph = MockFalkorGraph()
+    session = FalkorDBDriverWrapper(graph).session(default_access_mode="READ")
+    assert isinstance(session, FalkorDBSessionWrapper)
+    assert session.read_only is True
+
+    session.run("MATCH (n) RETURN n LIMIT 1")
+    assert graph.ro_query_calls == ["MATCH (n) RETURN n LIMIT 1"]
+    assert graph.query_calls == []  # the write-capable path was never touched
+
+
+def test_falkordb_default_session_uses_write_query_path():
+    # Internal indexing writes (no access mode) must still use graph.query().
+    graph = MockFalkorGraph()
+    session = FalkorDBDriverWrapper(graph).session()
+    assert session.read_only is False
+
+    session.run("MATCH (n) RETURN n")
+    assert graph.query_calls == ["MATCH (n) RETURN n"]
+    assert graph.ro_query_calls == []
+
+
+# --------------------------------------------------------------------------
+# End-to-end via execute_cypher_query on a FalkorDB backend.
+# --------------------------------------------------------------------------
+
+def test_execute_cypher_query_falkordb_reads_via_ro_query():
+    from codegraphcontext.tools.handlers.query_handlers import execute_cypher_query
+
+    graph = MockFalkorGraph()
+    manager = MockFalkorDBManager(graph)
+    result = execute_cypher_query(manager, cypher_query="MATCH (n) RETURN n LIMIT 1")
+
+    assert result.get("success") is True, f"Expected success, got: {result}"
+    # The query reached the server through the server-enforced read-only path.
+    assert graph.ro_query_calls == ["MATCH (n) RETURN n LIMIT 1"]
+    assert graph.query_calls == []
+
+
+def test_execute_cypher_query_falkordb_rejects_write_before_driver():
+    from codegraphcontext.tools.handlers.query_handlers import execute_cypher_query
+
+    graph = MockFalkorGraph()
+    manager = MockFalkorDBManager(graph)
+
+    for write in (
+        "CREATE (n:Foo {x: 1})",
+        "MATCH (n) DETACH DELETE n",
+        "MATCH (n) SET n.pwned = true",
+        "CALL apoc.create.node(['L'], {}) YIELD node RETURN node",
+    ):
+        result = execute_cypher_query(manager, cypher_query=write)
+        assert "error" in result, f"write query slipped through the guard: {write!r}"
+        # The regex guard rejected it before any driver call — nothing ran.
+        assert graph.query_calls == []
+        assert graph.ro_query_calls == []
+
+
+def test_execute_cypher_query_falkordb_var_named_created_allowed():
+    # keyword-as-substring must not be falsely rejected on the FalkorDB path.
+    from codegraphcontext.tools.handlers.query_handlers import execute_cypher_query
+
+    graph = MockFalkorGraph()
+    manager = MockFalkorDBManager(graph)
+    result = execute_cypher_query(
+        manager, cypher_query="MATCH (n) RETURN n.created AS created LIMIT 1"
+    )
+    assert result.get("success") is True, f"Expected success, got: {result}"
+    assert graph.ro_query_calls == ["MATCH (n) RETURN n.created AS created LIMIT 1"]

--- a/tests/unit/utils/test_cypher_readonly.py
+++ b/tests/unit/utils/test_cypher_readonly.py
@@ -27,3 +27,25 @@ def test_blocks_multi_statement_queries():
 
 def test_ignores_write_keywords_in_comments():
     assert is_read_only_cypher("// CREATE (n)\nMATCH (n) RETURN n")
+
+
+def test_blocks_write_apoc_procedures():
+    # Write-side APOC namespaces must be rejected, whether called or inline.
+    assert not is_read_only_cypher("CALL apoc.create.node(['L'], {}) YIELD node RETURN node")
+    assert not is_read_only_cypher("CALL apoc.merge.node(['L'], {id: 1}) YIELD node RETURN node")
+    assert not is_read_only_cypher("CALL apoc.refactor.mergeNodes([n]) YIELD node RETURN node")
+    assert not is_read_only_cypher(
+        "CALL apoc.periodic.iterate('MATCH (n) RETURN n', 'DELETE n', {}) YIELD batches RETURN batches"
+    )
+    # Inline (non-CALL) invocation of a write namespace is still rejected.
+    assert not is_read_only_cypher("RETURN apoc.create.uuid() AS id")
+
+
+def test_keyword_as_substring_not_false_positive():
+    # A variable/identifier that merely contains a write keyword as a substring
+    # (e.g. `created`, `deleted`, `Asset`) must NOT be rejected.
+    assert is_read_only_cypher("MATCH (n) WHERE n.created > 0 RETURN n.created AS created")
+    assert is_read_only_cypher("MATCH (n) RETURN n.deleted AS deleted")
+    assert is_read_only_cypher("MATCH (n:Asset) RETURN n")
+    # Read-only APOC helpers (path/coll/text) are still permitted inline.
+    assert is_read_only_cypher("RETURN apoc.coll.max([1, 2, 3]) AS m")


### PR DESCRIPTION
## Summary

Fixes #1010. The read-only guard for user-facing Cypher was **regex-only**, and FalkorDB did **not** enforce read-only at the session/protocol layer (it ignored `default_access_mode` and always ran the write-capable `graph.query()`). A payload that slipped past the blocklist — or any gap in it — could therefore execute a write. This PR adds **defense in depth**: the regex guard stays, and real read-only enforcement is added at the database session layer for every user-facing read path.

## The vulnerability

- `is_read_only_cypher` (regex blocklist) was the *only* thing standing between a user query and a write. Blocklists are bypassable.
- **Neo4j** read paths mostly opened `default_access_mode="READ"` already, but the **viz** endpoints opened a plain read/write session.
- **FalkorDB** (embedded + remote) had **no** session-level enforcement at all — `default_access_mode` was accepted and ignored, so writes were only ever blocked by the regex.

## The layered fix

**1. Session-level enforcement (the real gate)**
- **Neo4j**: user/read queries open `session(default_access_mode="READ")` — the server rejects writes at the protocol layer. Extended to the two `viz/server.py` read endpoints, which previously used a plain session.
- **FalkorDB** (embedded + remote): `FalkorDBDriverWrapper.session(default_access_mode="READ")` now returns a read-only session that routes queries through **`graph.ro_query()` (`GRAPH.RO_QUERY`)**, which the FalkorDB server refuses to run for any write operation. Internal indexing writes (no access mode) still use the normal `graph.query()` path — untouched.
  - FalkorDB *does* expose a read-only exec API (`ro_query`), so this is genuine server-side enforcement, not a regex fallback. If an older client lacks `ro_query`, the wrapper falls back to `query()` and the regex guard remains the gate.

**2. Hardened regex guard (`cypher_readonly.py`)**
- Keyword matching already used word boundaries (so `created`/`deleted`/`Asset` are not false-positives) and strips string literals + comments.
- Added explicit blocking of **write APOC namespaces** — `apoc.create.*`, `apoc.merge.*`, `apoc.refactor.*`, `apoc.periodic.*` — so they are caught even when invoked inline (not just via `CALL apoc`). Existing coverage (`CALL apoc`, `CALL dbms`, `CALL db.*.create`, `CALL {`, multi-statement `;`) is unchanged.

**3. Unified the second read path**
- `SystemTools.execute_cypher_query_tool` had its own drifting inline blocklist; it now uses the shared `is_read_only_cypher` guard and the same READ-access session logic.

Enforcement is applied **only** to user-facing read paths (`execute_cypher_query` / `/query` endpoint, CLI `cypher`, viz endpoints), **not** to CodeGraphContext's own internal indexing writes.

## Tests

- `tests/unit/utils/test_cypher_readonly.py`: write APOC procedures rejected (`apoc.create/merge/refactor/periodic`, called or inline); keyword-as-substring (`created`, `deleted`, `Asset`) not falsely rejected; read-only APOC helpers still allowed.
- `tests/unit/tools/test_cypher_readonly_enforcement.py` (new): mocks the FalkorDB driver to assert READ sessions use `ro_query` and default sessions use `query`; end-to-end `execute_cypher_query` on a FalkorDB backend goes through `ro_query`; write queries (`CREATE`/`DETACH DELETE`/`SET`/`CALL apoc.create`) are rejected before any driver call.
- Existing Neo4j read-access-session assertions (`test_cypher_query_readonly.py`) continue to pass.

Full `tests/unit` run: no new failures (the only failing tests are the pre-existing, unrelated `test_cgcignore_patterns.py` cases).

> Security change — please review; do not fast-merge.
