### PR TITLE
fix(viz): make visualization work without the unshipped viz/dist bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,10 @@ target/
 venv_indexing/
 scratch/
 scripts/.agents/
-scripts
+# NOTE: a bare `scripts` entry here used to ignore the whole directory, even
+# though seven scripts are tracked (they predate the rule) and line 21 of this
+# file points at scripts/sync_viz_dist.sh as the build step for viz/dist. The
+# rule made that script impossible to add without -f. Only .agents/ is ignored.
 .agents
 *.py[cod]
 .tox/

--- a/scripts/sync_viz_dist.sh
+++ b/scripts/sync_viz_dist.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Build the visualizer frontend and sync it into the Python package so the
+# wheel actually contains it.
+#
+# pyproject.toml already declares:
+#     [tool.setuptools.package-data]
+#     codegraphcontext = ["viz/dist/**/*"]
+# and MANIFEST.in already has:
+#     recursive-include src/codegraphcontext/viz/dist *
+#
+# ...but src/codegraphcontext/viz/dist is never produced, so every published
+# wheel shipped without it and `cgc visualize`, `-V/--visual` and the MCP
+# visualize_graph_query tool all failed. The CLI error message pointed users
+# at this script, which did not exist.
+#
+# Run this before `python -m build`, or from the release workflow.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONTEND_DIR="${REPO_ROOT}/website"
+BUILD_OUTPUT="${FRONTEND_DIR}/dist"
+TARGET_DIR="${REPO_ROOT}/src/codegraphcontext/viz/dist"
+
+if [[ ! -f "${FRONTEND_DIR}/package.json" ]]; then
+    echo "error: no frontend source at ${FRONTEND_DIR}" >&2
+    exit 1
+fi
+
+echo "==> Building visualizer frontend in ${FRONTEND_DIR}"
+cd "${FRONTEND_DIR}"
+if [[ -f package-lock.json ]]; then
+    npm ci
+else
+    npm install
+fi
+npm run build
+
+if [[ ! -f "${BUILD_OUTPUT}/index.html" ]]; then
+    echo "error: build produced no ${BUILD_OUTPUT}/index.html" >&2
+    exit 1
+fi
+
+echo "==> Syncing ${BUILD_OUTPUT} -> ${TARGET_DIR}"
+rm -rf "${TARGET_DIR}"
+mkdir -p "${TARGET_DIR}"
+cp -R "${BUILD_OUTPUT}/." "${TARGET_DIR}/"
+
+echo "==> Done. $(find "${TARGET_DIR}" -type f | wc -l) file(s) staged for packaging."
+echo "    Verify with: python -m build && unzip -l dist/*.whl | grep viz/dist"

--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -570,6 +570,119 @@ import uvicorn
 import urllib.parse
 from ..viz.server import run_server, set_db_manager
 
+_OFFLINE_VIZ_DEFAULT_QUERY = """
+MATCH (n)-[r]->(m)
+RETURN n, r, m
+LIMIT 300
+"""
+
+
+def _render_offline_visualization(
+    db_manager,
+    repo_path: Optional[str] = None,
+    cypher_query: Optional[str] = None,
+    output_path: Optional[str] = None,
+) -> None:
+    """Render the graph with the dependency-free single-file HTML renderer.
+
+    The React frontend in ``viz/dist`` is not shipped in the wheel, which made
+    every visualization entry point a hard failure on a plain ``pip install``.
+    ``utils/visualize_graph.py`` is a complete, zero-dependency renderer that
+    was sitting in the package with no callers — this wires it up so the
+    command degrades to a working (simpler) view instead of exiting 1.
+    """
+    from ..utils.visualize_graph import open_in_browser, build_graph_data
+
+    query = cypher_query or _OFFLINE_VIZ_DEFAULT_QUERY
+    nodes: Dict[Any, Dict[str, Any]] = {}
+    edges: List[Dict[str, Any]] = []
+
+    def _ident(value) -> Optional[str]:
+        return None if value is None else str(value)
+
+    # Neo4j/Falkor return driver objects carrying .labels / .type; Kùzu and
+    # Ladybug return plain dicts carrying _label plus _src/_dst. Check the
+    # driver attributes first — a driver object may also be dict-like.
+    def _is_relationship(value) -> bool:
+        if hasattr(value, "labels"):
+            return False
+        if hasattr(value, "type"):
+            return True
+        return isinstance(value, dict) and "_src" in value and "_dst" in value
+
+    def _is_node(value) -> bool:
+        if hasattr(value, "labels"):
+            return True
+        if hasattr(value, "type"):
+            return False
+        # Kùzu relationships also carry _label, so _src/_dst is what
+        # distinguishes them from nodes.
+        return isinstance(value, dict) and "_label" in value and "_src" not in value
+
+    def _node_payload(value) -> Dict[str, Any]:
+        if hasattr(value, "labels"):
+            props = dict(value)
+            labels = list(getattr(value, "labels", []) or [])
+            label = labels[0] if labels else "Node"
+            node_id = getattr(value, "element_id", None) or getattr(value, "id", None)
+        else:
+            props, label = dict(value), value.get("_label", "Node")
+            node_id = value.get("_id")
+        if node_id is None:
+            node_id = props.get("path") or props.get("name")
+        return {
+            "id": _ident(node_id),
+            "label": label,
+            "name": props.get("name") or props.get("path") or "",
+            "file_path": props.get("path", ""),
+            "line_number": props.get("line_number"),
+        }
+
+    def _edge_payload(value) -> Optional[Dict[str, Any]]:
+        start = getattr(value, "start_node", None)
+        end = getattr(value, "end_node", None)
+        if start is not None and end is not None:
+            return {
+                "source": _ident(getattr(start, "element_id", None) or getattr(start, "id", None)),
+                "target": _ident(getattr(end, "element_id", None) or getattr(end, "id", None)),
+                "type": getattr(value, "type", "RELATED"),
+            }
+        if isinstance(value, dict):
+            return {
+                "source": _ident(value.get("_src")),
+                "target": _ident(value.get("_dst")),
+                "type": value.get("_label", "RELATED"),
+            }
+        return None
+
+    with db_manager.get_driver().session() as session:
+        for record in session.run(query):
+            values = list(record.values()) if hasattr(record, "values") else list(record)
+            for value in values:
+                if _is_node(value):
+                    payload = _node_payload(value)
+                    if payload["id"] is not None:
+                        nodes[payload["id"]] = payload
+                elif _is_relationship(value):
+                    edge = _edge_payload(value)
+                    if edge and edge["source"] and edge["target"]:
+                        edges.append(edge)
+
+    if not nodes:
+        console.print(
+            "[yellow]No graph data returned — index a repository first "
+            "with 'cgc index <path>'.[/yellow]"
+        )
+        raise typer.Exit(code=1)
+
+    title = f"CGC Code Graph — {Path(repo_path).name}" if repo_path else "CGC Code Graph"
+    graph_data = build_graph_data(list(nodes.values()), edges)
+    path = open_in_browser(graph_data, title=title, output_path=output_path)
+    console.print(
+        f"[green]Rendered {len(nodes)} nodes and {len(edges)} edges to[/green] {path}"
+    )
+
+
 def visualize_helper(
     repo_path: Optional[str] = None,
     host: str = "127.0.0.1",
@@ -631,8 +744,15 @@ def visualize_helper(
                     "[dim]then sync[/dim] [cyan]website/dist[/cyan] [dim]→[/dim] "
                     "[cyan]src/codegraphcontext/viz/dist[/cyan][dim].[/dim]"
                 )
-                db_manager.close_driver()
-                raise SystemExit(1)
+                console.print(
+                    "\n[yellow]Falling back to the built-in offline renderer.[/yellow]"
+                )
+                try:
+                    return _render_offline_visualization(
+                        db_manager, repo_path=repo_path, cypher_query=cypher_query
+                    )
+                finally:
+                    db_manager.close_driver()
 
     index_html = static_dir / "index.html"
     if not index_html.is_file():

--- a/tests/unit/cli/test_offline_visualization.py
+++ b/tests/unit/cli/test_offline_visualization.py
@@ -1,0 +1,131 @@
+"""Regression tests for the offline visualization fallback."""
+import inspect
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.cli import cli_helpers
+
+
+class _Session:
+    def __init__(self, records):
+        self._records = records
+
+    def run(self, query, **params):
+        return iter(self._records)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _Record(list):
+    def values(self):
+        return list(self)
+
+
+def _db_manager(records):
+    manager = MagicMock()
+    manager.get_driver.return_value.session.return_value = _Session(records)
+    return manager
+
+
+# --- Kùzu / Ladybug shape: plain dicts with _id / _label / _src / _dst --------
+
+KUZU_RECORDS = [
+    _Record([
+        {"_id": "0:1", "_label": "File", "path": "/repo/a.py", "name": "a.py"},
+        {"_src": "0:1", "_dst": "0:2", "_label": "CONTAINS"},
+        {"_id": "0:2", "_label": "Function", "name": "alpha", "path": "/repo/a.py",
+         "line_number": 3},
+    ])
+]
+
+# --- Neo4j / Falkor shape: driver objects ------------------------------------
+
+class _Node(dict):
+    def __init__(self, element_id, labels, **props):
+        super().__init__(**props)
+        self.element_id = element_id
+        self.labels = labels
+
+
+class _Rel:
+    def __init__(self, rel_type, start, end):
+        self.type = rel_type
+        self.start_node = start
+        self.end_node = end
+
+
+_N1 = _Node("4:1", ["File"], path="/repo/a.py", name="a.py")
+_N2 = _Node("4:2", ["Function"], name="alpha", path="/repo/a.py", line_number=3)
+NEO4J_RECORDS = [_Record([_N1, _Rel("CONTAINS", _N1, _N2), _N2])]
+
+
+@pytest.mark.parametrize(
+    "records,label",
+    [(KUZU_RECORDS, "kuzu-style dicts"), (NEO4J_RECORDS, "neo4j-style objects")],
+)
+def test_offline_renderer_handles_both_driver_shapes(records, label, tmp_path, monkeypatch):
+    """Kùzu/Ladybug return plain dicts carrying `_label`/`_src`/`_dst`, while
+    Neo4j and FalkorDB return driver objects with `.labels`/`.type`. The
+    renderer must understand both or it silently produces an empty graph."""
+    monkeypatch.setattr("webbrowser.open", lambda *_a, **_k: True)
+    out = tmp_path / "graph.html"
+
+    cli_helpers._render_offline_visualization(
+        _db_manager(records), repo_path="/repo", output_path=str(out)
+    )
+
+    assert out.exists(), f"no HTML rendered for {label}"
+    html = out.read_text(encoding="utf-8")
+    assert "alpha" in html, f"node data missing for {label}"
+    assert "CONTAINS" in html, f"edge data missing for {label}"
+
+
+def test_offline_renderer_is_self_contained(tmp_path, monkeypatch):
+    """The point of the fallback is that it needs no bundled assets, so the
+    page must not reference any external resource."""
+    monkeypatch.setattr("webbrowser.open", lambda *_a, **_k: True)
+    out = tmp_path / "graph.html"
+
+    cli_helpers._render_offline_visualization(
+        _db_manager(KUZU_RECORDS), output_path=str(out)
+    )
+
+    html = out.read_text(encoding="utf-8")
+    assert "http://" not in html.replace("http://www.w3.org", "")
+    assert "https://" not in html.replace("https://www.w3.org", "")
+
+
+def test_offline_renderer_reports_an_empty_graph(monkeypatch, tmp_path):
+    monkeypatch.setattr("webbrowser.open", lambda *_a, **_k: True)
+
+    with pytest.raises(Exception):  # typer.Exit
+        cli_helpers._render_offline_visualization(
+            _db_manager([]), output_path=str(tmp_path / "x.html")
+        )
+
+
+def test_visualize_falls_back_instead_of_exiting():
+    """`cgc visualize` used to `raise SystemExit(1)` when viz/dist was absent —
+    which it always is, because the wheel never shipped it."""
+    source = inspect.getsource(cli_helpers.visualize_helper)
+    assert "_render_offline_visualization" in source, (
+        "missing assets must degrade to the offline renderer, not exit"
+    )
+
+
+def test_sync_viz_dist_script_exists_and_is_executable():
+    """The CLI error message told users to run ./scripts/sync_viz_dist.sh,
+    which did not exist."""
+    repo_root = Path(cli_helpers.__file__).resolve().parents[3]
+    script = repo_root / "scripts" / "sync_viz_dist.sh"
+
+    assert script.is_file(), f"{script} is referenced by the CLI but missing"
+    assert os.access(script, os.X_OK), f"{script} is not executable"
+    assert "viz/dist" in script.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #1386 — the last of the five criticals. Every visualization entry point was dead on a plain `pip install`.

## What is actually wrong

The packaging declarations are **already correct**:

```toml
# pyproject.toml
[tool.setuptools.package-data]
codegraphcontext = ["viz/dist/**/*"]
```
```
# MANIFEST.in
recursive-include src/codegraphcontext/viz/dist *
```

But `src/codegraphcontext/viz/` contains only `server.py` — **`dist/` is never produced**. Nothing in the repo or CI builds it, so there has never been anything for those declarations to package. And the error message points users at a script that doesn't exist:

```
$ cgc visualize
Visualization assets not found.
...
  ./scripts/sync_viz_dist.sh          ← does not exist
EXIT=1
```

That kills `cgc visualize`, `cgc v`, the `-V/--visual` flag advertised on a dozen subcommands, and the MCP `visualize_graph_query` tool.

## Fix 1 — wire up the renderer that was already there

`utils/visualize_graph.py` is a complete, dependency-free, single-file HTML force-directed renderer (`build_graph_data`, `render_html`, `open_in_browser`, `save_graph_html`) sitting in the package with **no callers anywhere**. It is now the fallback when `viz/dist` is missing:

```
$ cgc visualize --repo <path>
Falling back to the built-in offline renderer.
Rendered 10 nodes and 9 edges to /tmp/cgc_graph_feaudyzq.html
EXIT=0
```

Verified against the live backend, and the output is fully self-contained — no external `src=`/`href=` — so it works from a bare install with no assets and no network.

One subtlety worth flagging for review: the backends return **different record shapes**. Neo4j/FalkorDB give driver objects with `.labels`/`.type`; Kùzu and Ladybug give plain dicts with `_label` plus `_src`/`_dst`. Getting this wrong produces a silently *empty* graph rather than an error — I hit exactly that twice while building it, including because Kùzu relationships also carry `_label`, so `_src`/`_dst` is what distinguishes them from nodes. Both shapes are covered by parametrized tests.

## Fix 2 — add the missing build script

`scripts/sync_viz_dist.sh` builds `website/` (`vite build`) and syncs `website/dist` → `src/codegraphcontext/viz/dist`, so the packaging declarations that already exist have something to package. It should run before `python -m build` in the release workflow.

**I have not run it here** — that needs `npm ci` against the network, and I could not verify the frontend build in this environment. The script is syntax-checked and targets the real `"build": "vite build"` in `website/package.json`, but someone should run it once in CI before relying on it. With the fallback in place, `cgc visualize` works either way.

## Tests

6 new tests: both driver shapes render nodes *and* edges, the output is self-contained, an empty graph is reported rather than rendered blank, `visualize_helper` falls back instead of exiting, and `sync_viz_dist.sh` exists and is executable.

Full unit suite: **738 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py`, flaky on `main` independently — see #1408).

Closes #1386