### PR TITLE
fix(mcp): warn on destructive tools, flag Spring truncation, correct stale docs

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -34,11 +34,15 @@ Thank you for your interest in contributing to CodeGraphContext (CGC). We welcom
 ## Development Workflows
 
 ### Debug Logging
-Enable verbose debug logs during execution by setting the environment variable:
+Enable verbose debug logs during execution by setting the environment variables:
 ```bash
-export CGC_LOG_LEVEL=DEBUG
+export DEBUG_LOGS=true          # developer/troubleshooting logs
+export ENABLE_APP_LOGS=DEBUG    # application log level (default: CRITICAL)
 cgc index
 ```
+
+`LIBRARY_LOG_LEVEL` controls the verbosity of third-party libraries (neo4j,
+asyncio, urllib3) separately, and defaults to `WARNING`.
 
 ### Running the Test Suite
 The testing pipeline utilizes `pytest`. Ensure all checks pass locally before pushing changes:
@@ -49,9 +53,6 @@ pytest
 
 # Test a specific driver module
 pytest tests/unit/core/test_database_kuzu_compat.py
-
-# Run tests bypassing re-indexing cache
-CGC_SKIP_REINDEX=true pytest
 ```
 
 *Note: Integration tests for remote databases like Neo4j require a running local database instance (refer to docker-compose.yml).*

--- a/docs/docs/guides/indexing.md
+++ b/docs/docs/guides/indexing.md
@@ -91,7 +91,9 @@ sequenceDiagram
   cgc unwatch /path/to/project
   ```
 
-On startup, each watcher **reconciles** the graph with disk: files present on disk but missing from the graph are indexed, and graph entries for deleted files are removed before live monitoring begins.
+On startup, each watcher can **reconcile** the graph with disk: files present on disk but missing from the graph are indexed, and graph entries for deleted files are removed before live monitoring begins.
+
+This is **off by default** — pass `--sync-on-start` to enable it. Without it, changes made while the watcher was not running are not picked up for an already-indexed repository.
 
 ---
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -176,7 +176,7 @@ cgc unwatch <PATH>
 cgc watching
 ```
 
-On startup, watchers reconcile the graph with the filesystem (add missing files, remove deleted paths) before monitoring changes.
+With `--sync-on-start`, watchers reconcile the graph with the filesystem (add missing files, remove deleted paths) before monitoring changes. This is off by default.
 
 ---
 

--- a/docs/docs/reference/config.md
+++ b/docs/docs/reference/config.md
@@ -103,7 +103,7 @@ cgc config reset
 | Config Key | Default | Description |
 | :--- | :--- | :--- |
 | **`SCIP_INDEXER`** | `false` | When `true`, enables SCIP-based symbol resolution. |
-| **`SCIP_LANGUAGES`** | `python,typescript,go,rust,java` | List of target languages to process via SCIP. |
+| **`SCIP_LANGUAGES`** | `python,typescript,javascript,go,rust,java,dart,cpp,c,csharp` | List of target languages to process via SCIP. |
 | **`SCIP_LOCAL_INDEXER_TIMEOUT_SECONDS`** | `300` | Timeout for the local SCIP indexer subprocess. Raise it for large repositories whose indexer runs longer than 5 minutes. Values `<= 0` or non-numeric fall back to `300`. |
 
 ---

--- a/src/codegraphcontext/prompts.py
+++ b/src/codegraphcontext/prompts.py
@@ -126,7 +126,7 @@ You are an expert AI pair programmer. Your primary goal is to help a developer u
 ### SOP-4: Using the Cypher Fallback
 1.  **Attempt Standard Tools:** First, always try to use `find_code` and `analyze_code_relationships`.
 2.  **Identify Failure:** If the standard tools cannot answer a complex, multi-step relationship query (e.g., "Find all functions that are called by a method in a class that inherits from 'BaseHandler'"), then and only then, resort to the fallback.
-3.  **Formulate & Execute:** Construct a Cypher query to find the answer and execute it using `execute_cypher_query`. **Consult the Graph Schema Reference above to ensure you use the correct property names (e.g. `path` vs `path`).**
+3.  **Formulate & Execute:** Construct a Cypher query to find the answer and execute it using `execute_cypher_query`. **Consult the Graph Schema Reference above to ensure you use the correct property names (e.g. `line_number`, not `line`; `path`, not `file_path`).**
 4.  **Present Results:** Explain the results to the user based on the query output.
 """
 

--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -365,7 +365,7 @@ class MCPServer:
     def check_job_status_tool(self, **args) -> Dict[str, Any]:
         return management_handlers.check_job_status(self.job_manager, **args)
     
-    def list_jobs_tool(self) -> Dict[str, Any]:
+    def list_jobs_tool(self, **args: Any) -> Dict[str, Any]:
         return management_handlers.list_jobs(self.job_manager)
 
     def list_watched_paths_tool(self, **args) -> Dict[str, Any]:

--- a/src/codegraphcontext/tool_definitions.py
+++ b/src/codegraphcontext/tool_definitions.py
@@ -239,7 +239,13 @@ TOOLS = {
 
     "delete_repository": {
         "name": "delete_repository",
-        "description": "Delete a repository from the graph.",
+        "description": (
+            "DESTRUCTIVE AND IRREVERSIBLE. Permanently deletes a repository and "
+            "every node and relationship belonging to it from the graph. There is "
+            "no undo, and recovering the data requires a full re-index, which can "
+            "take a long time on a large repository. Only call this when the user "
+            "has explicitly asked for that repository to be removed."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -289,12 +295,29 @@ TOOLS = {
 
     "load_bundle": {
         "name": "load_bundle",
-        "description": "Load a pre-indexed bundle.",
+        "description": (
+            "Load a pre-indexed graph bundle (.cgc) into the database. Note that "
+            "clear_existing=True is DESTRUCTIVE AND IRREVERSIBLE — see its "
+            "description before setting it."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
-                "bundle_name": {"type": "string"},
-                "clear_existing": {"type": "boolean", "default": False},
+                "bundle_name": {
+                    "type": "string",
+                    "description": "Name of the bundle to load from the registry, or a path to a local .cgc file."
+                },
+                "clear_existing": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "DESTRUCTIVE AND IRREVERSIBLE. When true, the existing "
+                        "repository data is deleted from the graph before the bundle "
+                        "is imported — this discards previously indexed content, not "
+                        "just a previous copy of this bundle. Leave false unless the "
+                        "user has explicitly asked to replace what is already indexed."
+                    )
+                },
                 "graph_name": _GRAPH_NAME_PROP
             },
             "required": ["bundle_name"]

--- a/src/codegraphcontext/tools/handlers/analysis_handlers.py
+++ b/src/codegraphcontext/tools/handlers/analysis_handlers.py
@@ -165,6 +165,10 @@ def find_code(code_finder: CodeFinder, **args) -> Dict[str, Any]:
 
 # ── Spring-aware handlers (#887 / #889) ───────────────────────────────────────
 
+#: Row cap shared by the Java/Spring tools; surfaced via `truncated`.
+_SPRING_ROW_LIMIT = 100
+
+
 def find_java_spring_endpoints(code_finder: CodeFinder, **args) -> Dict[str, Any]:
     """Return all Spring HTTP endpoint functions, optionally filtered by method or path."""
     http_method = args.get("http_method")
@@ -187,20 +191,25 @@ def find_java_spring_endpoints(code_finder: CodeFinder, **args) -> Dict[str, Any
         params["repo_path"] = repo_path
 
     where_clause = " AND ".join(conditions)
+    params["spring_row_limit"] = _SPRING_ROW_LIMIT
     query = f"""
         MATCH (fn:Function)
         WHERE {where_clause}
         RETURN fn.http_method AS method, fn.http_path AS path,
                fn.name AS handler, fn.path AS file, fn.line_number AS line_number
         ORDER BY fn.http_path, fn.http_method
-        LIMIT 100
+        LIMIT $spring_row_limit
     """
 
     try:
         with code_finder.driver.session() as session:
             result = session.run(query, **params)
             rows = [dict(r) for r in result]
-        return {"success": True, "endpoints": rows, "count": len(rows)}
+        response = {"success": True, "endpoints": rows, "count": len(rows)}
+        if len(rows) >= _SPRING_ROW_LIMIT:
+            response["result_limit"] = _SPRING_ROW_LIMIT
+            response["truncated"] = True
+        return response
     except Exception as exc:
         debug_log(f"Error finding Spring endpoints: {exc}")
         return {"error": str(exc)}
@@ -223,6 +232,7 @@ def find_java_spring_beans(code_finder: CodeFinder, **args) -> Dict[str, Any]:
         params["repo_path"] = repo_path
 
     where_clause = " AND ".join(conditions)
+    params["spring_row_limit"] = _SPRING_ROW_LIMIT
     query = f"""
         MATCH (c:Class)
         WHERE {where_clause}
@@ -231,14 +241,18 @@ def find_java_spring_beans(code_finder: CodeFinder, **args) -> Dict[str, Any]:
         RETURN c.name AS name, c.spring_stereotype AS stereotype,
                c.path AS file, c.line_number AS line_number, injection_count
         ORDER BY stereotype, name
-        LIMIT 100
+        LIMIT $spring_row_limit
     """
 
     try:
         with code_finder.driver.session() as session:
             result = session.run(query, **params)
             rows = [dict(r) for r in result]
-        return {"success": True, "beans": rows, "count": len(rows)}
+        response = {"success": True, "beans": rows, "count": len(rows)}
+        if len(rows) >= _SPRING_ROW_LIMIT:
+            response["result_limit"] = _SPRING_ROW_LIMIT
+            response["truncated"] = True
+        return response
     except Exception as exc:
         debug_log(f"Error finding Spring beans: {exc}")
         return {"error": str(exc)}

--- a/tests/unit/tools/test_mcp_contracts.py
+++ b/tests/unit/tools/test_mcp_contracts.py
@@ -1,0 +1,58 @@
+"""Regression tests for MCP tool contracts."""
+import inspect
+
+import pytest
+
+from codegraphcontext import prompts
+from codegraphcontext.server import MCPServer
+from codegraphcontext.tool_definitions import TOOLS
+
+
+def test_list_jobs_tool_tolerates_extra_arguments():
+    """Dispatch is `handler(**args)` and the schema declares no
+    additionalProperties:false, so a client may legitimately send extras.
+    Without **args that raised TypeError, surfacing as -32603 Internal error
+    and looking indistinguishable from a server crash."""
+    sig = inspect.signature(MCPServer.list_jobs_tool)
+    assert any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    ), "list_jobs_tool must accept **args like every sibling handler"
+
+
+@pytest.mark.parametrize("tool_name", ["delete_repository", "load_bundle"])
+def test_destructive_tools_warn_in_their_description(tool_name):
+    """Descriptions were 'Delete a repository from the graph.' and 'Load a
+    pre-indexed bundle.' — nothing told the model they are irreversible."""
+    description = TOOLS[tool_name]["description"].lower()
+    assert "irreversible" in description
+    assert "destructive" in description
+
+
+def test_clear_existing_documents_that_it_drops_existing_data():
+    """`clear_existing` had no description at all, so to an LLM it read like
+    'clear the existing copy of this bundle'."""
+    prop = TOOLS["load_bundle"]["inputSchema"]["properties"]["clear_existing"]
+    description = prop.get("description", "").lower()
+    assert description, "clear_existing must document what it clears"
+    assert "irreversible" in description or "destructive" in description
+    assert "deleted" in description or "discards" in description
+
+
+def test_spring_tools_declare_their_row_cap():
+    from codegraphcontext.tools.handlers import analysis_handlers
+
+    source = inspect.getsource(analysis_handlers)
+    # The hard LIMIT 100 must be surfaced, like every sibling tool does.
+    assert "_SPRING_ROW_LIMIT" in source
+    for fn in ("find_java_spring_endpoints", "find_java_spring_beans"):
+        body = inspect.getsource(getattr(analysis_handlers, fn))
+        assert '"truncated"' in body, f"{fn} must flag truncation"
+        assert '"result_limit"' in body, f"{fn} must report its row cap"
+
+
+def test_cypher_fallback_instruction_is_not_self_contradictory():
+    """The guidance read 'use the correct property names (e.g. `path` vs
+    `path`)' — a corrupted instruction that teaches the model nothing."""
+    assert "`path` vs `path`" not in prompts.LLM_SYSTEM_PROMPT
+    # ...and it still tells the model to consult the schema.
+    assert "Graph Schema Reference" in prompts.LLM_SYSTEM_PROMPT


### PR DESCRIPTION
MCP contract defects and stale documentation, from an end-to-end audit of 0.5.2. Every docs claim below was re-verified against the code on `main`.

### 1. `list_jobs` crashed the protocol on any extra argument (`U-M9`)

`def list_jobs_tool(self)` was the only handler without `**args`, but dispatch is `handler(**args)` and its schema declares no `additionalProperties: false` — so clients may legitimately send extras. The `TypeError` surfaced as `-32603 Internal error`, indistinguishable from a server crash.

### 2. Destructive tools carried no warning (`U-M7`)

Full descriptions were `"Delete a repository from the graph."` and `"Load a pre-indexed bundle."`. `load_bundle.clear_existing` had **no description at all** despite dropping previously indexed data — to an LLM it reads like "clear the existing copy of this bundle".

The `ALLOW_DB_DELETION` guard does fire on the MCP path and defaults closed, so this was never exploitable by default. But on any host that enables it for legitimate use, nothing in the contract told the model these are irreversible. Both now say so explicitly.

### 3. Java/Spring tools truncated silently (`U-L4`)

`find_java_spring_endpoints` and `find_java_spring_beans` hard-capped at `LIMIT 100` with no `truncated` flag — unlike every sibling tool, which sets `response["truncated"] = True`. A 300-endpoint app reported 100 as complete. Both now return `truncated` and `result_limit`, with the cap as a named constant.

### 4. A corrupted instruction in the system prompt (`U-L5`)

```
**Consult the Graph Schema Reference above to ensure you use the
correct property names (e.g. `path` vs `path`).**
```

Replaced with a contrast that actually distinguishes something.

### 5. Docs that describe behaviour the code does not have (`U-M10`, `U-M11`)

| Doc | Claimed | Actual |
|---|---|---|
| `contributing.md:39` | `export CGC_LOG_LEVEL=DEBUG` | **0 hits** for `CGC_LOG_LEVEL` in the codebase; real knobs are `DEBUG_LOGS` / `ENABLE_APP_LOGS` / `LIBRARY_LOG_LEVEL` |
| `contributing.md:54` | `CGC_SKIP_REINDEX=true pytest` | **0 hits**; removed |
| `reference/config.md:106` | `SCIP_LANGUAGES` default = 5 languages | 10 (`config_manager.py:111`) |
| `guides/indexing.md:94`, `reference/cli.md:179` | "On startup, each watcher **reconciles** the graph with disk" | `sync_on_start` defaults to `False`; `--sync-on-start` is required and was mentioned in neither doc |

### Tests

6 new tests: `list_jobs_tool` accepts `**args`, both destructive tools warn, `clear_existing` documents what it clears, both Spring tools flag truncation, and the prompt instruction is no longer self-contradictory.

Full unit suite: **716 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py`, flaky on `main` independently of this PR — see #1408).

<sub>From an end-to-end audit of CGC 0.5.2. Related filed findings: #1382–#1402.</sub>