### PR TITLE
fix(indexer): a symlinked file no longer aborts the entire index run

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -245,7 +245,21 @@ class GraphWriter:
 
             file_path_obj = Path(file_path_str)
             repo_path_obj = Path(resolved_repo_str)
-            relative_path_to_file = file_path_obj.relative_to(repo_path_obj)
+            try:
+                relative_path_to_file = file_path_obj.relative_to(repo_path_obj)
+            except ValueError:
+                # _normalize_path calls .resolve(), which follows symlinks, so a
+                # symlink inside the repo pointing outside it lands here. This
+                # call used to be bare — unlike the guarded one 17 lines above
+                # and its sibling in add_minimal_file_node — and the ValueError
+                # unwound all the way out of the indexing run, so every file
+                # after this one was silently never indexed.
+                warning_logger(
+                    f"{file_path_str} resolves outside the repository "
+                    f"{resolved_repo_str} (symlink?); indexing it without a "
+                    "directory hierarchy."
+                )
+                relative_path_to_file = Path(file_path_obj.name)
             parent_path = resolved_repo_str
             parent_label = "Repository"
             for part in relative_path_to_file.parts[:-1]:

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from ...core.jobs import JobManager, JobStatus
-from ...utils.debug_log import debug_log, error_logger, info_logger
+from ...utils.debug_log import debug_log, error_logger, info_logger, warning_logger
 from .discovery import discover_files_to_index
 from .persistence.writer import GraphWriter
 from .pre_scan import pre_scan_for_imports
@@ -136,23 +136,40 @@ async def run_tree_sitter_index_async(
 
     # Parsing remains concurrent, but graph writes are ordered so shared nodes
     # such as imported modules receive deterministic canonical metadata.
+    # One unwritable file must not abort the run. There is no transaction here,
+    # so an exception escaping this loop left a partially written graph with no
+    # rollback and every remaining file silently unindexed.
+    write_failures: List[Dict[str, Any]] = []
     for file_data in sorted(all_file_data, key=lambda data: str(data.get("path") or "")):
         repo_path = Path(file_data.pop("_index_repo_path"))
-        if "error" not in file_data:
-            await asyncio.to_thread(
-                writer.add_file_to_graph,
-                file_data,
-                repo_name,
-                imports_map,
-                repo_path_str=resolved_repo_path_str,
-            )
-        elif not file_data.get("unsupported"):
-            await asyncio.to_thread(
-                add_minimal_file_node,
-                Path(file_data["path"]),
-                repo_path,
-                is_dependency,
-            )
+        try:
+            if "error" not in file_data:
+                await asyncio.to_thread(
+                    writer.add_file_to_graph,
+                    file_data,
+                    repo_name,
+                    imports_map,
+                    repo_path_str=resolved_repo_path_str,
+                )
+            elif not file_data.get("unsupported"):
+                await asyncio.to_thread(
+                    add_minimal_file_node,
+                    Path(file_data["path"]),
+                    repo_path,
+                    is_dependency,
+                )
+        except Exception as exc:  # noqa: BLE001 - keep indexing the other files
+            path = file_data.get("path")
+            write_failures.append({"path": path, "error": str(exc)})
+            error_logger(f"Failed to write {path} to the graph: {exc}")
+            file_data["error"] = str(exc)
+            file_data["parse_failed"] = True
+
+    if write_failures:
+        warning_logger(
+            f"{len(write_failures)} file(s) could not be written to the graph; "
+            "the rest of the repository was still indexed."
+        )
 
     all_file_data = [file_data for file_data in all_file_data if "error" not in file_data]
 

--- a/tests/unit/tools/test_index_resilience.py
+++ b/tests/unit/tools/test_index_resilience.py
@@ -1,0 +1,90 @@
+"""Regression tests: one bad file must not abort an entire index run."""
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.tools.indexing import pipeline
+from codegraphcontext.tools.indexing.persistence import writer as writer_mod
+
+
+def _relative_to_calls(source: str):
+    """Yield (lineno, guarded) for every `X.relative_to(Y)` call in *source*."""
+    tree = ast.parse(source)
+
+    guarded_lines = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try):
+            handles_value_error = any(
+                (isinstance(h.type, ast.Name) and h.type.id == "ValueError")
+                or (
+                    isinstance(h.type, ast.Tuple)
+                    and any(isinstance(e, ast.Name) and e.id == "ValueError" for e in h.type.elts)
+                )
+                or h.type is None
+                for h in node.handlers
+            )
+            if handles_value_error:
+                for child in ast.walk(node):
+                    guarded_lines.add(getattr(child, "lineno", None))
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "relative_to"
+        ):
+            yield node.lineno, node.lineno in guarded_lines
+
+
+def test_every_relative_to_in_the_writer_is_guarded():
+    """`_normalize_path` calls `.resolve()`, which follows symlinks, so any
+    symlink inside a repo pointing outside it makes `relative_to` raise.
+
+    One call was bare while the one 17 lines above it and its sibling in
+    `add_minimal_file_node` were both wrapped. The ValueError unwound out of
+    the whole indexing run: every file after the symlink was silently never
+    indexed, a partial File node was left outside the repo prefix (where
+    `delete_repository_from_graph` cannot reach it), and the CLI exited 0.
+    """
+    unguarded = [
+        line for line, guarded in _relative_to_calls(inspect.getsource(writer_mod))
+        if not guarded
+    ]
+    assert not unguarded, (
+        "unguarded Path.relative_to in writer.py at line(s) "
+        f"{unguarded} — a symlinked file will abort the whole index run"
+    )
+
+
+def test_pipeline_write_loop_catches_per_file_failures():
+    """Defence in depth: there is no transaction around the write loop, so an
+    exception escaping it leaves a partially written graph with no rollback."""
+    source = inspect.getsource(pipeline.run_tree_sitter_index_async)
+
+    assert "write_failures" in source, "per-file write failures must be collected"
+    # The add_file_to_graph / add_minimal_file_node dispatch must sit inside a try.
+    tree = ast.parse(source.lstrip())
+    protected = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try):
+            for child in ast.walk(node):
+                protected.add(getattr(child, "lineno", None))
+
+    calls = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and node.id in {"add_minimal_file_node"}
+    ]
+    assert calls, "expected the minimal-file-node call to be present"
+    assert all(line in protected for line in calls), (
+        "the per-file graph writes must be wrapped so one failure cannot "
+        "abort the remaining files"
+    )
+
+
+def test_relative_to_raises_for_a_path_outside_the_root():
+    """Documents the exact failure the guard exists for."""
+    with pytest.raises(ValueError):
+        Path("/tmp/outside/target.py").relative_to(Path("/tmp/repo"))


### PR DESCRIPTION
Fixes #1383. A single symlink pointing outside the repository silently destroyed the rest of the index run.

## Root cause

`_normalize_path` calls `.resolve()`, which follows symlinks. Any symlink inside the repo pointing outside it therefore makes `relative_to` raise:

```python
file_path_obj = Path(file_path_str)      # already .resolve()d — follows symlinks
repo_path_obj = Path(resolved_repo_str)
relative_path_to_file = file_path_obj.relative_to(repo_path_obj)   # ← unguarded
```

The same operation is wrapped in `try/except ValueError` **17 lines earlier**, and `add_minimal_file_node` guards it too. This one call was bare, and the exception unwound out of `run_tree_sitter_index_async` entirely.

## Reproduced

Repo with `normal.py`, `zzz_last.py`, and `sub/link.py -> ../../outside/target.py`:

```
$ cgc index .../symtest/repo
An error occurred during indexing: '.../symtest/outside/target.py'
  is not in the subpath of '.../symtest/repo'
EXIT=0
```

Damage, measured against the graph:

| | Before | After |
|---|---|---|
| Functions indexed | `normal_fn` only | `normal_fn`, `outside_fn`, `zzz_last_fn` |
| `zzz_last_fn` | **never indexed** — run aborted | indexed |
| Orphan `File` node | `.../outside/target.py`, **outside the repo prefix** | none |

The orphan is the nastier half: `delete_repository_from_graph` filters on `path STARTS WITH repo + "/"`, so a node left outside that prefix survives both `cgc delete` and `cgc delete --all` and has to be removed by hand.

## The fix

1. Guard the bare `relative_to` the same way its two siblings already are. The symlink target is indexed without a directory hierarchy and a warning is logged, rather than taking the run down.
2. **Defence in depth:** wrap the per-file graph writes in `pipeline.py`. There is no transaction around that loop, so any escaping exception leaves a partially written graph with no rollback and every remaining file unindexed. Failures are now collected, logged, and counted alongside parse failures.

After:

```
| Total scanned files   | 3 |
| Function nodes        | 6 |
EXIT=0
→ normal_fn, outside_fn, zzz_last_fn
```

## Tests

3 new tests; **2 fail against unpatched `main`**. The main one walks the AST of `writer.py` and fails if *any* `Path.relative_to` against the repo root is not inside a `ValueError` handler — guarding the class rather than the one instance, since the file already had two guarded calls and one that was missed.

Full unit suite: **735 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py`, flaky on `main` independently — see #1408).

## Note

The audit lists `EXIT=0` as part of this finding. That is the separate `cgc index` exit-code bug (#1385), fixed in #1415 — here the run legitimately succeeds.

Closes #1383