### PR TITLE
docs(cli): correct reference command options

### DIFF
--- a/docs/CLI_COMPLETE_REFERENCE.md
+++ b/docs/CLI_COMPLETE_REFERENCE.md
@@ -53,7 +53,7 @@
 | `cgc analyze tree` | `<class>` `--file` | Visualize class inheritance hierarchy. |
 | `cgc analyze complexity` | `[path]` `--threshold` `--limit` | List functions with high cyclomatic complexity. Default threshold: 10. |
 | `cgc analyze dead-code` | `--exclude` | Find potentially unused functions (0 callers). |
-| `cgc analyze overrides` | `<class>` `--file` | Show methods that override parent class methods. |
+| `cgc analyze overrides` | `<function_name>` | Show implementations of a function across different classes. |
 | `cgc analyze variable` | `<var_name>` `--file` | Analyze variable usage and assignments. |
 
 ---
@@ -66,7 +66,7 @@
 | `cgc find pattern` | `<pattern>` `--case-sensitive` | Find elements using fuzzy substring matching. |
 | `cgc find type` | `<type>` `--limit` | List all nodes of a specific type (function, class, module). |
 | `cgc find variable` | `<name>` | Find variables by name across the codebase. |
-| `cgc find content` | `<text>` `--case-sensitive` | Search for text content within code (docstrings, comments). |
+| `cgc find content` | `<text>` | Search for text content within code (docstrings, comments). |
 | `cgc find decorator` | `<name>` | Find all functions/classes with a specific decorator. |
 | `cgc find argument` | `<name>` | Find all functions that have a specific argument name. |
 
@@ -113,7 +113,7 @@
 | Command | Arguments | Description |
 |---------|-----------|-------------|
 | `cgc doctor` | None | Run system diagnostics (DB, dependencies, permissions). |
-| `cgc visualize` | `[query]` | Generate link to Neo4j Browser. *(Alias: `cgc v`)* |
+| `cgc visualize` | `--repo <path>` `--host <host>` `--port <port>` | Launch the local interactive graph UI. *(Alias: `cgc v`)* |
 | `cgc query` | `<query>` | Execute raw Cypher query against DB. |
 | `cgc help` | None | Show main help message with all commands. |
 | `cgc version` | None | Show application version. |

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -27,7 +27,7 @@ Use `cgc version` (or `cgc --version`) to print the installed release (currently
 
 | Command | Usage | Notes |
 | :--- | :--- | :--- |
-| **`index`** | `cgc index [PATH] [--force] [--dependency]` | Shortcut: `cgc i`. Incremental by default; `--force` rebuilds from scratch. |
+| **`index`** | `cgc index [PATH] [--force] [--summarize]` | Shortcut: `cgc i`. Incremental by default; `--force` rebuilds from scratch and `--summarize` prints an indexing summary. |
 | **`clean`** | `cgc clean` | Purges orphaned nodes and dangling relationships. |
 | **`stats`** | `cgc stats` | Repository and node counts for the active context. |
 | **`delete`** | `cgc delete <repo_path>` | Shortcut: `cgc rm`. Removes one indexed repository. |
@@ -69,7 +69,7 @@ cgc analyze <subcommand> [args] [options]
 | `analyze tree <class>` | Class inheritance tree. |
 | `analyze complexity <function>` | Cyclomatic complexity for one function. |
 | `analyze dead-code` | Unreferenced functions/files (with optional filters). |
-| `analyze overrides <class>` | Methods overridden in subclasses. |
+| `analyze overrides <function>` | Implementations of a function across different classes. |
 | `analyze variable <name>` | Variable scope and modification sites. |
 | `analyze kotlin-call-audit` | Kotlin-specific call resolution audit. |
 
@@ -91,7 +91,7 @@ cgc query "MATCH (n)-[r]->(m) RETURN n,r,m LIMIT 50" --visual
 Generate `CGC_REPORT.md` with god-node, complexity, and coupling metrics.
 
 ```bash
-cgc report [--include-java]
+cgc report [--java]
 ```
 
 #### `visualize`


### PR DESCRIPTION
## Summary

- correct the documented `report`, `index`, `analyze overrides`, `find content`, and `visualize` command surfaces
- describe `visualize` as the local interactive UI rather than a Neo4j Browser query link

Fixes #1402

## Validation

- invoked the current CLI help for `report`, `index`, `analyze overrides`, `find content`, and `visualize` via `PYTHONPATH=src uv run python -m codegraphcontext.cli.main … --help`
- `PYTHONPATH=src uv run pytest -q`
- stale-option documentation scan and `git diff --check`