### PR TITLE
fix(cli): repair `bundle load` and `index` exit codes (Typer default leakage)

### DIFF
--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -829,6 +829,7 @@ def bundle_load(
     bundle_name: str = typer.Argument(..., help="Bundle name or path to load (e.g., 'numpy' or 'numpy.cgc')"),
     clear: bool = typer.Option(False, "--clear", help="Clear existing graph data before loading"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation when using --clear"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
 ):
     """
     Load a pre-indexed bundle (download if needed, then import).
@@ -849,7 +850,7 @@ def bundle_load(
     
     # If it's an absolute path or has .cgc extension and exists, use it directly
     if bundle_path.is_absolute() or (bundle_path.suffix == '.cgc' and bundle_path.exists()):
-        bundle_import(str(bundle_path), clear=clear, yes=yes)
+        bundle_import(str(bundle_path), clear=clear, yes=yes, context=context)
         return
     
     # Add .cgc extension if not present
@@ -859,7 +860,7 @@ def bundle_load(
     # Check if exists locally
     if bundle_path.exists():
         console.print(f"[dim]Found local bundle: {bundle_path}[/dim]")
-        bundle_import(str(bundle_path), clear=clear, yes=yes)
+        bundle_import(str(bundle_path), clear=clear, yes=yes, context=context)
         return
     
     # Try to download from registry
@@ -877,7 +878,7 @@ def bundle_load(
         
         if downloaded_path:
             # Import the downloaded bundle
-            bundle_import(downloaded_path, clear=clear, yes=yes)
+            bundle_import(downloaded_path, clear=clear, yes=yes, context=context)
         else:
             console.print(f"[bold red]Failed to download bundle '{name}'[/bold red]")
             raise typer.Exit(code=1)
@@ -1015,9 +1016,12 @@ def load_shortcut(
     bundle_name: str = typer.Argument(..., help="Bundle name or path to load"),
     clear: bool = typer.Option(False, "--clear", help="Clear existing graph data before loading"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation when using --clear"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
 ):
     """Shortcut for 'cgc bundle load'"""
-    bundle_load(bundle_name, clear, yes=yes)
+    # Must pass `context` explicitly: invoked as a plain function, Typer does not
+    # resolve defaults, so an omitted parameter keeps its OptionInfo sentinel.
+    bundle_load(bundle_name, clear, yes=yes, context=context)
 
 # ============================================================================
 # REGISTRY COMMAND GROUP - Browse and Download Bundles
@@ -1118,7 +1122,7 @@ def registry_download(
     
     if load and bundle_path:
         console.print("\n[cyan]Loading bundle...[/cyan]")
-        bundle_import(bundle_path, clear=False)
+        bundle_import(bundle_path, clear=False, yes=False, context=None)
 
 @registry_app.command("request")
 def registry_request(
@@ -1414,9 +1418,18 @@ def index(
             reindex_helper(path, context)
         else:
             index_helper(path, context)
+    except typer.Exit:
+        # typer.Exit subclasses RuntimeError and str() is empty, so the handler
+        # below caught it, printed nothing, and returned 0 — every helper that
+        # raised `typer.Exit(code=1)` (missing path, failed indexing) silently
+        # became a success. Re-raise control flow before catching errors.
+        raise
     except Exception as e:
         if str(e):
             console.print(f"[red]An error occurred during indexing: {e}[/red]")
+        else:
+            console.print("[red]An error occurred during indexing.[/red]")
+        raise typer.Exit(code=1)
 
     if summarize:
         import os
@@ -2961,10 +2974,13 @@ def cypher_legacy(
 def index_abbrev(
     path: Optional[str] = typer.Argument(None, help="Path to index"),
     force: bool = typer.Option(False, "--force", "-f", help="Force re-index (delete existing and rebuild)"),
+    summarize: bool = typer.Option(False, "--summarize", "-s", help="Display a codebase summary after indexing"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use")
 ):
     """Shortcut for 'cgc index'"""
-    index(path, force=force, context=context)
+    # `summarize` must be passed explicitly: omitted, it keeps its OptionInfo
+    # sentinel, which is truthy — so `cgc i` always printed the summary.
+    index(path, force=force, summarize=summarize, context=context)
 
 @app.command("ls", rich_help_panel="Shortcuts")
 def list_abbrev(

--- a/tests/unit/cli/test_command_delegation_and_exit_codes.py
+++ b/tests/unit/cli/test_command_delegation_and_exit_codes.py
@@ -1,0 +1,115 @@
+"""Regression tests for command-to-command delegation and `cgc index` exit codes."""
+import ast
+import inspect
+from unittest.mock import patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from codegraphcontext.cli import main as cli_main
+from codegraphcontext.cli.main import app
+
+runner = CliRunner()
+
+
+def _command_functions(tree):
+    """Map command function name -> (ordered params, typer-defaulted params)."""
+    commands = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if not any("command" in ast.dump(d) for d in node.decorator_list):
+            continue
+        params = [a.arg for a in node.args.args]
+        defaults = node.args.defaults
+        offset = len(params) - len(defaults)
+        typer_defaulted = {
+            params[offset + i]
+            for i, d in enumerate(defaults)
+            if "typer" in ast.dump(d) and ("Option" in ast.dump(d) or "Argument" in ast.dump(d))
+        }
+        commands[node.name] = (params, typer_defaulted)
+    return commands
+
+
+def test_no_command_delegates_without_supplying_typer_defaults():
+    """Typer resolves defaults only when *it* invokes the command. A command
+    calling a sibling as a plain function must pass every Typer-defaulted
+    parameter explicitly, or the callee receives a `typer.models.OptionInfo`
+    sentinel — which is truthy, and which leaks into user-facing errors.
+
+    This guards the whole bug class, not just the instances found so far:
+      - bundle_load -> bundle_import omitted `context`, making `cgc bundle
+        load` and `cgc load` fail 100% of the time.
+      - index_abbrev -> index omitted `summarize`, so `cgc i` always printed
+        the codebase summary.
+    """
+    tree = ast.parse(inspect.getsource(cli_main))
+    commands = _command_functions(tree)
+
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
+                continue
+            callee = call.func.id
+            if callee not in commands or callee == node.name:
+                continue
+            params, typer_defaulted = commands[callee]
+            supplied = set(params[: len(call.args)]) | {
+                kw.arg for kw in call.keywords if kw.arg
+            }
+            missing = typer_defaulted - supplied
+            if missing:
+                offenders.append(
+                    f"main.py:{call.lineno} {node.name}() -> {callee}() "
+                    f"missing {sorted(missing)}"
+                )
+
+    assert not offenders, "command delegation drops Typer defaults:\n  " + "\n  ".join(offenders)
+
+
+def test_optioninfo_is_truthy():
+    """Documents why an omitted boolean flag silently turns itself on."""
+    assert bool(typer.Option(False, "--summarize")) is True
+
+
+@pytest.mark.parametrize("argv", [
+    ["index", "/nonexistent-path-for-cgc-tests"],
+    ["index", "--force", "/nonexistent-path-for-cgc-tests"],
+])
+def test_index_exits_nonzero_when_the_helper_aborts(argv):
+    """`typer.Exit` subclasses RuntimeError with an empty str(), so the bare
+    `except Exception` swallowed it and returned 0 — CI treated every indexing
+    failure as success."""
+    with patch.object(cli_main, "index_helper", side_effect=typer.Exit(code=1)), \
+         patch.object(cli_main, "reindex_helper", side_effect=typer.Exit(code=1)), \
+         patch.object(cli_main, "_load_credentials"):
+        result = runner.invoke(app, argv)
+
+    assert result.exit_code == 1
+
+
+def test_index_exits_nonzero_on_an_unexpected_error():
+    with patch.object(cli_main, "index_helper", side_effect=RuntimeError("boom")), \
+         patch.object(cli_main, "_load_credentials"):
+        result = runner.invoke(app, ["index", "."])
+
+    assert result.exit_code == 1
+
+
+def test_index_still_exits_zero_on_success():
+    with patch.object(cli_main, "index_helper"), \
+         patch.object(cli_main, "_load_credentials"):
+        result = runner.invoke(app, ["index", "."])
+
+    assert result.exit_code == 0
+
+
+def test_bundle_load_accepts_a_context_flag():
+    result = runner.invoke(app, ["bundle", "load", "--help"])
+    assert result.exit_code == 0
+    assert "--context" in " ".join(result.output.split())


### PR DESCRIPTION
Fixes two of the five criticals from the 0.5.2 audit — #1384 and #1385. They turn out to share a root cause, and auditing that root cause surfaced two further bugs the report did not find.

## Root cause

Typer resolves parameter defaults only when **Typer itself** invokes the command. A command that calls a sibling as a plain Python function must pass every Typer-defaulted parameter explicitly — otherwise the callee receives a `typer.models.OptionInfo` sentinel. And that sentinel is **truthy**:

```python
>>> bool(typer.Option(False, "--summarize"))
True
```

## 1. `cgc bundle load` / `cgc load` were 100 % broken (#1384)

```
$ cgc bundle load test.cgc
Error: Context '<typer.models.OptionInfo object at 0x7f23a72fe000>' is not registered.
Create it with: cgc context create <typer.models.OptionInfo object at 0x7f23a72fe000>
EXIT=1
```

`bundle_load` called `bundle_import` without `context`; `load_shortcut` called `bundle_load` without it in turn. Both now forward it, and both gained the `--context` flag that `bundle import` already had.

After the fix:

```
$ cgc bundle load test.cgc --clear -y
✅ Successfully imported test.cgc
   Repository: bundlesrc
   Nodes: 5 | Edges: 5
EXIT=0
```

## 2. `cgc index` exited 0 on every failure (#1385)

```python
except Exception as e:
    if str(e):
        console.print(f"[red]An error occurred during indexing: {e}[/red]")
```

`typer.Exit` subclasses `RuntimeError` and its `str()` is empty — so the handler caught it, printed nothing, and returned 0.

```
$ cgc index /nonexistent      EXIT=0   ->  now 1
$ cgc index --force /nonexistent  EXIT=0   ->  now 1
$ cgc index <valid>           EXIT=0   ->  still 0
```

This is also the mechanism by which the symlink abort (#1383) exits 0.

## 3 & 4. Two more instances, not in the report

Auditing the bug class across `main.py` found:

| Site | Dropped | Effect |
|---|---|---|
| `registry_download` → `bundle_import` | `yes` | `OptionInfo` passed as the confirmation flag |
| `index_abbrev` → `index` | `summarize` | **`cgc i` always printed the codebase summary**, because the sentinel is truthy |

Confirmed and fixed:

```
$ cgc i <path> --force               summary blocks printed: 0   (was 1)
$ cgc i <path> --force --summarize   summary blocks printed: 1
```

## Tests

7 new tests. **5 fail against unpatched `main`**, verified by stashing the fix.

The key one is `test_no_command_delegates_without_supplying_typer_defaults`: it walks the AST of `cli/main.py` and fails if *any* command calls another while omitting a Typer-defaulted parameter. That guards the whole class rather than the four known instances — this is the third time this pattern has bitten.

Full unit suite: **739 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py`, flaky on `main` independently — see #1408).

Closes #1384
Closes #1385