### PR TITLE
fix: add nornic to valid backends in config db command

### DIFF
--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -577,7 +577,7 @@ def config_reset():
         console.print("[yellow]Reset cancelled[/yellow]")
 
 @config_app.command("db")
-def config_db(backend: str = typer.Argument(..., help="Database backend: 'neo4j', 'falkordb', 'falkordb-remote', 'kuzudb', or 'ladybugdb'")):
+def config_db(backend: str = typer.Argument(..., help="Database backend: 'neo4j', 'falkordb', 'falkordb-remote', 'kuzudb', 'nornic', or 'ladybugdb'")):
     """
     Quickly switch the default database backend.
     
@@ -589,9 +589,9 @@ def config_db(backend: str = typer.Argument(..., help="Database backend: 'neo4j'
         cgc config db kuzudb
     """
     backend = backend.lower()
-    if backend not in ['falkordb', 'falkordb-remote', 'neo4j', 'kuzudb', 'ladybugdb']:
+    if backend not in ['falkordb', 'falkordb-remote', 'neo4j', 'kuzudb', 'nornic', 'ladybugdb']:
         console.print(f"[bold red]Invalid backend: {backend}[/bold red]")
-        console.print("Must be 'falkordb', 'falkordb-remote', 'neo4j', 'kuzudb', or 'ladybugdb'")
+        console.print("Must be 'falkordb', 'falkordb-remote', 'neo4j', 'kuzudb', 'nornic', or 'ladybugdb'")
         raise typer.Exit(code=1)
     
     updated = config_manager.set_config_value("DEFAULT_DATABASE", backend)


### PR DESCRIPTION
Closes #1400

The config_db command in main.py had a hardcoded allowed list that was missing 'nornic', causing 'cgc config db nornic' to return an error even though nornic is a fully supported backend.

config_manager.py, core/__init__.py, and all documentation already treated nornic as valid — only main.py was out of sync. This PR aligns main.py's validation list with the rest of the codebase so `nornic` is correctly accepted.