### PR TITLE
fix(indexer): merge pre-scan symbols, reach generic dotfiles, surface parse failures

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -112,6 +112,9 @@ def _print_index_execution_summary(graph_builder: GraphBuilder) -> None:
         "Files by extension",
         _format_extension_counts(summary.get("files_by_extension", {})),
     )
+    failed_files = summary.get("failed_files", 0)
+    if failed_files:
+        table.add_row("[red]Files failed to parse[/red]", f"[red]{failed_files}[/red]")
     table.add_row("Function nodes", str(summary.get("function_nodes", 0)))
     table.add_row("Class nodes", str(summary.get("class_nodes", 0)))
     table.add_row("CALLS edges", str(summary.get("call_edges", 0)))

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -97,6 +97,8 @@ class GraphBuilder:
         }
         
         # Files that should be added to the graph as minimal File nodes, even if not parsed
+        # Keep in sync with discovery._GENERIC_EXTENSIONS / _GENERIC_FILENAMES.
+        # Dotfiles have no suffix, so they must be matched by name, not extension.
         self.generic_extensions = {
             ".toml", ".sh", ".yaml", ".yml", ".json", ".ini", ".cfg", ".md", ".txt",
             ".bat", ".ps1"
@@ -1065,11 +1067,22 @@ class GraphBuilder:
             else:
                 file_data = parser.parse(path, is_dependency, index_source=index_source)
             file_data["repo_path"] = str(repo_path)
+            # Most parsers catch their own exceptions and return {"path", "error"}
+            # rather than raising, so the handler below never sees them. Flag the
+            # failure here so it is distinguishable from the benign "generic file"
+            # and "no parser" returns above, which share the same shape.
+            if "error" in file_data:
+                file_data["parse_failed"] = True
             return file_data
         except Exception as e:
             error_logger(f"Error parsing {path} with {parser.language_name} parser: {e}")
             debug_log(f"[parse_file] Error parsing {path}: {e}")
-            return {"path": str(path), "error": str(e)}
+            # `parse_failed` distinguishes a genuine parser failure from the
+            # benign "generic file type" / "no parser" returns above, which
+            # otherwise share the same shape. Without it a broken parse and a
+            # .md file take the identical branch in the pipeline and the run
+            # still reports "Successfully finished indexing".
+            return {"path": str(path), "error": str(e), "parse_failed": True}
 
     def estimate_processing_time(self, path: Path) -> Optional[Tuple[int, float]]:
         """Estimate the time required to index a repository.

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from ...core.jobs import JobManager, JobStatus
-from ...utils.debug_log import debug_log, error_logger, info_logger
+from ...utils.debug_log import debug_log, error_logger, info_logger, warning_logger
 from .discovery import discover_files_to_index
 from .persistence.writer import GraphWriter
 from .pre_scan import pre_scan_for_imports
@@ -36,6 +36,7 @@ def build_index_summary(
     all_file_data: List[Dict[str, Any]],
     resolved_call_groups: tuple,
     serialization_seconds: float,
+    parse_failures: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Build CLI-facing metrics for a completed Tree-sitter indexing run."""
     extension_counts = Counter()
@@ -48,6 +49,8 @@ def build_index_summary(
     class_nodes = sum(len(file_data.get("classes", [])) for file_data in all_file_data)
     call_edges = sum(len(group) for group in resolved_call_groups)
 
+    failed = list(parse_failures or [])
+
     return {
         "total_scanned_files": len(files),
         "files_by_extension": dict(sorted(extension_counts.items())),
@@ -55,6 +58,10 @@ def build_index_summary(
         "class_nodes": class_nodes,
         "call_edges": call_edges,
         "serialization_seconds": serialization_seconds,
+        # A run where files failed to parse used to be indistinguishable from a
+        # clean one: the summary had no failure row at all.
+        "failed_files": len(failed),
+        "failed_file_details": failed,
     }
 
 
@@ -153,6 +160,21 @@ async def run_tree_sitter_index_async(
                 repo_path,
                 is_dependency,
             )
+
+    # Capture genuine parse failures before the error entries are dropped —
+    # build_index_summary runs much later, against the filtered list.
+    parse_failures = [
+        {"path": file_data.get("path"), "error": file_data.get("error")}
+        for file_data in all_file_data
+        if file_data.get("parse_failed")
+    ]
+    if parse_failures:
+        warning_logger(
+            f"{len(parse_failures)} file(s) failed to parse and contributed no "
+            "symbols to the graph."
+        )
+        for failure in parse_failures[:10]:
+            warning_logger(f"  parse failed: {failure['path']}: {failure['error']}")
 
     all_file_data = [file_data for file_data in all_file_data if "error" not in file_data]
 
@@ -322,6 +344,7 @@ async def run_tree_sitter_index_async(
                 all_file_data,
                 resolved_calls,
                 time.time() - serialization_start,
+                parse_failures=parse_failures,
             )
         )
 

--- a/src/codegraphcontext/tools/indexing/pre_scan.py
+++ b/src/codegraphcontext/tools/indexing/pre_scan.py
@@ -114,7 +114,19 @@ def pre_scan_for_imports(
     registry = _get_registry()
     for ext, file_list in files_by_ext.items():
         scanner = registry.get(ext)
-        if scanner:
-            imports_map.update(scanner(file_list, get_parser))
+        if not scanner:
+            continue
+        # dict.update() *replaces* the value list, so in a polyglot repo a
+        # symbol defined in two languages kept only the last-scanned
+        # language's paths — e.g. a Java `Widget` disappeared behind a Python
+        # `Widget`, and cross-file CALLS/INHERITS resolution for it then fell
+        # to a lower-confidence tier or failed outright. Merge instead.
+        for name, paths in scanner(file_list, get_parser).items():
+            if not paths:
+                imports_map.setdefault(name, [])
+                continue
+            bucket = imports_map.setdefault(name, [])
+            seen = set(bucket)
+            bucket.extend(p for p in paths if not (p in seen or seen.add(p)))
 
     return imports_map

--- a/tests/unit/tools/test_indexer_prescan_and_failures.py
+++ b/tests/unit/tools/test_indexer_prescan_and_failures.py
@@ -1,0 +1,95 @@
+"""Regression tests for pre-scan merging, generic dotfiles and parse-failure reporting."""
+from pathlib import Path
+
+from codegraphcontext.tools.indexing import pre_scan
+from codegraphcontext.tools.indexing.discovery import (
+    _GENERIC_EXTENSIONS,
+    _GENERIC_FILENAMES,
+)
+from codegraphcontext.tools.indexing.pipeline import build_index_summary
+
+
+def test_prescan_merges_symbols_across_languages(monkeypatch):
+    """dict.update() replaced the path list, so a symbol defined in two
+    languages kept only the last-scanned language's paths."""
+
+    def java_scanner(files, get_parser):
+        return {"Widget": ["/repo/Widget.java"], "render": ["/repo/Widget.java"]}
+
+    def python_scanner(files, get_parser):
+        return {"Widget": ["/repo/helper.py"], "render": ["/repo/helper.py"]}
+
+    monkeypatch.setattr(
+        pre_scan, "_get_registry", lambda: {".java": java_scanner, ".py": python_scanner}
+    )
+
+    result = pre_scan.pre_scan_for_imports(
+        [Path("/repo/Widget.java"), Path("/repo/helper.py")],
+        {".java": "java", ".py": "python"},
+        lambda ext: None,
+    )
+
+    assert sorted(result["Widget"]) == ["/repo/Widget.java", "/repo/helper.py"]
+    assert sorted(result["render"]) == ["/repo/Widget.java", "/repo/helper.py"]
+
+
+def test_prescan_does_not_duplicate_repeated_paths(monkeypatch):
+    def scanner_a(files, get_parser):
+        return {"Shared": ["/repo/a.py"]}
+
+    def scanner_b(files, get_parser):
+        return {"Shared": ["/repo/a.py", "/repo/b.rb"]}
+
+    monkeypatch.setattr(
+        pre_scan, "_get_registry", lambda: {".py": scanner_a, ".rb": scanner_b}
+    )
+
+    result = pre_scan.pre_scan_for_imports(
+        [Path("/repo/a.py"), Path("/repo/b.rb")],
+        {".py": "python", ".rb": "ruby"},
+        lambda ext: None,
+    )
+
+    assert result["Shared"] == ["/repo/a.py", "/repo/b.rb"]
+
+
+def test_dotfiles_are_matched_by_name_not_extension():
+    """Path('.gitignore').suffix == '', so listing dotfiles among the
+    extensions meant they never matched and never got a File node."""
+    assert Path(".gitignore").suffix == ""
+
+    for dotfile in (".gitignore", ".dockerignore"):
+        assert dotfile in _GENERIC_FILENAMES
+        # ...and no longer in the (unreachable) extension set.
+        assert dotfile not in _GENERIC_EXTENSIONS
+
+
+def test_index_summary_reports_parse_failures():
+    """A run where files failed to parse was indistinguishable from a clean
+    one: the summary had no failure row at all."""
+    failures = [{"path": "/repo/latin.py", "error": "'utf-8' codec can't decode byte"}]
+
+    summary = build_index_summary(
+        files=[Path("/repo/latin.py"), Path("/repo/ok.py")],
+        parsers={".py": "python"},
+        all_file_data=[{"path": "/repo/ok.py", "functions": [{}]}],
+        resolved_call_groups=(),
+        serialization_seconds=0.0,
+        parse_failures=failures,
+    )
+
+    assert summary["failed_files"] == 1
+    assert summary["failed_file_details"] == failures
+
+
+def test_index_summary_reports_zero_failures_for_a_clean_run():
+    summary = build_index_summary(
+        files=[Path("/repo/ok.py")],
+        parsers={".py": "python"},
+        all_file_data=[{"path": "/repo/ok.py", "functions": [{}]}],
+        resolved_call_groups=(),
+        serialization_seconds=0.0,
+    )
+
+    assert summary["failed_files"] == 0
+    assert summary["failed_file_details"] == []


### PR DESCRIPTION
Three indexer defects from an end-to-end audit of 0.5.2.

### 1. `pre_scan_for_imports` clobbered symbols across languages (`I-M09`)

```python
for ext, file_list in files_by_ext.items():
    scanner = registry.get(ext)
    if scanner:
        imports_map.update(scanner(file_list, get_parser))   # replaces, never merges
```

Each scanner returns `{symbol: [paths]}`, and `dict.update()` replaces the whole value list. Reproduced on a directory with `Widget.java` (class `Widget`, method `render`) and `helper.py` (class `Widget`, method `render`):

```
Widget: ['/…/helper.py']     ← Widget.java path gone
render: ['/…/helper.py']     ← Widget.java path gone
```

Java's `Widget` and `render` were absent from the global imports map, so cross-file CALLS/INHERITS resolution for them fell to a lower-confidence tier or failed. Paths are now merged, de-duplicated and order-preserving.

### 2. Generic dotfiles were unreachable config (`I-L14`)

`.gitignore` and `.dockerignore` were listed among generic **extensions** — but `Path(".gitignore").suffix == ""`, so they never matched, and they were absent from the filename set. Dead configuration; those files never got a File node. Moved to `_GENERIC_FILENAMES`, in both `discovery.py` and the `GraphBuilder` copy that the comment says must stay in sync.

**One deliberate deviation from the audit:** `.env` was in the same dead list, and I did **not** reinstate it. Making it reachable would newly pull secrets-bearing files into the graph — see #1313 (secrets stored verbatim). Only the two harmless dotfiles are enabled.

### 3. Parse failures were invisible (`I-M13`)

The audit attributes this to `parse_file`'s exception handler, but that turned out to be only half the story: **most parsers catch their own exceptions** and return `{"path", "error"}` rather than raising, so that handler never fires. For example `python.py`:

```python
except Exception as e:
    error_logger(f"Failed to parse {original_file_path}: {e}")
    return {"path": str(original_file_path), "error": str(e)}
```

That return has the same shape as the benign "generic file type" / "no parser" returns, so `pipeline.py` gave a broken file the identical treatment as a `.md` file, and `build_index_summary` had no failure count at all. A repo where 30 % of files failed to parse reported "Successfully finished indexing".

Fixed at the point that covers all 23 parsers uniformly — `parse_file` flags any parser return carrying an `error` — with the failures collected before the error entries are dropped (the summary is built much later, against the filtered list).

Verified end to end on a repo with a latin-1 encoded `.py` file:

```
| Total scanned files   | 3 |
| Files failed to parse | 1 |     ← previously absent entirely
| Function nodes        | 2 |
```

This makes the silent drop in #1390 (non-UTF-8 files) *visible*; it does not fix that issue, which needs the `errors=` argument added to the seven affected parsers.

### Tests

5 new tests: cross-language merge, de-duplication, dotfile matching (including the `.env` exclusion), and the summary's failure count for both a failing and a clean run.

Full unit suite: **715 passed, 7 skipped, 0 failed**, plus **32 passed** for the two cgcignore suites (this PR touches `discovery.py`). Excludes `test_cgcignore_patterns.py` from the main run, which is flaky on `main` independently of this PR — see #1408.

<sub>From an end-to-end audit of CGC 0.5.2. Related filed findings: #1382–#1402.</sub>