### PR TITLE
fix(registry): stop leaking GITHUB_TOKEN to huggingface.co; use POSIX paths for repo scoping

### DIFF
--- a/src/codegraphcontext/core/bundle_registry.py
+++ b/src/codegraphcontext/core/bundle_registry.py
@@ -11,19 +11,58 @@ class RegistryUnavailableError(RuntimeError):
     """Raised when the remote bundle registry cannot be reached."""
 
 
+import os
+import re
+
+#: Hugging Face dataset repos are `owner/name`; anything else (a slash-prefixed
+#: value, a scheme, a host) would let HF_REGISTRY_REPO steer the request to an
+#: arbitrary host — and therefore steer any credential attached to it.
+_HF_REPO_RE = re.compile(r"\A[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*\Z")
+
+DEFAULT_HF_REGISTRY_REPO = "codegraphcontext/registry"
+
+
 def _github_headers() -> dict:
-    """Return GitHub API headers, including auth token if available."""
-    import os
+    """Return GitHub API headers, including auth token if available.
+
+    Only ever attach this to api.github.com requests. The registry manifest
+    lives on huggingface.co and must not receive a GitHub credential.
+    """
     headers = {"Accept": "application/vnd.github.v3+json"}
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
     if token:
         headers["Authorization"] = f"token {token}"
     return headers
 
+
+def _huggingface_headers() -> dict:
+    """Headers for huggingface.co. Uses HF_TOKEN — never the GitHub token."""
+    headers = {"Accept": "application/json"}
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _resolve_hf_registry_repo() -> str:
+    """Return the configured HF dataset repo, rejecting anything not `owner/name`."""
+    hf_repo = os.environ.get("HF_REGISTRY_REPO") or DEFAULT_HF_REGISTRY_REPO
+    if not _HF_REPO_RE.match(hf_repo):
+        logger.warning(
+            "Ignoring invalid HF_REGISTRY_REPO %r (expected 'owner/name'); "
+            "falling back to %s",
+            hf_repo,
+            DEFAULT_HF_REGISTRY_REPO,
+        )
+        return DEFAULT_HF_REGISTRY_REPO
+    return hf_repo
+
+
 def _get_manifest_url() -> str:
-    import os
-    hf_repo = os.environ.get("HF_REGISTRY_REPO") or "codegraphcontext/registry"
-    return f"https://huggingface.co/datasets/{hf_repo}/raw/main/manifest.json"
+    return (
+        f"https://huggingface.co/datasets/{_resolve_hf_registry_repo()}"
+        "/raw/main/manifest.json"
+    )
 
 class BundleRegistry:
     """
@@ -42,7 +81,7 @@ class BundleRegistry:
         fetch_errors: list[str] = []
 
         try:
-            response = requests.get(_get_manifest_url(), headers=_github_headers(), timeout=10)
+            response = requests.get(_get_manifest_url(), headers=_huggingface_headers(), timeout=10)
             if response.status_code == 200:
                 manifest = response.json()
                 if manifest.get('bundles'):

--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -315,7 +315,7 @@ class CGCBundle:
                 # Specific repository
                 result = session.run(
                     "MATCH (r:Repository {path: $path}) RETURN r",
-                    path=str(repo_path.resolve())
+                    path=repo_path.resolve().as_posix()
                 )
                 repo_node = result.single()
                 if repo_node:
@@ -339,8 +339,8 @@ class CGCBundle:
                     metadata["repo"] = repo.get('name', str(repo_path.name if repo_path else 'unknown'))
                     # Clean up absolute path prefix to keep it relative
                     meta_path = repo.get('path', '')
-                    if repo_path and meta_path.startswith(str(repo_path.resolve())):
-                        repo_str = str(repo_path.resolve())
+                    if repo_path and meta_path.startswith(repo_path.resolve().as_posix()):
+                        repo_str = repo_path.resolve().as_posix()
                         rel = meta_path[len(repo_str):].lstrip('/')
                         metadata["repo_path"] = "./" + rel if rel else "."
                     else:
@@ -365,13 +365,13 @@ class CGCBundle:
                     metadata["branch"] = branch
 
                 try:
-                    repo_str = str(repo_path.resolve())
+                    repo_str = repo_path.resolve().as_posix()
                     result = session.run("""
                         MATCH (f:File)
                         WHERE f.path = $repo_path OR f.path STARTS WITH $repo_prefix
                         RETURN f.language as language, count(*) as count
                         ORDER BY count DESC
-                    """, repo_path=repo_str, repo_prefix=repo_str + os.sep)
+                    """, repo_path=repo_str, repo_prefix=repo_str + "/")
                     languages = {record["language"]: record["count"] for record in result if record["language"]}
                     metadata["languages"] = list(languages.keys())
                 except Exception:
@@ -444,8 +444,8 @@ class CGCBundle:
         return schema
 
     def _repo_scope_params(self, repo_path: Path) -> Dict[str, str]:
-        repo_str = str(repo_path.resolve())
-        return {"repo_path": repo_str, "repo_prefix": repo_str + os.sep}
+        repo_str = repo_path.resolve().as_posix()
+        return {"repo_path": repo_str, "repo_prefix": repo_str + "/"}
 
     def _run_session_query(self, session, query: str, params: Dict[str, str]):
         try:
@@ -553,8 +553,8 @@ class CGCBundle:
                     
                         # Clean up absolute path prefix to keep it relative
                         if repo_path:
-                            repo_str = str(repo_path.resolve())
-                            repo_prefix = repo_str + os.sep
+                            repo_str = repo_path.resolve().as_posix()
+                            repo_prefix = repo_str + "/"
                             for key, val in list(node_dict.items()):
                                 if not isinstance(val, str):
                                     continue
@@ -640,8 +640,8 @@ class CGCBundle:
 
                         # Clean up absolute path prefix inside edge properties
                         if repo_path:
-                            repo_str = str(repo_path.resolve())
-                            repo_prefix = repo_str + os.sep
+                            repo_str = repo_path.resolve().as_posix()
+                            repo_prefix = repo_str + "/"
                             for key, val in list(rel_props.items()):
                                 if not isinstance(val, str):
                                     continue
@@ -686,13 +686,13 @@ class CGCBundle:
         with self.db_manager.get_driver(self._active_graph).session() as session:
             # Count by node type
             if repo_path:
-                repo_str = str(repo_path.resolve())
+                repo_str = repo_path.resolve().as_posix()
                 result = session.run("""
                     MATCH (n)
                     WHERE n.path = $repo_path OR n.path STARTS WITH $repo_prefix
                     RETURN labels(n)[0] as label, count(*) as count
                     ORDER BY count DESC
-                """, repo_path=repo_str, repo_prefix=repo_str + os.sep)
+                """, repo_path=repo_str, repo_prefix=repo_str + "/")
             else:
                 result = session.run("""
                     MATCH (n)
@@ -709,7 +709,7 @@ class CGCBundle:
                        OR (m.path = $repo_path OR m.path STARTS WITH $repo_prefix)
                     RETURN type(r) as type, count(*) as count
                     ORDER BY count DESC
-                """, repo_path=repo_str, repo_prefix=repo_str + os.sep)
+                """, repo_path=repo_str, repo_prefix=repo_str + "/")
             else:
                 result = session.run("""
                     MATCH ()-[r]->()
@@ -723,7 +723,7 @@ class CGCBundle:
                 result = session.run(
                     "MATCH (f:File) WHERE f.path = $repo_path OR f.path STARTS WITH $repo_prefix RETURN count(f) as count",
                     repo_path=repo_str,
-                    repo_prefix=repo_str + os.sep,
+                    repo_prefix=repo_str + "/",
                 )
             else:
                 result = session.run("MATCH (f:File) RETURN count(f) as count")

--- a/src/codegraphcontext/tools/languages/c.py
+++ b/src/codegraphcontext/tools/languages/c.py
@@ -802,7 +802,7 @@ def pre_scan_c(files: list[Path], parser_wrapper) -> dict:
                 name = capture.text.decode('utf-8')
                 if name not in imports_map:
                     imports_map[name] = []
-                imports_map[name].append(str(path.resolve()))
+                imports_map[name].append(path.resolve().as_posix())
         except Exception as e:
             warning_logger(f"Tree-sitter pre-scan failed for {path}: {e}")
     return imports_map

--- a/src/codegraphcontext/tools/languages/cpp.py
+++ b/src/codegraphcontext/tools/languages/cpp.py
@@ -662,7 +662,7 @@ def pre_scan_cpp(files: list[Path], parser_wrapper) -> dict:
                 tree = parser_wrapper.parser.parse(source_bytes)
 
             for node, capture_name in execute_query(parser_wrapper.language, query_str, tree.root_node):
-                resolved_path = str(path.resolve())
+                resolved_path = path.resolve().as_posix()
                 if capture_name == "name":
                     name = node.text.decode("utf-8")
                     paths = imports_map.setdefault(name, [])

--- a/src/codegraphcontext/tools/languages/dart.py
+++ b/src/codegraphcontext/tools/languages/dart.py
@@ -319,7 +319,7 @@ class DartTreeSitterParser:
         for part_of_match in re.finditer(r"^\s*part\s+of\s+['\"]([^'\"]+)['\"]\s*;", source_code, re.MULTILINE):
             parts.append({
                 "main_file": str((path.parent / part_of_match.group(1)).resolve()),
-                "part_file": str(path.resolve()),
+                "part_file": path.resolve().as_posix(),
                 "direction": "part_of",
             })
         return parts

--- a/src/codegraphcontext/tools/languages/elisp.py
+++ b/src/codegraphcontext/tools/languages/elisp.py
@@ -673,7 +673,7 @@ def pre_scan_elisp(files: list[Path], parser_wrapper) -> dict:
             with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 tree = parser_wrapper.parser.parse(bytes(f.read(), "utf8"))
 
-            resolved_path = str(path.resolve())
+            resolved_path = path.resolve().as_posix()
             for function in parser._find_functions(tree.root_node, is_dependency=False):
                 imports_map.setdefault(function["name"], []).append(resolved_path)
 

--- a/src/codegraphcontext/tools/languages/elixir.py
+++ b/src/codegraphcontext/tools/languages/elixir.py
@@ -500,7 +500,7 @@ def _pre_scan_recursive(node, path: Path, imports_map: dict):
                                     name = ac.text.decode('utf-8')
                                     if name not in imports_map:
                                         imports_map[name] = []
-                                    imports_map[name].append(str(path.resolve()))
+                                    imports_map[name].append(path.resolve().as_posix())
                 elif keyword in FUNCTION_KEYWORDS:
                     # Get function name
                     for sib in node.children:
@@ -512,7 +512,7 @@ def _pre_scan_recursive(node, path: Path, imports_map: dict):
                                         name = target.text.decode('utf-8')
                                         if name not in imports_map:
                                             imports_map[name] = []
-                                        imports_map[name].append(str(path.resolve()))
+                                        imports_map[name].append(path.resolve().as_posix())
                 break
 
     for child in node.children:

--- a/src/codegraphcontext/tools/languages/go.py
+++ b/src/codegraphcontext/tools/languages/go.py
@@ -614,7 +614,7 @@ def pre_scan_go(files: list[Path], parser_wrapper) -> dict:
                 name = capture.text.decode('utf-8')
                 if name not in imports_map:
                     imports_map[name] = []
-                imports_map[name].append(str(path.resolve()))
+                imports_map[name].append(path.resolve().as_posix())
         except Exception as e:
             warning_logger(f"Tree-sitter pre-scan failed for {path}: {e}")
     

--- a/src/codegraphcontext/tools/languages/javascript.py
+++ b/src/codegraphcontext/tools/languages/javascript.py
@@ -634,7 +634,7 @@ def pre_scan_javascript(files: list[Path], parser_wrapper) -> dict:
                 name = capture.text.decode('utf-8')
                 if name not in imports_map:
                     imports_map[name] = []
-                imports_map[name].append(str(path.resolve()))
+                imports_map[name].append(path.resolve().as_posix())
         except Exception as e:
             warning_logger(f"Tree-sitter pre-scan failed for {path}: {e}")
     return imports_map

--- a/src/codegraphcontext/tools/languages/lua.py
+++ b/src/codegraphcontext/tools/languages/lua.py
@@ -433,7 +433,7 @@ def pre_scan_lua(files: list[Path], parser_wrapper) -> dict:
     for path in files:
         try:
             parsed = parser.parse(str(path))
-            resolved_path = str(path.resolve())
+            resolved_path = path.resolve().as_posix()
 
             for function in parsed.get("functions", []):
                 names = {function["name"]}

--- a/src/codegraphcontext/tools/languages/perl.py
+++ b/src/codegraphcontext/tools/languages/perl.py
@@ -320,7 +320,7 @@ def pre_scan_perl(files: List[Path], parser_wrapper) -> Dict[str, List[str]]:
                 name = node.text.decode('utf-8')
                 if name not in name_to_files:
                     name_to_files[name] = []
-                name_to_files[name].append(str(path.resolve()))
+                name_to_files[name].append(path.resolve().as_posix())
         except Exception as e:
             warning_logger(f"Error pre-scanning Perl file {path}: {e}")
     return name_to_files

--- a/src/codegraphcontext/tools/languages/python.py
+++ b/src/codegraphcontext/tools/languages/python.py
@@ -661,7 +661,7 @@ def pre_scan_python(files: list[Path], parser_wrapper) -> dict:
                 name = capture.text.decode('utf-8')
                 if name not in imports_map:
                     imports_map[name] = []
-                imports_map[name].append(str(path.resolve()))
+                imports_map[name].append(path.resolve().as_posix())
         except Exception as e:
             warning_logger(f"Tree-sitter pre-scan failed for {path}: {e}")
         finally:

--- a/src/codegraphcontext/tools/languages/ruby.py
+++ b/src/codegraphcontext/tools/languages/ruby.py
@@ -560,7 +560,7 @@ def pre_scan_ruby(files: list[Path], parser_wrapper) -> dict:
                 name = capture.text.decode('utf-8')
                 if name not in imports_map:
                     imports_map[name] = []
-                imports_map[name].append(str(path.resolve()))
+                imports_map[name].append(path.resolve().as_posix())
         except Exception as e:
             warning_logger(f"Tree-sitter pre-scan failed for {path}: {e}")
     

--- a/src/codegraphcontext/tools/languages/rust.py
+++ b/src/codegraphcontext/tools/languages/rust.py
@@ -373,7 +373,7 @@ def pre_scan_rust(files: list[Path], parser_wrapper) -> dict:
                 name = capture.text.decode('utf-8')
                 if name not in imports_map:
                     imports_map[name] = []
-                imports_map[name].append(str(path.resolve()))
+                imports_map[name].append(path.resolve().as_posix())
         except Exception as e:
             warning_logger(f"Tree-sitter pre-scan failed for {path}: {e}")
     return imports_map

--- a/src/codegraphcontext/tools/languages/typescript.py
+++ b/src/codegraphcontext/tools/languages/typescript.py
@@ -630,7 +630,7 @@ def pre_scan_typescript(files: list[Path], parser_wrapper) -> dict:
                         if name:
                             if name not in imports_map:
                                 imports_map[name] = []
-                            file_path_str = str(path.resolve())
+                            file_path_str = path.resolve().as_posix()
                             if file_path_str not in imports_map[name]:
                                 imports_map[name].append(file_path_str)
                                 

--- a/src/codegraphcontext/tools/languages/typescriptjsx.py
+++ b/src/codegraphcontext/tools/languages/typescriptjsx.py
@@ -54,7 +54,7 @@ def pre_scan_typescript(files: list[Path], parser_wrapper) -> dict:
                         if name:
                             if name not in imports_map:
                                 imports_map[name] = []
-                            file_path_str = str(path.resolve())
+                            file_path_str = path.resolve().as_posix()
                             if file_path_str not in imports_map[name]:
                                 imports_map[name].append(file_path_str)
                 except Exception as query_error:

--- a/tests/unit/core/test_registry_credentials_and_paths.py
+++ b/tests/unit/core/test_registry_credentials_and_paths.py
@@ -1,0 +1,92 @@
+"""Regression tests for credential scoping and cross-platform path handling."""
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core import bundle_registry
+from codegraphcontext.core.bundle_registry import (
+    DEFAULT_HF_REGISTRY_REPO,
+    _get_manifest_url,
+    _github_headers,
+    _huggingface_headers,
+    _resolve_hf_registry_repo,
+)
+
+
+def test_github_token_is_not_sent_to_huggingface(monkeypatch):
+    """A developer with GITHUB_TOKEN exported (routine in CI) leaked it to
+    huggingface.co on every registry call."""
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret_value")
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+    headers = _huggingface_headers()
+
+    assert "Authorization" not in headers
+    assert "ghp_secret_value" not in "".join(headers.values())
+
+
+def test_huggingface_headers_use_hf_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("HF_TOKEN", "hf_abc")
+
+    assert _huggingface_headers()["Authorization"] == "Bearer hf_abc"
+
+
+def test_github_headers_still_carry_the_github_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_abc")
+    assert _github_headers()["Authorization"] == "token ghp_abc"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "evil.example.com/x/../../y",
+        "/etc/passwd",
+        "https://evil.example.com/repo",
+        "owner/name/extra/../..",
+        "..%2f..%2fetc",
+        "",
+    ],
+)
+def test_invalid_hf_registry_repo_falls_back_to_the_default(monkeypatch, value):
+    """HF_REGISTRY_REPO was interpolated unvalidated, so a crafted value could
+    steer the request — and any credential on it — off huggingface.co."""
+    monkeypatch.setenv("HF_REGISTRY_REPO", value)
+
+    assert _resolve_hf_registry_repo() == DEFAULT_HF_REGISTRY_REPO
+    assert _get_manifest_url().startswith(
+        f"https://huggingface.co/datasets/{DEFAULT_HF_REGISTRY_REPO}/"
+    )
+
+
+def test_valid_hf_registry_repo_is_honoured(monkeypatch):
+    monkeypatch.setenv("HF_REGISTRY_REPO", "my-org/my_registry.v2")
+    assert _resolve_hf_registry_repo() == "my-org/my_registry.v2"
+
+
+def test_bundle_scoping_uses_posix_separators():
+    """Graph paths are stored via Path.resolve().as_posix() (#1080), so the
+    bundle's repo scoping must compare POSIX strings. Using os.sep produced a
+    prefix that could never match on Windows, yielding an empty bundle."""
+    import inspect
+
+    from codegraphcontext.core import cgc_bundle
+
+    source = inspect.getsource(cgc_bundle)
+    assert "os.sep" not in source, "repo scoping must not use native separators"
+    assert "str(repo_path.resolve())" not in source
+
+
+def test_prescan_paths_are_posix():
+    """The pre-scan imports_map fed substring heuristics that compare a
+    '/'-joined import name against the stored path; native separators made
+    those tiers unmatchable on Windows."""
+    import inspect
+
+    from codegraphcontext.tools.languages import go, python
+
+    for module in (python, go):
+        source = inspect.getsource(module)
+        assert "str(path.resolve())" not in source
+        assert "path.resolve().as_posix()" in source


### PR DESCRIPTION
One credential-scoping bug and three instances of the same native-vs-POSIX path mismatch, from an end-to-end audit of 0.5.2.

### 1. `GITHUB_TOKEN` was sent to huggingface.co (`G-M08`)

```python
def _github_headers() -> dict:
    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
    if token:
        headers["Authorization"] = f"token {token}"

def _get_manifest_url() -> str:
    hf_repo = os.environ.get("HF_REGISTRY_REPO") or "codegraphcontext/registry"
    return f"https://huggingface.co/datasets/{hf_repo}/raw/main/manifest.json"

response = requests.get(_get_manifest_url(), headers=_github_headers(), timeout=10)
```

`_github_headers()` had exactly **one** call site, and it was the Hugging Face URL — so the GitHub credential was only ever sent to a third-party host, never to GitHub. Anyone with `GITHUB_TOKEN` exported (routine in CI and dev shells) leaked it on every registry call.

HF requests now use `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` through a separate builder. `_github_headers` is kept for github.com callers.

### 2. `HF_REGISTRY_REPO` was unvalidated

It is interpolated straight into the URL, so a value containing a host or scheme could steer the request — and any credential attached to it — off huggingface.co. It is now matched against `owner/name` and falls back to the default with a warning.

### 3. Bundle repo-scoping used native separators (`G-M09`, Windows)

```python
repo_str = str(repo_path.resolve())          # backslashes on Windows
return {"repo_path": repo_str, "repo_prefix": repo_str + os.sep}
```

Every graph path is written through `writer._normalize_path` → `Path.resolve().as_posix()`, explicitly to fix `STARTS WITH` on Windows (#1080). `cgc_bundle` was never converted, so on Windows the prefix could never match and `cgc bundle export --repo <path>` produced a valid-looking but **empty** bundle. All 8 `resolve()` sites and 7 separator concatenations now use POSIX form.

### 4. Same mismatch in the pre-scan imports_map (`I-L17`, Windows)

15 sites across 14 language parsers stored `str(path.resolve())`. Resolution normalises at the end so the final payload was correct, but the intermediate substring heuristics (`full_import_name.replace(".", "/") in path`) compare a `/`-joined import name against a `\`-separated path and can **never** match on Windows — silently downgrading those calls to the AMBIGUOUS first-candidate tier.

### Tests

12 new tests: the GitHub token is absent from HF headers even when exported, `HF_TOKEN` is used when present, `_github_headers` still carries the GitHub token, six invalid `HF_REGISTRY_REPO` values fall back to the default, a valid one is honoured, and neither `cgc_bundle` nor the parsers retain native-separator scoping.

Two of these are Windows-only and marked *code-evident* in the audit — this environment was Linux, so they are established by reading the code and guarded by tests, not by a live Windows run.

Full unit suite: **722 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py`, which is flaky on `main` independently of this PR — see #1408).

<sub>From an end-to-end audit of CGC 0.5.2. Related filed findings: #1382–#1402.</sub>