### PR TITLE
fix(security): validate bundle labels and relationship types before interpolation

### DIFF
--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -21,6 +21,7 @@ Bundle Structure:
 
 import json
 import os
+import re
 import zipfile
 import tempfile
 from pathlib import Path
@@ -50,9 +51,34 @@ class _BundleEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
+#: Cypher identifiers accepted from a bundle. Labels and relationship types
+#: cannot be passed as query parameters — they are interpolated into the query
+#: text — so a bundle is an untrusted source of executable Cypher unless every
+#: identifier is validated first. A bundle carrying the label
+#:     Evil) WITH n MATCH (v:Victim) DETACH DELETE v //
+#: previously produced, and executed:
+#:     CREATE (n:Evil) WITH n MATCH (v:Victim) DETACH DELETE v //) SET n = $props ...
+_CYPHER_IDENTIFIER_RE = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class BundleValidationError(ValueError):
+    """Raised when a bundle contains content that is unsafe to import."""
+
+
+def _validate_cypher_identifier(value: Any, kind: str) -> str:
+    """Return *value* if it is a bare Cypher identifier, else raise."""
+    if not isinstance(value, str) or not _CYPHER_IDENTIFIER_RE.match(value):
+        raise BundleValidationError(
+            f"Refusing to import bundle: invalid {kind} {value!r}. "
+            f"{kind.capitalize()}s must match [A-Za-z_][A-Za-z0-9_]* — a value "
+            "outside that set can inject arbitrary Cypher."
+        )
+    return value
+
+
 class CGCBundle:
     """Handles creation and loading of .cgc bundle files."""
-    
+
     VERSION = "0.1.0"  # CGC bundle format version
     
     def __init__(self, db_manager):
@@ -810,7 +836,45 @@ cgc import <bundle-file>.cgc
                     return False, "Invalid metadata: missing cgc_version"
         except json.JSONDecodeError as e:
             return False, f"Invalid metadata.json: {e}"
-        
+
+        # Reject unsafe identifiers up front. The import writes in batches with
+        # no transaction, so validating lazily would let a malicious label
+        # halfway through the file execute after earlier nodes were committed.
+        ok, message = self._validate_bundle_identifiers(bundle_dir)
+        if not ok:
+            return False, message
+
+        return True, "Valid bundle"
+
+    @staticmethod
+    def _validate_bundle_identifiers(bundle_dir: Path) -> Tuple[bool, str]:
+        """Check every node label and relationship type before importing anything."""
+        try:
+            with open(bundle_dir / "nodes.jsonl", 'r', encoding='utf-8') as f:
+                for line_no, line in enumerate(f, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    labels = json.loads(line).get('_labels') or []
+                    if isinstance(labels, str):
+                        labels = [labels]
+                    for label in labels:
+                        _validate_cypher_identifier(label, "node label")
+
+            with open(bundle_dir / "edges.jsonl", 'r', encoding='utf-8') as f:
+                for line_no, line in enumerate(f, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    _validate_cypher_identifier(
+                        json.loads(line).get('type'), "relationship type"
+                    )
+        except BundleValidationError as e:
+            error_logger(f"Bundle rejected: {e}")
+            return False, str(e)
+        except json.JSONDecodeError as e:
+            return False, f"Malformed JSON Lines in bundle: {e}"
+
         return True, "Valid bundle"
     
     def _check_existing_repository(self, repo_name: str, repo_path: Optional[str]) -> bool:
@@ -977,6 +1041,7 @@ cgc import <bundle-file>.cgc
             
             if isinstance(labels, str):
                 labels = [labels]
+            labels = [_validate_cypher_identifier(l, "node label") for l in labels]
             label_str = ':'.join(labels)
             primary_label = labels[0]
 
@@ -1044,7 +1109,7 @@ cgc import <bundle-file>.cgc
                 old_from = (old_from.get('table', 0), old_from.get('offset', 0))
             if isinstance(old_to, dict):
                 old_to = (old_to.get('table', 0), old_to.get('offset', 0))
-            rel_type = edge.get('type')
+            rel_type = _validate_cypher_identifier(edge.get('type'), "relationship type")
             properties = edge.get('properties', {})
             
             # Map old IDs to new IDs

--- a/tests/unit/core/test_bundle_identifier_validation.py
+++ b/tests/unit/core/test_bundle_identifier_validation.py
@@ -1,0 +1,144 @@
+"""Security regression tests: a .cgc bundle must not be able to inject Cypher."""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.core.cgc_bundle import (
+    BundleValidationError,
+    CGCBundle,
+    _validate_cypher_identifier,
+)
+
+INJECTIONS = [
+    "Evil) WITH n MATCH (v:Victim) DETACH DELETE v //",
+    "Function` ) DETACH DELETE n //",
+    "A:B",
+    "A B",
+    "A-B",
+    "A{x:1}",
+    "A)",
+    "",
+    "1StartsWithDigit",
+    "MATCH (n) DETACH DELETE n",
+]
+
+VALID = ["Function", "Class", "_Private", "Repo2", "ExternalClass", "DbTable"]
+
+
+class _RecordingSession:
+    def __init__(self):
+        self.queries = []
+
+    def run(self, query, **params):
+        self.queries.append(query)
+        result = MagicMock()
+        result.single.return_value = {"new_id": 1}
+        return result
+
+
+def _bundle():
+    db_manager = MagicMock()
+    db_manager.get_backend_type.return_value = "falkordb"
+    return CGCBundle(db_manager)
+
+
+@pytest.mark.parametrize("value", INJECTIONS)
+def test_invalid_identifiers_are_rejected(value):
+    with pytest.raises(BundleValidationError):
+        _validate_cypher_identifier(value, "node label")
+
+
+@pytest.mark.parametrize("value", VALID)
+def test_valid_identifiers_are_accepted(value):
+    assert _validate_cypher_identifier(value, "node label") == value
+
+
+def test_node_label_injection_never_reaches_the_driver():
+    """Labels are interpolated into the query text (they cannot be
+    parameterised), so an unvalidated label is executable Cypher. Before the
+    fix this produced, and ran:
+
+        CREATE (n:Evil) WITH n MATCH (v:Victim) DETACH DELETE v //) SET n = $props ...
+    """
+    session = _RecordingSession()
+    payload = "Evil) WITH n MATCH (v:Victim) DETACH DELETE v //"
+
+    with pytest.raises(BundleValidationError):
+        _bundle()._import_node_batch(session, [([payload], {"name": "x"}, 1)], {})
+
+    assert session.queries == [], "no query may be issued for an invalid label"
+
+
+def test_relationship_type_injection_never_reaches_the_driver():
+    session = _RecordingSession()
+    edge = {
+        "from": 1,
+        "to": 2,
+        "type": "R]->() WITH 1 AS x MATCH (v:Victim) DETACH DELETE v //",
+        "properties": {},
+    }
+
+    bundle = _bundle()
+    bundle._id_mapping = {1: 1, 2: 2}
+
+    with pytest.raises(BundleValidationError):
+        bundle._import_edge_batch(session, [edge])
+
+    assert session.queries == []
+
+
+def test_legitimate_labels_still_build_a_query():
+    session = _RecordingSession()
+    _bundle()._import_node_batch(session, [(["Function"], {"uid": "u1"}, 1)], {})
+
+    assert len(session.queries) == 1
+    assert "MERGE (n:Function" in session.queries[0]
+
+
+def _write_bundle(tmp_path: Path, nodes, edges) -> Path:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "metadata.json").write_text(json.dumps({"cgc_version": "0.1.0"}))
+    (bundle_dir / "schema.json").write_text(json.dumps({}))
+    (bundle_dir / "nodes.jsonl").write_text("\n".join(json.dumps(n) for n in nodes))
+    (bundle_dir / "edges.jsonl").write_text("\n".join(json.dumps(e) for e in edges))
+    return bundle_dir
+
+
+def test_bundle_is_rejected_before_any_node_is_written(tmp_path):
+    """The import writes in batches with no transaction, so a malicious label
+    halfway through the file would execute after earlier nodes had committed.
+    Validation must happen up front."""
+    nodes = [
+        {"_labels": ["Function"], "_id": 1, "uid": "ok"},
+        {"_labels": ["Evil) WITH n MATCH (v:Victim) DETACH DELETE v //"], "_id": 2},
+    ]
+    bundle_dir = _write_bundle(tmp_path, nodes, [])
+
+    ok, message = _bundle()._validate_bundle(bundle_dir)
+
+    assert ok is False
+    assert "invalid node label" in message
+
+
+def test_bundle_with_bad_relationship_type_is_rejected(tmp_path):
+    nodes = [{"_labels": ["Function"], "_id": 1, "uid": "ok"}]
+    edges = [{"from": 1, "to": 1, "type": "CALLS]->() DETACH DELETE n //"}]
+    bundle_dir = _write_bundle(tmp_path, nodes, edges)
+
+    ok, message = _bundle()._validate_bundle(bundle_dir)
+
+    assert ok is False
+    assert "invalid relationship type" in message
+
+
+def test_clean_bundle_passes_validation(tmp_path):
+    nodes = [{"_labels": ["Function"], "_id": 1, "uid": "ok"}]
+    edges = [{"from": 1, "to": 1, "type": "CALLS"}]
+    bundle_dir = _write_bundle(tmp_path, nodes, edges)
+
+    ok, _ = _bundle()._validate_bundle(bundle_dir)
+
+    assert ok is True


### PR DESCRIPTION
Fixes #1382 — the most severe finding in the 0.5.2 audit. Importing a `.cgc` bundle executed **arbitrary Cypher** as the CGC user.

## The vulnerability

Node labels and relationship types **cannot be parameterised** — they are interpolated into the query text:

```python
label_str = ':'.join(labels)                     # straight from nodes.jsonl
query = f"CREATE (n:{label_str}) SET n = $props RETURN {id_function}(n) as new_id"
...
rel_type = edge.get('type')                      # straight from edges.jsonl
query = f"MATCH (a:{from_label} …), (b:{to_label} …) CREATE (a)-[r:{rel_type}]->(b) SET r = $props"
```

`_validate_bundle` checked only that four files exist and that `metadata.json` has a `cgc_version` key — never comparing its value. Labels and relationship types were not checked at all.

## Reproduced

I built a bundle whose node `_labels` was `Evil) WITH n MATCH (v:Victim) DETACH DELETE v //` and recorded the query handed to the driver:

```
CREATE (n:Evil) WITH n MATCH (v:Victim) DETACH DELETE v //) SET n = $props RETURN id(n) as new_id
```

That is valid Cypher: it creates the node, then deletes every `:Victim` in the graph.

**Scope note, stated honestly:** I could not complete the *end-to-end* data-destruction run in this environment. The live backend here is KùzuDB (via the silent fallback in #1387/#1388), and Kùzu is strongly typed — it rejects an undeclared node table, so the payload cannot land there. The injection is exploitable on the schemaless backends, FalkorDB in particular, which is the default on Linux/macOS. The query-construction proof above is exact and backend-independent.

This matters beyond direct destruction: bundles are a first-class distribution mechanism with a public registry, downloaded with **no checksum and no signature**, and `load_bundle` is reachable from the unauthenticated HTTP gateway (#1008).

## The fix

Every label and relationship type must match `[A-Za-z_][A-Za-z0-9_]*` before it reaches a query. Validation runs at two levels:

1. **Up front**, scanning `nodes.jsonl` and `edges.jsonl` in `_validate_bundle`, so the bundle is rejected before anything is written. This matters because the import writes in batches with **no transaction** — validating lazily would let a malicious label halfway through the file execute after earlier nodes had already committed.
2. **At each interpolation site**, as a backstop for any future caller that bypasses `_validate_bundle`.

```
$ cgc bundle import evil.cgc
Import failed: Invalid bundle: Refusing to import bundle: invalid node label
'Evil) WITH n MATCH (v:Victim) DETACH DELETE v //'. Node labels must match
[A-Za-z_][A-Za-z0-9_]* — a value outside that set can inject arbitrary Cypher.
EXIT=1
```

Legitimate bundles are unaffected — export → import of a real repository round-trips unchanged (5 nodes / 5 edges, exit 0).

## Tests

22 new tests: 10 injection payloads rejected, 6 valid identifiers accepted, no query reaching the driver for a bad label or relationship type, a legitimate label still building its query, and bundle-level rejection for a malicious label appearing *after* a valid node.

Full unit suite: **754 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py`, flaky on `main` independently — see #1408).

## Still open

This fixes the injection only. Bundle **provenance** — no checksum, no signature, no `cgc_version` compatibility check, and an unbounded download — remains open and is worth its own issue.

Closes #1382