### PR TITLE
fix: stop counting `<module>` as a function, declare HEURISTIC_CALLS on Kùzu

### DIFF
--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -237,6 +237,32 @@ class EmbeddedGraphManager(GraphQueryInterface):
                 line_number INT64, args STRING[], full_call_name STRING, args_key STRING, confidence DOUBLE, resolution_tier INT64, 
                 confidence_label STRING, source STRING, resolution_method STRING, called_name STRING
             """, True),
+            # Same bindings as CALLS. writer.py emits HEURISTIC_CALLS for
+            # resolution tier >= 8, but the table was never declared here, so on
+            # Kùzu those edges could not be written and every query matching
+            # [:CALLS|HEURISTIC_CALLS] failed outright with
+            # "Binder exception: Table HEURISTIC_CALLS does not exist" —
+            # which broke `cgc analyze dead-code` completely on this backend.
+            ("HEURISTIC_CALLS", """
+                FROM Function TO Function, FROM Function TO Class, FROM Function TO Interface, FROM Function TO Trait, 
+                FROM Function TO Struct, FROM Function TO Enum, FROM Function TO Record, FROM Function TO `Union`,
+                FROM Function TO Mixin, FROM Function TO Extension, FROM Function TO Object, FROM Function TO Parameter,
+                FROM Class TO Function, FROM Class TO Class, FROM Class TO Interface, FROM Class TO Trait, 
+                FROM Class TO Struct, FROM Class TO Enum, FROM Class TO Record, FROM Class TO `Union`,
+                FROM Interface TO Function, FROM Interface TO Class, FROM Interface TO Interface,
+                FROM Trait TO Function, FROM Trait TO Class, FROM Trait TO Interface,
+                FROM Mixin TO Function, FROM Mixin TO Class, FROM Mixin TO Interface,
+                FROM Extension TO Function, FROM Extension TO Class, FROM Extension TO Interface,
+                FROM Object TO Function, FROM Object TO Class, FROM Object TO Interface,
+                FROM `Union` TO Function, FROM `Union` TO Class, FROM `Union` TO Interface,
+                FROM `Macro` TO Function, FROM `Macro` TO Class, FROM `Macro` TO Interface,
+                FROM File TO Function, FROM File TO Class, FROM File TO Interface, FROM File TO Trait, 
+                FROM File TO Struct, FROM File TO Enum, FROM File TO Record, FROM File TO `Union`,
+                FROM Function TO File,
+                FROM Variable TO Function, FROM Variable TO Class, FROM Variable TO Interface,
+                line_number INT64, args STRING[], full_call_name STRING, args_key STRING, confidence DOUBLE, resolution_tier INT64, 
+                confidence_label STRING, source STRING, resolution_method STRING, called_name STRING
+            """, True),
             ("IMPORTS", "FROM File TO Module, alias STRING, full_import_name STRING, imported_name STRING, line_number INT64", False),
             ("INHERITS", """
                 FROM Class TO Class, FROM Class TO Trait, FROM Class TO Interface, FROM Class TO Struct, FROM Class TO Enum, FROM Class TO `Union`, FROM Class TO Record, FROM Class TO Mixin, FROM Class TO Extension, FROM Class TO Module, FROM Class TO Object, FROM Class TO ExternalClass,

--- a/src/codegraphcontext/core/watcher.py
+++ b/src/codegraphcontext/core/watcher.py
@@ -240,7 +240,15 @@ class RepositoryEventHandler(FileSystemEventHandler):
 
         self.graph_builder.update_file_in_graph(changed_path, self.repo_path, self.imports_map)
 
-        other_callers = list(caller_paths)
+        # Every file in affected_paths is re-parsed below and fed back into
+        # link_function_calls, so every one of them needs its outgoing CALLS
+        # cleared first. Clearing only caller_paths left the inheritance-only
+        # neighbours to have their edges re-created on top of the existing ones
+        # — and on Neo4j/Nornic the writer uses CREATE, not MERGE, so duplicate
+        # CALLS multiplied on every save. (FalkorDB and Kùzu use MERGE, which is
+        # why this never showed up there.) The changed file itself is excluded:
+        # update_file_in_graph above already deleted and rebuilt it.
+        other_callers = list(affected_paths - {changed_path_str})
         other_inheritors = list(inheritor_paths)
         if other_callers:
             self.graph_builder.delete_outgoing_calls_from_files(other_callers)

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -807,6 +807,7 @@ class CodeFinder:
                 MATCH (func:Function)
                 WHERE func.is_dependency = false {repo_filter} {func_ignore}
                   AND NOT func.name IN ['main', 'setup', 'run']
+                  AND func.name <> '<module>'
                   AND NOT (func.name STARTS WITH '__' AND func.name ENDS WITH '__')
                   AND NOT func.name STARTS WITH '_test'
                   AND NOT func.name STARTS WITH 'test_'

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -44,7 +44,15 @@ def build_index_summary(
         language = parsers.get(file.suffix, "generic")
         extension_counts[f"{extension} ({language})"] += 1
 
-    function_nodes = sum(len(file_data.get("functions", [])) for file_data in all_file_data)
+    # Exclude the synthetic `<module>` frame the Python parser adds per file —
+    # it is the attribution target for module-level calls, not a function the
+    # user wrote, and counting it inflated every reported total by one per file.
+    function_nodes = sum(
+        1
+        for file_data in all_file_data
+        for func in file_data.get("functions", [])
+        if not func.get("is_synthetic") and func.get("name") != "<module>"
+    )
     class_nodes = sum(len(file_data.get("classes", [])) for file_data in all_file_data)
     call_edges = sum(len(group) for group in resolved_call_groups)
 

--- a/src/codegraphcontext/tools/indexing/schema.py
+++ b/src/codegraphcontext/tools/indexing/schema.py
@@ -10,9 +10,17 @@ def create_graph_schema(driver: Any, db_manager: Any) -> None:
     """Create constraints and indexes. *driver* must support .session() context manager."""
     backend_type = getattr(db_manager, "get_backend_type", lambda: "neo4j")()
     # FalkorDB (both embedded and remote) has a confirmed null-pointer crash in
-    # EnforceUniqueEntity when composite UNIQUE constraints are used with MERGE.
-    # Skip all CREATE CONSTRAINT statements for FalkorDB backends; the indices
-    # created below are sufficient for MERGE to perform correct deduplication.
+    # EnforceUniqueEntity when composite UNIQUE constraints are used with MERGE,
+    # so all CREATE CONSTRAINT statements are skipped for FalkorDB backends.
+    #
+    # Be precise about what that costs: there are then NO uniqueness constraints
+    # on FalkorDB — `CALL db.constraints()` returns []. Indexes do not enforce
+    # uniqueness; they only make the MERGE lookup fast. Deduplication holds
+    # because MERGE deduplicates within an UNWIND and FalkorDB serialises writes
+    # per graph, not because the schema guarantees it. That assumption breaks
+    # with an external writer or a future FalkorDB executing writes
+    # concurrently. (The previous comment claimed the indexes were "sufficient
+    # for MERGE to perform correct deduplication", which overstates it.)
     is_falkordb = backend_type.startswith("falkordb")
 
     with driver.session() as session:

--- a/src/codegraphcontext/tools/languages/python.py
+++ b/src/codegraphcontext/tools/languages/python.py
@@ -206,6 +206,11 @@ class PythonTreeSitterParser:
                 "decorators": [],
                 "lang": self.language_name,
                 "is_dependency": False,
+                # Not a function anyone wrote — it is the module-level frame
+                # that top-level calls get attributed to. Marked so counts and
+                # the dead-code report can exclude it instead of presenting it
+                # as a real, unused function.
+                "is_synthetic": True,
             }
             if index_source:
                 module_func["source"] = self._get_node_text(root_node)

--- a/tests/unit/tools/test_module_nodes_and_incremental.py
+++ b/tests/unit/tools/test_module_nodes_and_incremental.py
@@ -1,0 +1,102 @@
+"""Regression tests for <module> pseudo-nodes, incremental CALLS and Kùzu schema."""
+import inspect
+from pathlib import Path
+
+from codegraphcontext.core import watcher as watcher_mod
+from codegraphcontext.tools import code_finder as code_finder_mod
+from codegraphcontext.tools.indexing import schema as schema_mod
+from codegraphcontext.tools.indexing.pipeline import build_index_summary
+
+
+def test_dead_code_excludes_the_module_pseudo_node():
+    """`<module>` is the synthetic frame module-level calls are attributed to,
+    not a function anyone wrote. It was the *first row* of `cgc analyze
+    dead-code`, i.e. the report's headline entry was an artifact."""
+    source = inspect.getsource(code_finder_mod.CodeFinder.find_dead_code)
+    assert "func.name <> '<module>'" in source
+
+
+def test_index_summary_excludes_synthetic_module_frames():
+    """One `<module>` node is created per Python file, so every reported
+    function total was inflated by one per file."""
+    all_file_data = [
+        {
+            "path": "/repo/a.py",
+            "functions": [
+                {"name": "real_one"},
+                {"name": "<module>", "is_synthetic": True},
+            ],
+        },
+        {
+            "path": "/repo/b.py",
+            "functions": [{"name": "<module>", "is_synthetic": True}],
+        },
+    ]
+
+    summary = build_index_summary(
+        files=[Path("/repo/a.py"), Path("/repo/b.py")],
+        parsers={".py": "python"},
+        all_file_data=all_file_data,
+        resolved_call_groups=(),
+        serialization_seconds=0.0,
+    )
+
+    assert summary["function_nodes"] == 1
+
+
+def test_index_summary_excludes_module_frames_without_the_marker():
+    """Graphs indexed before `is_synthetic` existed must still be counted
+    correctly, so the name check is a fallback."""
+    all_file_data = [
+        {"path": "/repo/a.py", "functions": [{"name": "real"}, {"name": "<module>"}]}
+    ]
+
+    summary = build_index_summary(
+        files=[Path("/repo/a.py")],
+        parsers={".py": "python"},
+        all_file_data=all_file_data,
+        resolved_call_groups=(),
+        serialization_seconds=0.0,
+    )
+
+    assert summary["function_nodes"] == 1
+
+
+def test_python_parser_marks_the_module_frame_as_synthetic():
+    from codegraphcontext.tools.languages import python as python_lang
+
+    source = inspect.getsource(python_lang)
+    assert '"is_synthetic": True' in source
+
+
+def test_incremental_update_clears_calls_for_every_reparsed_file():
+    """All of affected_paths get re-parsed and fed back to link_function_calls,
+    but only caller_paths had their outgoing CALLS cleared. On Neo4j/Nornic the
+    writer uses CREATE, not MERGE, so the inheritance-only neighbours
+    accumulated duplicate CALLS on every save."""
+    source = inspect.getsource(watcher_mod)
+    assert "affected_paths - {changed_path_str}" in source, (
+        "outgoing CALLS must be cleared for every re-parsed file, not just callers"
+    )
+
+
+def test_kuzu_declares_the_heuristic_calls_table():
+    """writer.py emits HEURISTIC_CALLS for resolution tier >= 8, but the table
+    was never declared in the Kùzu schema — so those edges could not be written
+    and any query matching [:CALLS|HEURISTIC_CALLS] failed with
+    'Binder exception: Table HEURISTIC_CALLS does not exist'. That broke
+    `cgc analyze dead-code` completely on KùzuDB, which is the Windows default
+    and the universal fallback backend."""
+    from codegraphcontext.core import database_embedded_kuzu as kuzu_mod
+
+    source = inspect.getsource(kuzu_mod)
+    assert '("HEURISTIC_CALLS", """' in source
+
+
+def test_schema_comment_does_not_claim_indexes_enforce_uniqueness():
+    """Indexes do not enforce uniqueness; `CALL db.constraints()` returns [] on
+    FalkorDB. The old comment claimed the indexes were 'sufficient for MERGE to
+    perform correct deduplication'."""
+    source = inspect.getsource(schema_mod)
+    assert "sufficient for MERGE to perform correct deduplication" not in source
+    assert "NO uniqueness constraints" in source


### PR DESCRIPTION
Four fixes from the 0.5.2 audit — plus one bug found while verifying them that is **not** in the report and is arguably the most serious item here.

### 1. `<module>` was counted and reported as a real function (`U-M1`)

The Python parser adds a synthetic `<module>` frame per file as the attribution target for module-level calls. It was treated as an ordinary `Function`:

```
$ cgc analyze dead-code
⚠️  Potentially Unused Functions:
│ <module>  │ /home/…/cgc_entry.py:1  │     ← first row
```

On CGC's own repo, **264 of 5,501** `Function` nodes were these frames, so every function total a user saw was inflated by one per Python file. It is now marked `is_synthetic`, excluded from the index summary and excluded from the dead-code query.

```
before: 2 files -> Function nodes 3      (only_one + two <module> frames)
after:  2 files -> Function nodes 1
```

The name-based check is kept as a fallback so graphs indexed before the marker existed still count correctly without a re-index.

### 2. Incremental update duplicated CALLS on Neo4j (`I-M12`)

`affected_paths` = changed ∪ callers ∪ inheritors, and **all** of them are re-parsed and fed back through `link_function_calls` — but only `caller_paths` had their outgoing CALLS cleared:

```python
other_callers = list(caller_paths)          # ← missing the inheritance-only neighbours
```

On Neo4j/Nornic the writer uses `CREATE`, not `MERGE`, so those neighbours got their edges re-created on top of the existing ones and duplicates multiplied on every save. FalkorDB and Kùzu use `MERGE`, which is why this never surfaced locally.

### 3. 🔴 `cgc analyze dead-code` is completely broken on KùzuDB — not in the audit

Found while verifying #1. `writer.py:715` emits `HEURISTIC_CALLS` for resolution tier ≥ 8, but the rel table **was never declared in the Kùzu schema**. Reproduced on pristine `upstream/main`:

```
$ cgc analyze dead-code
RuntimeError: Binder exception: Table HEURISTIC_CALLS does not exist.
```

Two consequences: tier-8+ edges cannot be written on Kùzu at all, and *every* query matching `[:CALLS|HEURISTIC_CALLS]` fails outright — which includes `find_dead_code` and the inheritance re-resolution pass. KùzuDB is the **default on Windows** and the fallback backend everywhere else.

Declared with the same bindings as `CALLS`. After:

```
$ cgc analyze dead-code
│ only_one │ …/modtest/m.py:1 │
Total: 1 function(s)
EXIT=0
```

### 4. A comment that overstated FalkorDB's guarantees (`G-M11`)

```python
# Skip all CREATE CONSTRAINT statements for FalkorDB backends; the indices
# created below are sufficient for MERGE to perform correct deduplication.
```

Indexes do not enforce uniqueness — `CALL db.constraints()` returns `[]`. Deduplication holds because `MERGE` dedupes within an `UNWIND` and FalkorDB serialises writes per graph. That is an assumption worth stating plainly (it breaks with an external writer or concurrent write execution), not a guarantee the schema provides. No behaviour change; the audit was explicit that no duplicates could actually be produced today.

### Tests

7 new tests, **all 7 fail against unpatched `main`**.

Full unit suite: **739 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py`, flaky on `main` independently — see #1408).