### PR TITLE
docs: document database deletion safety flag

### DIFF
--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -25,6 +25,8 @@ Use `cgc version` (or `cgc --version`) to print the installed release (currently
 
 ## Core Index & Lifecycle
 
+The `clean`, `delete`, and `rm` commands are disabled by default because they remove data. Before using them, enable `ALLOW_DB_DELETION` as described in [Destructive Operation Safety](config.md#destructive-operation-safety).
+
 | Command | Usage | Notes |
 | :--- | :--- | :--- |
 | **`index`** | `cgc index [PATH] [--force] [--dependency]` | Shortcut: `cgc i`. Incremental by default; `--force` rebuilds from scratch. |

--- a/docs/docs/reference/config.md
+++ b/docs/docs/reference/config.md
@@ -78,6 +78,24 @@ cgc config reset
 
 ## Configuration Variable Reference
 
+### Destructive Operation Safety
+
+| Config Key | Default | Description |
+| :--- | :--- | :--- |
+| **`ALLOW_DB_DELETION`** | `false` | Enables destructive database operations, including `cgc clean` and `cgc delete` (`cgc rm`). |
+
+`cgc clean` and `cgc delete` exit with an error while this setting is `false`. Enable it explicitly before running either command:
+
+```bash
+cgc config set ALLOW_DB_DELETION true
+```
+
+After the operation, restore the safety guard:
+
+```bash
+cgc config set ALLOW_DB_DELETION false
+```
+
 ### Core Engine Settings
 
 | Config Key | Default | Description |


### PR DESCRIPTION
## Summary

Documented ALLOW_DB_DELETION, its false default, the enable/disable workflow, and the prerequisite for clean, delete, and rm.

## Verification

- documentation content assertions → pass
- generated documentation link assertions → pass
- cd docs && ../.venv/bin/mkdocs build → pass (one unrelated existing broken-link warning)
- cd docs && ../.venv/bin/mkdocs build --strict → fail (existing broken link in guides/bundles.md)
- PATH="$PWD/.venv/bin:$PATH" ./tests/run_tests.sh fast → fail (764 passed, 19 skipped, 5 unrelated baseline failures)
- git diff HEAD^ HEAD --check → pass

## Remaining risks

Repository baseline has five unrelated test failures and one existing MkDocs broken-link warning.

## Commits

- docs: document database deletion safety flag

Fixes #1401.