### PR TITLE
docs(cli): correct command reference examples

### DIFF
--- a/docs/CLI_COMPLETE_REFERENCE.md
+++ b/docs/CLI_COMPLETE_REFERENCE.md
@@ -23,7 +23,7 @@
 
 | Command | Arguments | Description |
 |---------|-----------|-------------|
-| `cgc index` | `[path]` `--force` | Index a repository. Default: current directory. Use `--force` to re-index. *(Alias: `cgc i`)* |
+| `cgc index` | `[path]` `--force` `--summarize` | Index a repository. Default: current directory. Use `--force` to re-index and `--summarize` to display a summary afterward. *(Alias: `cgc i`)* |
 | `cgc list` | None | List all indexed repositories. *(Alias: `cgc ls`)* |
 | `cgc delete` | `[path]` `--all` | Delete a repository from the graph. Use `--all` to wipe everything. *(Alias: `cgc rm`)* |
 | `cgc stats` | `[path]` | Show indexing statistics for DB or specific repo. |
@@ -53,7 +53,7 @@
 | `cgc analyze tree` | `<class>` `--file` | Visualize class inheritance hierarchy. |
 | `cgc analyze complexity` | `[path]` `--threshold` `--limit` | List functions with high cyclomatic complexity. Default threshold: 10. |
 | `cgc analyze dead-code` | `--exclude` | Find potentially unused functions (0 callers). |
-| `cgc analyze overrides` | `<class>` `--file` | Show methods that override parent class methods. |
+| `cgc analyze overrides` | `<function>` | Show implementations of a function across classes. |
 | `cgc analyze variable` | `<var_name>` `--file` | Analyze variable usage and assignments. |
 
 ---
@@ -66,7 +66,7 @@
 | `cgc find pattern` | `<pattern>` `--case-sensitive` | Find elements using fuzzy substring matching. |
 | `cgc find type` | `<type>` `--limit` | List all nodes of a specific type (function, class, module). |
 | `cgc find variable` | `<name>` | Find variables by name across the codebase. |
-| `cgc find content` | `<text>` `--case-sensitive` | Search for text content within code (docstrings, comments). |
+| `cgc find content` | `<text>` | Search for text content within code (docstrings, comments). |
 | `cgc find decorator` | `<name>` | Find all functions/classes with a specific decorator. |
 | `cgc find argument` | `<name>` | Find all functions that have a specific argument name. |
 
@@ -113,7 +113,7 @@
 | Command | Arguments | Description |
 |---------|-----------|-------------|
 | `cgc doctor` | None | Run system diagnostics (DB, dependencies, permissions). |
-| `cgc visualize` | `[query]` | Generate link to Neo4j Browser. *(Alias: `cgc v`)* |
+| `cgc visualize` | `--repo` `--host` `--port` `--context` | Launch the local interactive graph UI server. *(Alias: `cgc v`)* |
 | `cgc query` | `<query>` | Execute raw Cypher query against DB. |
 | `cgc help` | None | Show main help message with all commands. |
 | `cgc version` | None | Show application version. |

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -27,7 +27,7 @@ Use `cgc version` (or `cgc --version`) to print the installed release (currently
 
 | Command | Usage | Notes |
 | :--- | :--- | :--- |
-| **`index`** | `cgc index [PATH] [--force] [--dependency]` | Shortcut: `cgc i`. Incremental by default; `--force` rebuilds from scratch. |
+| **`index`** | `cgc index [PATH] [--force] [--summarize]` | Shortcut: `cgc i`. Incremental by default; `--force` rebuilds from scratch; `--summarize` displays a summary after indexing. |
 | **`clean`** | `cgc clean` | Purges orphaned nodes and dangling relationships. |
 | **`stats`** | `cgc stats` | Repository and node counts for the active context. |
 | **`delete`** | `cgc delete <repo_path>` | Shortcut: `cgc rm`. Removes one indexed repository. |
@@ -69,7 +69,7 @@ cgc analyze <subcommand> [args] [options]
 | `analyze tree <class>` | Class inheritance tree. |
 | `analyze complexity <function>` | Cyclomatic complexity for one function. |
 | `analyze dead-code` | Unreferenced functions/files (with optional filters). |
-| `analyze overrides <class>` | Methods overridden in subclasses. |
+| `analyze overrides <function>` | Implementations of a function across classes. |
 | `analyze variable <name>` | Variable scope and modification sites. |
 | `analyze kotlin-call-audit` | Kotlin-specific call resolution audit. |
 
@@ -91,7 +91,7 @@ cgc query "MATCH (n)-[r]->(m) RETURN n,r,m LIMIT 50" --visual
 Generate `CGC_REPORT.md` with god-node, complexity, and coupling metrics.
 
 ```bash
-cgc report [--include-java]
+cgc report [--java]
 ```
 
 #### `visualize`


### PR DESCRIPTION
## Summary

Addresses #1402: docs: five reference examples use flags or arguments that do not exist

## Commits

- docs(cli): correct command reference examples

Fixes #1402.