### PR TITLE
fix(cli): count nodes not rows in stats, make doctor honest, allow report --repo

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -815,17 +815,23 @@ def stats_helper(path: str = None, context: Optional[str] = None):
                     return
                 
                 # Get stats
-                # Get stats using separate queries to handle depth and avoid Cartesian products
+                # Get stats using separate queries to handle depth and avoid Cartesian products.
+                # `count(x)` counts *rows*, and a variable-length CONTAINS* match
+                # yields one row per distinct path to the node: a method is
+                # reachable as Repo->..->File->Function and again as
+                # Repo->..->File->Class->Function, a nested function three ways.
+                # count(DISTINCT x) is required or the totals are inflated —
+                # functions were over-reported by ~55% on CGC's own repo.
                 # 1. Files
-                file_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(f:File) RETURN count(f) as c"
+                file_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(f:File) RETURN count(DISTINCT f) as c"
                 file_count = session.run(file_query, path=repo_path_str).single()["c"]
-                
+
                 # 2. Functions (including methods in classes)
-                func_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(func:Function) RETURN count(func) as c"
+                func_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(func:Function) RETURN count(DISTINCT func) as c"
                 func_count = session.run(func_query, path=repo_path_str).single()["c"]
-                
+
                 # 3. Classes
-                class_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(c:Class) RETURN count(c) as c"
+                class_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(c:Class) RETURN count(DISTINCT c) as c"
                 class_count = session.run(class_query, path=repo_path_str).single()["c"]
                 
                 # 4. Modules (imported) - Note: Module nodes are outside the repo structure usually, connected via IMPORTS

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -1157,6 +1157,10 @@ def doctor():
     console.print("[bold cyan]🏥 Running CodeGraphContext Diagnostics...[/bold cyan]\n")
     
     all_checks_passed = True
+    # Warnings are not failures, but printing "All diagnostics passed! System is
+    # healthy." while a ⚠ is on screen is misleading — `doctor` is the command
+    # people run when something is already wrong.
+    warnings_found = False
 
     config_manager.ensure_first_run_bootstrap()
     config_manager.ensure_config_file()
@@ -1294,6 +1298,32 @@ def doctor():
 
                 if is_falkordb_usable():
                     console.print("   [green]✓[/green] FalkorDB Lite is installed")
+                    # An import probe is not a connection check. This section is
+                    # titled "Checking Database Connection" and the neo4j /
+                    # falkordb-remote branches genuinely connect, so the default
+                    # backend must too — otherwise `doctor` reports a healthy
+                    # system without ever touching the database.
+                    try:
+                        from codegraphcontext.core import get_database_manager
+
+                        probe_manager = get_database_manager()
+                        try:
+                            with probe_manager.get_driver().session() as probe_session:
+                                probe_session.run("RETURN 1")
+                            console.print("   [green]✓[/green] FalkorDB Lite connection successful")
+                            backend_in_use = probe_manager.get_backend_type()
+                            if backend_in_use != "falkordb":
+                                console.print(
+                                    f"   [yellow]⚠[/yellow] Configured backend is 'falkordb' but "
+                                    f"'{backend_in_use}' is actually active"
+                                )
+                                warnings_found = True
+                        finally:
+                            probe_manager.close_driver()
+                    except Exception as conn_error:
+                        console.print("   [red]✗[/red] FalkorDB Lite connection failed")
+                        console.print(f"       Reason: {conn_error}")
+                        all_checks_passed = False
                 else:
                     raise ImportError("FalkorDB Lite is not available on this platform")
             except ImportError:
@@ -1304,6 +1334,7 @@ def doctor():
                 all_checks_passed = False
         else:
             console.print(f"   [yellow]⚠[/yellow] No connectivity probe for backend '{default_db}'")
+            warnings_found = True
     except Exception as e:
         console.print(f"   [red]✗[/red] Database check error: {e}")
         all_checks_passed = False
@@ -1333,6 +1364,7 @@ def doctor():
             console.print(f"   [green]✓[/green] {len(available)}/{len(probe_langs)} probed parsers OK: {', '.join(available)}")
             if unavailable:
                 console.print(f"   [yellow]⚠[/yellow] Unavailable: {', '.join(unavailable)}")
+                warnings_found = True
         except ImportError:
             console.print("   [red]✗[/red] tree-sitter-language-pack not installed")
             all_checks_passed = False
@@ -1358,6 +1390,7 @@ def doctor():
                 all_checks_passed = False
         else:
             console.print("   [yellow]⚠[/yellow] Config directory doesn't exist, will be created on first use")
+            warnings_found = True
     except Exception as e:
         console.print(f"   [red]✗[/red] Permission check error: {e}")
         all_checks_passed = False
@@ -1370,11 +1403,17 @@ def doctor():
         console.print(f"   [green]✓[/green] cgc command found at: {cgc_path}")
     else:
         console.print("   [yellow]⚠[/yellow] cgc command not in PATH (using python -m cgc)")
+        warnings_found = True
     
     # Final summary
     console.print("\n" + "=" * 60)
-    if all_checks_passed:
+    if all_checks_passed and not warnings_found:
         console.print("[bold green]✅ All diagnostics passed! System is healthy.[/bold green]")
+    elif all_checks_passed:
+        console.print(
+            "[bold yellow]✅ No failures, but some checks reported warnings "
+            "(⚠ above).[/bold yellow]"
+        )
     else:
         console.print("[bold yellow]⚠️  Some issues detected. Please review the output above.[/bold yellow]")
         console.print("\n[cyan]Common fixes:[/cyan]")
@@ -1609,6 +1648,7 @@ def delete(
 def report(
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Output file path. Defaults to CGC_REPORT.md in the current directory."),
     java: bool = typer.Option(False, "--java", "-j", help="Include Spring/Maven Java sections."),
+    repo: Optional[str] = typer.Option(None, "--repo", "-r", help="Repository root to scope the report to. Defaults to auto-detection from the current directory."),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
 ):
     """
@@ -1627,7 +1667,15 @@ def report(
     db_manager, _, _, _ = _initialize_services(context)
     try:
         from codegraphcontext.tools.report_generator import generate_report
-        report_text = generate_report(db_manager, output_path=output_path, include_java=java)
+        # Without --repo the generator silently picks the repo with the most
+        # indexed files, which is disclosed only in the report body.
+        scoped_repo = Path(repo).expanduser().resolve().as_posix() if repo else None
+        report_text = generate_report(
+            db_manager,
+            output_path=output_path,
+            include_java=java,
+            repo_path=scoped_repo,
+        )
         console.print(f"[green]✓[/green] Report written to [bold]{output_path}[/bold]")
         # Print a short preview (first ~40 lines)
         preview_lines = report_text.splitlines()[:40]

--- a/tests/unit/cli/test_stats_counts_and_doctor.py
+++ b/tests/unit/cli/test_stats_counts_and_doctor.py
@@ -1,0 +1,60 @@
+"""Regression tests for stats counting, doctor honesty and report scoping."""
+import inspect
+import re
+
+from typer.testing import CliRunner
+
+from codegraphcontext.cli import cli_helpers, main as cli_main
+from codegraphcontext.cli.main import app
+
+runner = CliRunner()
+
+
+def _stats_source():
+    return inspect.getsource(cli_helpers.stats_helper)
+
+
+def test_stats_counts_are_distinct():
+    """`count(x)` over a variable-length CONTAINS* match counts rows, not
+    nodes: a method is reachable both as File->Function and
+    File->Class->Function, so functions were over-reported by ~55%."""
+    source = _stats_source()
+    contains_counts = re.findall(r"CONTAINS\*\]->\((\w+):(\w+)\) RETURN count\((DISTINCT )?", source)
+    assert contains_counts, "expected the CONTAINS* count queries to be present"
+    for var, label, distinct in contains_counts:
+        assert distinct, f"count over CONTAINS* for {label} must use DISTINCT"
+
+
+def test_doctor_probes_the_connection_for_the_default_backend():
+    """Section 2 is titled 'Checking Database Connection', but for the default
+    falkordb backend it was only an import probe."""
+    source = inspect.getsource(cli_main.doctor)
+    assert "is_falkordb_usable" in source
+    # It must now actually open a connection, like the neo4j / remote branches.
+    assert "get_database_manager" in source
+    assert "RETURN 1" in source
+
+
+def test_doctor_does_not_claim_health_when_warnings_were_printed():
+    source = inspect.getsource(cli_main.doctor)
+    assert "warnings_found = False" in source
+    assert "if all_checks_passed and not warnings_found:" in source
+    # Every ⚠ line in doctor should set the flag.
+    warn_lines = [
+        line for line in source.splitlines()
+        if "[yellow]⚠[/yellow]" in line and "console.print" in line
+    ]
+    assert len(warn_lines) >= 4
+    assert source.count("warnings_found = True") >= len(warn_lines)
+
+
+def test_report_accepts_a_repo_flag():
+    """`cgc report` had no way to target a repo; with several indexed it
+    silently picked the one with the most files."""
+    result = runner.invoke(app, ["report", "--help"])
+    assert result.exit_code == 0
+    normalised = " ".join(result.output.split())
+    assert "--repo" in normalised
+
+    source = inspect.getsource(cli_main.report)
+    assert "repo_path=scoped_repo" in source


### PR DESCRIPTION
Four correctness/honesty defects in what CGC *reports about itself*, from an end-to-end audit of 0.5.2.

### 1. `cgc stats <path>` inflated the function count by 55 % (`U-M2`)

```cypher
MATCH (r:Repository {path: $path})-[:CONTAINS*]->(func:Function) RETURN count(func) AS c
```

`count()` counts **rows**. A variable-length `CONTAINS*` match yields one row per distinct path to the node, and a method is reachable both as `Repo→…→File→Function` and as `Repo→…→File→Class→Function`; a nested function three ways.

```
$ cgc stats                        → Functions 5501
$ cgc stats /home/…/repo           → Functions 8531
MATCH (r)-[:CONTAINS*]->(f:Function) RETURN count(f), count(DISTINCT f)
                                   → 8531, 5501
```

Files and Classes happened to be unaffected (single containment path), but they are switched to `DISTINCT` too so the class of bug cannot come back.

### 2. `cgc doctor` never touched the database on the default backend (`U-M4`)

Section 2 is titled **"Checking Database Connection"**, and the `neo4j` and `falkordb-remote` branches genuinely call `test_connection()`. The `falkordb` branch — the default — only ran `is_falkordb_usable()`, an import probe. `doctor` is the command people run *when something is already broken*, and it reported a healthy system without ever connecting.

It now opens a connection and runs `RETURN 1`. On the machine I developed this on, that immediately caught a real instance of the silent-fallback bug (#1387, #1388, #1331):

```
   ✓ FalkorDB Lite is installed
   ✓ FalkorDB Lite connection successful
   ⚠ Configured backend is 'falkordb' but 'kuzudb' is actually active
```

### 3. "All diagnostics passed! System is healthy." while a ⚠ was on screen (`U-M4`)

```
5. Checking CGC Command...
   ⚠ cgc command not in PATH (using python -m cgc)
============================================================
✅ All diagnostics passed! System is healthy.
```

Warnings are now tracked separately from failures, and all five ⚠ sites set the flag:

```
✅ No failures, but some checks reported warnings (⚠ above).
```

Exit code is deliberately unchanged — warnings still exit 0, only failures exit 1.

### 4. `cgc report` could not target a repository (`U-L2`)

With multiple repos indexed it silently scoped to whichever had the most files, disclosed only in the report body. `generate_report` already accepted `repo_path`; the CLI simply never passed it. Adds `--repo`/`-r`.

### Tests

4 new tests covering all four: `DISTINCT` on every `CONTAINS*` count, doctor actually connecting, warnings gating the health message, and `--repo` being wired through.

Full unit suite: **714 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py`, flaky on `main` independently of this PR — see #1408).

<sub>From an end-to-end audit of CGC 0.5.2. Related filed findings: #1382–#1402.</sub>