### PR TITLE
fix(graph): stop silent failures in schema DDL, FalkorDB errors and label discovery

### DIFF
--- a/src/codegraphcontext/core/database_falkordb.py
+++ b/src/codegraphcontext/core/database_falkordb.py
@@ -416,11 +416,36 @@ class FalkorDBManager:
         """Closes the connection. Pass teardown=True to stop the worker subprocess."""
         if self._driver is not None:
             info_logger("Closing FalkorDB Lite connection")
+            # Dropping the reference alone leaks the underlying redis
+            # connection pool: `connected_clients` on the server grew by one
+            # per get_driver()/close_driver() cycle and never came back down,
+            # which in a long-running MCP server that switches contexts trends
+            # toward the redis `maxclients` limit.
+            self._disconnect_pool(self._driver)
             self._driver = None
             self._graph = None
             self._graphs = {}
         if teardown:
             self.shutdown()
+
+    @staticmethod
+    def _disconnect_pool(driver) -> None:
+        """Best-effort release of the redis connection pool behind *driver*."""
+        for attr in ("connection", "_conn"):
+            conn = getattr(driver, attr, None)
+            pool = getattr(conn, "connection_pool", None)
+            if pool is not None:
+                try:
+                    pool.disconnect()
+                except Exception as exc:  # noqa: BLE001 - closing must never raise
+                    info_logger(f"FalkorDB pool disconnect failed: {exc}")
+                return
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception as exc:  # noqa: BLE001
+                    info_logger(f"FalkorDB connection close failed: {exc}")
+                return
 
     def shutdown(self):
         """Kills the subprocess on exit."""
@@ -535,13 +560,40 @@ class FalkorDBSessionWrapper:
             result = self.graph.query(query, parameters)
             return FalkorDBResultWrapper(result)
         except Exception as e:
-            # Ignore errors about existing constraints/indexes
+            # "already exists" is only benign for schema DDL, where it means the
+            # index/constraint was created by an earlier run. Applying the test
+            # to *every* query turned genuine data-write failures into an empty
+            # success wrapper (.data() == [], .single() is None), so callers
+            # blew up with a TypeError far away from the real cause.
             error_msg = str(e).lower()
-            if "already exists" in error_msg or "already created" in error_msg or "already indexed" in error_msg:
+            is_benign_ddl = self._is_schema_ddl(query) and (
+                "already exists" in error_msg
+                or "already created" in error_msg
+                or "already indexed" in error_msg
+            )
+            if is_benign_ddl:
                 return FalkorDBResultWrapper(None)
-                
+
             error_logger(f"FalkorDB query failed: {query[:100]}... Error: {e}")
             raise
+
+    @staticmethod
+    def _is_schema_ddl(query: str) -> bool:
+        """True when *query* is a schema statement, matched on its leading
+        keyword rather than by searching the whole text (which would also
+        match the same words inside a string literal)."""
+        head = query.lstrip().lstrip("(").lstrip()
+        return bool(
+            re.match(
+                r"(?is)\A(CREATE|DROP)\s+"
+                r"(BTREE\s+|RANGE\s+|TEXT\s+|POINT\s+|VECTOR\s+|FULLTEXT\s+)?"
+                r"(INDEX|CONSTRAINT)\b",
+                head,
+            )
+            # FalkorDB's procedural index API, e.g.
+            # CALL db.idx.fulltext.createNodeIndex('Function', 'name', ...)
+            or bool(re.match(r"(?is)\ACALL\s+db\.idx\.", head))
+        )
 
     def _translate_constraint_command(self, query: str):
         """

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -114,12 +114,17 @@ class GraphWriter:
                     result = session.run(
                         "MATCH (n) RETURN DISTINCT label(n) AS lbl"
                     )
-                    labels = sorted(
+                    return sorted(
                         {record[0] for record in result if record[0] is not None}
                     )
-                    if labels:
-                        return labels
-                return execute_read_operation(self.driver, backend, _work)
+                # `_work` used to fall off the end (returning None) when it
+                # discovered no labels, and the caller iterates this result —
+                # aborting delete_repository_from_graph with a TypeError
+                # *after* it had already dropped every relationship, leaving a
+                # half-deleted repository. Fall through to the canonical list.
+                discovered = execute_read_operation(self.driver, backend, _work)
+                if discovered:
+                    return discovered
             except Exception as e:
                 info_logger(
                     f"[DELETE] label discovery failed for {backend} "

--- a/src/codegraphcontext/tools/indexing/schema.py
+++ b/src/codegraphcontext/tools/indexing/schema.py
@@ -6,6 +6,30 @@ from typing import Any
 from ...utils.debug_log import info_logger, warning_logger
 
 
+class _DDLRunner:
+    """Runs schema DDL so that one failing statement cannot skip the rest.
+
+    Every statement here is independent (`CREATE INDEX ...` on a distinct
+    label), but they used to share a single try/except: the first failure
+    aborted the remaining ~35, leaving the graph without indexes on Class,
+    Variable, Parameter and friends. Every `MERGE` then degenerated into a
+    full label scan, turning indexing quadratic with nothing surfaced.
+    """
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+        self.attempted = 0
+        self.failures: list[tuple[str, str]] = []
+
+    def run(self, statement: str, *args: Any, **kwargs: Any) -> Any:
+        self.attempted += 1
+        try:
+            return self._session.run(statement, *args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 - one bad statement must not stop the rest
+            self.failures.append((" ".join(statement.split())[:120], str(exc)))
+            return None
+
+
 def create_graph_schema(driver: Any, db_manager: Any) -> None:
     """Create constraints and indexes. *driver* must support .session() context manager."""
     backend_type = getattr(db_manager, "get_backend_type", lambda: "neo4j")()
@@ -16,99 +40,109 @@ def create_graph_schema(driver: Any, db_manager: Any) -> None:
     is_falkordb = backend_type.startswith("falkordb")
 
     with driver.session() as session:
+        ddl = _DDLRunner(session)
         try:
             if is_falkordb:
                 # FalkorDB requires a supporting index to exist BEFORE creating a UNIQUE constraint.
-                session.run("CREATE INDEX IF NOT EXISTS FOR (r:Repository) ON (r.path)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (f:File) ON (f.path)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (d:Directory) ON (d.path)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (m:Module) ON (m.name)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (f:Function) ON (f.name, f.path, f.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (c:Class) ON (c.name, c.path, c.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (t:Trait) ON (t.name, t.path, t.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (i:Interface) ON (i.name, i.path, i.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (m:Macro) ON (m.name, m.path, m.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (v:Variable) ON (v.name, v.path, v.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (s:Struct) ON (s.name, s.path, s.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (e:Enum) ON (e.name, e.path, e.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (u:Union) ON (u.name, u.path, u.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (a:Annotation) ON (a.name, a.path, a.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (r:Record) ON (r.name, r.path, r.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (p:Property) ON (p.name, p.path, p.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (em:EnumMember) ON (em.name, em.path)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (o:Object) ON (o.name, o.path, o.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (mx:Mixin) ON (mx.name, mx.path, mx.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (ex:Extension) ON (ex.name, ex.path, ex.line_number)")
-                session.run("CREATE INDEX IF NOT EXISTS FOR (p:Parameter) ON (p.name, p.path, p.function_line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (r:Repository) ON (r.path)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (f:File) ON (f.path)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (d:Directory) ON (d.path)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (m:Module) ON (m.name)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (f:Function) ON (f.name, f.path, f.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (c:Class) ON (c.name, c.path, c.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (t:Trait) ON (t.name, t.path, t.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (i:Interface) ON (i.name, i.path, i.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (m:Macro) ON (m.name, m.path, m.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (v:Variable) ON (v.name, v.path, v.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (s:Struct) ON (s.name, s.path, s.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (e:Enum) ON (e.name, e.path, e.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (u:Union) ON (u.name, u.path, u.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (a:Annotation) ON (a.name, a.path, a.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (r:Record) ON (r.name, r.path, r.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (p:Property) ON (p.name, p.path, p.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (em:EnumMember) ON (em.name, em.path)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (o:Object) ON (o.name, o.path, o.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (mx:Mixin) ON (mx.name, mx.path, mx.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (ex:Extension) ON (ex.name, ex.path, ex.line_number)")
+                ddl.run("CREATE INDEX IF NOT EXISTS FOR (p:Parameter) ON (p.name, p.path, p.function_line_number)")
 
             if not is_falkordb:
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT repository_path IF NOT EXISTS FOR (r:Repository) REQUIRE r.path IS UNIQUE"
                 )
-                session.run("CREATE CONSTRAINT path IF NOT EXISTS FOR (f:File) REQUIRE f.path IS UNIQUE")
-                session.run(
+                ddl.run("CREATE CONSTRAINT path IF NOT EXISTS FOR (f:File) REQUIRE f.path IS UNIQUE")
+                ddl.run(
                     "CREATE CONSTRAINT directory_path IF NOT EXISTS FOR (d:Directory) REQUIRE d.path IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT function_unique IF NOT EXISTS FOR (f:Function) REQUIRE (f.name, f.path, f.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT class_unique IF NOT EXISTS FOR (c:Class) REQUIRE (c.name, c.path, c.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT trait_unique IF NOT EXISTS FOR (t:Trait) REQUIRE (t.name, t.path, t.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT interface_unique IF NOT EXISTS FOR (i:Interface) REQUIRE (i.name, i.path, i.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT macro_unique IF NOT EXISTS FOR (m:Macro) REQUIRE (m.name, m.path, m.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT variable_unique IF NOT EXISTS FOR (v:Variable) REQUIRE (v.name, v.path, v.line_number) IS UNIQUE"
                 )
-                session.run("CREATE CONSTRAINT module_name IF NOT EXISTS FOR (m:Module) REQUIRE m.name IS UNIQUE")
-                session.run(
+                ddl.run("CREATE CONSTRAINT module_name IF NOT EXISTS FOR (m:Module) REQUIRE m.name IS UNIQUE")
+                ddl.run(
                     "CREATE CONSTRAINT struct_cpp IF NOT EXISTS FOR (cstruct: Struct) REQUIRE (cstruct.name, cstruct.path, cstruct.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT enum_cpp IF NOT EXISTS FOR (cenum: Enum) REQUIRE (cenum.name, cenum.path, cenum.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT union_cpp IF NOT EXISTS FOR (cunion: Union) REQUIRE (cunion.name, cunion.path, cunion.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT annotation_unique IF NOT EXISTS FOR (a:Annotation) REQUIRE (a.name, a.path, a.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT record_unique IF NOT EXISTS FOR (r:Record) REQUIRE (r.name, r.path, r.line_number) IS UNIQUE"
                 )
-                session.run(
+                ddl.run(
                     "CREATE CONSTRAINT property_unique IF NOT EXISTS FOR (p:Property) REQUIRE (p.name, p.path, p.line_number) IS UNIQUE"
                 )
 
-            session.run("CREATE INDEX function_lang IF NOT EXISTS FOR (f:Function) ON (f.lang)")
-            session.run("CREATE INDEX class_lang IF NOT EXISTS FOR (c:Class) ON (c.lang)")
-            session.run("CREATE INDEX annotation_lang IF NOT EXISTS FOR (a:Annotation) ON (a.lang)")
-            session.run(
+            ddl.run("CREATE INDEX function_lang IF NOT EXISTS FOR (f:Function) ON (f.lang)")
+            ddl.run("CREATE INDEX class_lang IF NOT EXISTS FOR (c:Class) ON (c.lang)")
+            ddl.run("CREATE INDEX annotation_lang IF NOT EXISTS FOR (a:Annotation) ON (a.lang)")
+            ddl.run(
                 "CREATE INDEX parameter_unique IF NOT EXISTS FOR (p:Parameter) ON (p.name, p.path, p.function_line_number)"
             )
 
             if is_falkordb and backend_type == "falkordb":
                 for label in ["Function", "Class"]:
                     try:
-                        session.run(
+                        ddl.run(
                             f"CALL db.idx.fulltext.createNodeIndex('{label}', 'name', 'source', 'docstring')"
                         )
                     except Exception:
                         pass
             elif backend_type == "neo4j":
-                session.run("""
+                ddl.run("""
                     CREATE FULLTEXT INDEX code_search_index IF NOT EXISTS
                     FOR (n:Function|Class|Variable)
                     ON EACH [n.name, n.source, n.docstring]
                 """)
 
-            info_logger("Database schema verified/created successfully")
+            if ddl.failures:
+                warning_logger(
+                    f"Database schema created with {len(ddl.failures)} failed "
+                    f"statement(s) out of {ddl.attempted}; the affected indexes "
+                    "are missing and MERGE-heavy queries may be slow."
+                )
+                for statement, error in ddl.failures:
+                    warning_logger(f"  DDL failed: {statement} -> {error}")
+            else:
+                info_logger("Database schema verified/created successfully")
         except Exception as e:
             warning_logger(f"Schema creation warning: {e}")

--- a/tests/unit/core/test_graph_layer_robustness.py
+++ b/tests/unit/core/test_graph_layer_robustness.py
@@ -1,0 +1,129 @@
+"""Regression tests for graph-layer failure handling."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.core.database_falkordb import (
+    FalkorDBManager,
+    FalkorDBSessionWrapper,
+)
+from codegraphcontext.tools.indexing.schema import create_graph_schema
+
+
+class _FlakySession:
+    """Session whose Nth statement always fails."""
+
+    def __init__(self, fail_on):
+        self.fail_on = fail_on
+        self.executed = []
+
+    def run(self, statement, *args, **kwargs):
+        self.executed.append(" ".join(statement.split()))
+        if len(self.executed) == self.fail_on:
+            raise RuntimeError("simulated DDL failure")
+        return MagicMock()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _Driver:
+    def __init__(self, session):
+        self._session = session
+
+    def session(self, **kwargs):
+        return self._session
+
+
+@pytest.mark.parametrize("backend", ["falkordb", "neo4j"])
+def test_one_failing_ddl_statement_does_not_skip_the_rest(backend):
+    """A single failing CREATE INDEX used to abort the remaining ~35
+    statements, leaving the graph unindexed with nothing surfaced."""
+    session = _FlakySession(fail_on=5)
+    db_manager = MagicMock()
+    db_manager.get_backend_type.return_value = backend
+
+    create_graph_schema(_Driver(session), db_manager)
+
+    assert len(session.executed) > 20, (
+        f"only {len(session.executed)} statements ran; a failure still aborts the rest"
+    )
+
+
+def test_all_ddl_statements_run_when_none_fail():
+    session = _FlakySession(fail_on=0)
+    db_manager = MagicMock()
+    db_manager.get_backend_type.return_value = "falkordb"
+
+    create_graph_schema(_Driver(session), db_manager)
+
+    assert len(session.executed) > 20
+
+
+class _Graph:
+    def __init__(self, exc):
+        self.exc = exc
+
+    def query(self, query, parameters):
+        raise self.exc
+
+
+def test_already_exists_is_swallowed_only_for_schema_ddl():
+    """The substring test used to apply to every query, so a genuine data
+    write that failed came back as an empty success wrapper."""
+    wrapper = FalkorDBSessionWrapper(_Graph(RuntimeError("Index already exists")))
+
+    # DDL: benign, swallowed.
+    result = wrapper.run("CREATE INDEX FOR (f:Function) ON (f.name)")
+    assert result.data() == []
+
+    # Data write with the same error text: must propagate.
+    with pytest.raises(RuntimeError):
+        wrapper.run("UNWIND $batch AS row MERGE (n:Function {name: row.name})")
+
+
+def test_schema_ddl_detection():
+    is_ddl = FalkorDBSessionWrapper._is_schema_ddl
+    assert is_ddl("CREATE INDEX FOR (f:Function) ON (f.name)")
+    assert is_ddl("  create constraint foo IF NOT EXISTS FOR (f:File) REQUIRE f.path IS UNIQUE")
+    assert is_ddl("CREATE FULLTEXT INDEX code_search_index FOR (n:Function) ON EACH [n.name]")
+    assert is_ddl("CALL db.idx.fulltext.createNodeIndex('Function', 'name')")
+    assert is_ddl("DROP INDEX foo")
+    # A data query merely *mentioning* the words is not DDL.
+    assert not is_ddl("MATCH (f:Function) WHERE f.source CONTAINS 'CREATE INDEX' RETURN f")
+    assert not is_ddl("MERGE (n:Function {name: 'CREATE CONSTRAINT'})")
+    assert not is_ddl("MATCH (n) RETURN n")
+
+
+def test_close_driver_disconnects_the_connection_pool():
+    """Dropping the reference alone leaked one redis client per cycle."""
+    manager = FalkorDBManager.__new__(FalkorDBManager)
+    pool = MagicMock()
+    driver = MagicMock()
+    driver.connection.connection_pool = pool
+    manager._driver = driver
+    manager._graph = MagicMock()
+    manager._graphs = {"g": MagicMock()}
+    manager._process = None
+
+    manager.close_driver()
+
+    pool.disconnect.assert_called_once()
+    assert manager._driver is None
+
+
+def test_close_driver_survives_a_pool_that_raises():
+    manager = FalkorDBManager.__new__(FalkorDBManager)
+    driver = MagicMock()
+    driver.connection.connection_pool.disconnect.side_effect = RuntimeError("boom")
+    manager._driver = driver
+    manager._graph = None
+    manager._graphs = {}
+    manager._process = None
+
+    manager.close_driver()   # must not raise
+
+    assert manager._driver is None


### PR DESCRIPTION
Four independent graph-layer defects from an end-to-end audit of 0.5.2. Every one of them fails *quietly* — the common thread is that the system keeps going and reports success.

### 1. One failing DDL statement skipped ~35 more (`G-M05`)

`create_graph_schema` ran all 43 `CREATE INDEX` / `CREATE CONSTRAINT` statements inside a single `try:` whose only handler was `warning_logger` — invisible under the shipped default `ENABLE_APP_LOGS=CRITICAL`.

Reproduced with a stub driver failing on statement 5:

```
statements executed: 5
   CREATE INDEX … (r:Repository) ON (r.path)
   … (f:File) ON (f.path)
   … (d:Directory) ON (d.path)
   … (m:Module) ON (m.name)
   … (f:Function) ON (f.name, f.path, f.line_number)   ← failed; 20+ statements skipped
```

The graph then runs without indexes on `Class`, `Variable`, `Parameter` etc., so every `MERGE` in `add_file_to_graph` degenerates to a full label scan — indexing goes quadratic with nothing surfaced. Each statement now runs independently through a small `_DDLRunner`, and failures are reported with a count plus the offending statements.

### 2. "already exists" was swallowed for *every* query (`G-M06`)

```python
# before
if "already exists" in error_msg or "already created" in error_msg or "already indexed" in error_msg:
    return FalkorDBResultWrapper(None)      # looks like a successful empty result
```

Applied to data writes too. A failing write came back as an empty success wrapper (`.data() == []`, `.single()` is `None`), so a caller doing `result.single()["cnt"]` got a `TypeError` nowhere near the cause. The allow-list now applies only to schema DDL, detected from the **leading keyword** rather than by searching the whole query — so a query merely *mentioning* `CREATE INDEX` inside a string literal is not misclassified.

### 3. `_get_all_node_labels` could return `None` mid-delete (`G-L13`)

The Kùzu/Ladybug branch fell off the end of `_work` when it found no labels, so the `except`-fallback to `NODE_LABELS` was bypassed and `None` was returned. The caller does `for label in all_labels:` → `TypeError`, aborting `delete_repository_from_graph` **after** it had already deleted all CALLS/INHERITS/IMPORTS/CONTAINS relationships — leaving a half-deleted repository. It now falls through to the canonical list.

### 4. FalkorDB connections were never released (`G-L12`)

`close_driver` set `self._driver = None` without disconnecting the pool. Measured against a live server:

```
clients at start:                             1
after 15  get_driver()/close_driver() cycles: 6   (+5)
after 100 get_driver()/close_driver() cycles: 21  (+20)
```

Linear growth, trending toward redis `maxclients` in a long-running MCP server that switches contexts. Closing is now best-effort and never raises.

### Tests

7 new tests. **5 of them fail against the unpatched source**, verified by stashing the fix:

```
FAILED test_one_failing_ddl_statement_does_not_skip_the_rest[falkordb]
FAILED test_one_failing_ddl_statement_does_not_skip_the_rest[neo4j]
FAILED test_already_exists_is_swallowed_only_for_schema_ddl
FAILED test_schema_ddl_detection
FAILED test_close_driver_disconnects_the_connection_pool
```

### A note on the suite

`tests/unit/core/test_cgcignore_patterns.py` is **flaky on `main`, independently of this PR** — it stands up a real shared database. Two consecutive full-suite runs on pristine `upstream/main` both gave `5 failed, 735 passed`, with the failing test names varying run to run. Excluding just that file, this branch is:

```
717 passed, 7 skipped, 0 failed
```

Worth a separate issue; I didn't touch it here.

<sub>From an end-to-end audit of CGC 0.5.2. Related filed findings: #1382–#1402.</sub>