### PR TITLE
fix: classify Cypher DDL by leading keyword; disambiguate nested-function containment

### DIFF
--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Optional, Tuple, Dict, Any, List, ClassVar
 
 from codegraphcontext.core.graph_query import GraphQueryInterface
+from ..utils.cypher_ddl import is_schema_ddl
 from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logger, warning_logger
 
 
@@ -1065,7 +1066,10 @@ class EmbeddedSessionWrapper:
         query = re.sub(r'\bON\s+CREATE\s+SET\b', 'SET', query, flags=re.IGNORECASE)
         query = re.sub(r'\bON\s+MATCH\s+SET\b', 'SET', query, flags=re.IGNORECASE)
 
-        if any(x in query.upper() for x in ["CREATE CONSTRAINT", "CREATE INDEX"]):
+        # Anchored to the leading keyword: a substring test also matched
+        # these words inside a string literal, silently turning ordinary
+        # data queries into "RETURN 1".
+        if is_schema_ddl(query):
             return "RETURN 1", {}
 
         # 5. Cleanup unused parameters (Kuzu is strict)

--- a/src/codegraphcontext/core/database_falkordb.py
+++ b/src/codegraphcontext/core/database_falkordb.py
@@ -20,6 +20,7 @@ import re
 from pathlib import Path
 from typing import Optional, Tuple
 
+from codegraphcontext.utils.cypher_ddl import ddl_kind, is_schema_ddl
 from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logger, warning_logger
 
 # ---------------------------------------------------------------------------
@@ -626,18 +627,24 @@ class FalkorDBSessionWrapper:
 
     def _translate_schema_query(self, query: str) -> str:
         """Translate Neo4j schema queries to FalkorDB/RedisGraph syntax."""
-        q_upper = query.upper()
-        
-        # Handle Fulltext Indexes (Not supported in same syntax, skip for now)
-        if "CREATE FULLTEXT INDEX" in q_upper:
+        # Classify on the statement's leading keyword, not by searching the
+        # whole text: a substring test also matches these words inside a string
+        # literal, which silently replaced ordinary data queries with
+        # "RETURN 1" — a fabricated result of the wrong shape, with no error.
+        kind = ddl_kind(query)
+        if kind is None:
+            return query
+
+        # Fulltext indexes: not supported in the same syntax, skip for now.
+        if kind == "fulltext":
             return "RETURN 1"
-            
-        # Handle Constraints through GRAPH.CONSTRAINT in run()
-        if "CREATE CONSTRAINT" in q_upper:
+
+        # Constraints go through GRAPH.CONSTRAINT in run().
+        if kind == "constraint":
             return "RETURN 1"
-            
-        # Handle Regular Indexes
-        elif "CREATE INDEX" in q_upper:
+
+        # Handle regular indexes
+        if kind == "index":
             # Remove "IF NOT EXISTS"
             query = re.sub(r'\s+IF NOT EXISTS', '', query, flags=re.IGNORECASE)
             # Remove Index Name: CREATE INDEX name FOR -> CREATE INDEX FOR

--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -338,14 +338,25 @@ class GraphWriter:
                             )
                         if item.get("context_type") == "function_definition":
                             outer_ctx = item.get("context")
-                            outer_name = (
-                                outer_ctx[0]
-                                if isinstance(outer_ctx, (tuple, list)) and outer_ctx
-                                else outer_ctx
-                            )
+                            is_seq = isinstance(outer_ctx, (tuple, list)) and outer_ctx
+                            outer_name = outer_ctx[0] if is_seq else outer_ctx
+                            # The parser already reports the enclosing function's
+                            # line (_get_parent_context returns name, type, line)
+                            # but it was discarded, so the MATCH below keyed on
+                            # name alone. Any file with two same-named functions
+                            # — i.e. the same method name on two classes, which
+                            # is extremely common — got a false CONTAINS edge.
+                            if is_seq and len(outer_ctx) > 2 and isinstance(outer_ctx[2], int):
+                                outer_line = outer_ctx[2]
+                            else:
+                                # Parsers that flatten `context` to a bare name
+                                # report the line separately.
+                                raw_line = item.get("context_line", -1)
+                                outer_line = raw_line if isinstance(raw_line, int) else -1
                             nested_fn_batch.append(
                                 {
                                     "outer": outer_name,
+                                    "outer_line": outer_line,
                                     "inner_name": item["name"],
                                     "inner_line": item["line_number"],
                                 }
@@ -493,6 +504,7 @@ class GraphWriter:
                     """
                     UNWIND $batch AS row
                     MATCH (outer:Function {name: row.outer, path: $file_path})
+                    WHERE row.outer_line < 0 OR outer.line_number = row.outer_line
                     MATCH (inner:Function {name: row.inner_name, path: $file_path, line_number: row.inner_line})
                     MERGE (outer)-[:CONTAINS]->(inner)
                 """,

--- a/src/codegraphcontext/tools/languages/python.py
+++ b/src/codegraphcontext/tools/languages/python.py
@@ -274,8 +274,15 @@ class PythonTreeSitterParser:
                     decorators = [self._get_node_text(child) for child in func_node.children if child.type == 'decorator']
 
 
-                context, context_type, _ = self._get_parent_context(func_node)
-                class_context, _, _ = self._get_parent_context(func_node, types=('class_definition',))
+                # Keep the enclosing definition's line. It was discarded here,
+                # which left the nested-function CONTAINS write matching the
+                # outer function by name alone — so a file with two same-named
+                # functions (the same method on two classes, very common) got a
+                # false containment edge from each of them.
+                context, context_type, context_line = self._get_parent_context(func_node)
+                class_context, _, class_context_line = self._get_parent_context(
+                    func_node, types=('class_definition',)
+                )
 
                 args = []
                 if params_node:
@@ -314,7 +321,13 @@ class PythonTreeSitterParser:
                     "cyclomatic_complexity": self._calculate_complexity(func_node),
                     "context": context,
                     "context_type": context_type,
+                    # Disambiguates the enclosing definition when a file has two
+                    # functions/classes with the same name.
+                    "context_line": context_line if context_line is not None else -1,
                     "class_context": class_context,
+                    "class_context_line": (
+                        class_context_line if class_context_line is not None else -1
+                    ),
                     "decorators": [d for d in decorators if d],
                     "lang": self.language_name,
                     "is_dependency": False,

--- a/src/codegraphcontext/utils/cypher_ddl.py
+++ b/src/codegraphcontext/utils/cypher_ddl.py
@@ -1,0 +1,80 @@
+"""Classify Cypher statements as schema DDL.
+
+Both backend wrappers used to decide "is this a CREATE INDEX / CREATE
+CONSTRAINT?" with a substring search over the whole query text, e.g.::
+
+    if "CREATE FULLTEXT INDEX" in query.upper():
+        return "RETURN 1"
+
+That also matches those words inside a *string literal*, so an ordinary read
+query was silently replaced by ``RETURN 1`` — returning a fabricated value with
+the wrong shape and no error::
+
+    cgc query 'MATCH (f:Function) WHERE f.source CONTAINS "CREATE INDEX"
+               RETURN count(f) AS c'
+    -> [ { "1": 1 } ]        instead of  [ { "c": 5 } ]
+
+`execute_cypher_query` is the designated expert fallback for LLM agents, so an
+agent investigating CGC's own schema code hits this directly.
+
+Detection here is anchored to the leading keyword of the statement, after
+comments and string literals have been removed.
+"""
+from __future__ import annotations
+
+import re
+
+__all__ = ["strip_cypher_literals", "is_schema_ddl", "ddl_kind"]
+
+# Single-quoted, double-quoted and backtick-quoted spans, honouring backslash
+# escapes; plus // line comments and /* */ block comments.
+_LITERAL_OR_COMMENT_RE = re.compile(
+    r"""
+      '(?:\\.|[^'\\])*'      # '...'
+    | "(?:\\.|[^"\\])*"      # "..."
+    | `(?:\\.|[^`\\])*`      # `...`
+    | //[^\n]*               # // line comment
+    | /\*.*?\*/              # /* block comment */
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+_DDL_RE = re.compile(
+    r"""\A\s*
+    (?P<verb>CREATE|DROP)\s+
+    (?:(?P<qualifier>BTREE|RANGE|TEXT|POINT|VECTOR|FULLTEXT|LOOKUP)\s+)?
+    (?P<object>INDEX|CONSTRAINT)\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+#: FalkorDB's procedural index API, which is DDL despite being a CALL.
+_PROC_DDL_RE = re.compile(r"\A\s*CALL\s+db\.idx\.", re.IGNORECASE)
+
+
+def strip_cypher_literals(query: str) -> str:
+    """Blank out string literals and comments, preserving overall length."""
+    return _LITERAL_OR_COMMENT_RE.sub(lambda m: " " * len(m.group(0)), query)
+
+
+def is_schema_ddl(query: str) -> bool:
+    """True when *query* is a schema statement rather than a data query."""
+    if not isinstance(query, str):
+        return False
+    stripped = strip_cypher_literals(query)
+    return bool(_DDL_RE.match(stripped) or _PROC_DDL_RE.match(stripped))
+
+
+def ddl_kind(query: str) -> str | None:
+    """Return ``'index'``, ``'constraint'``, ``'fulltext'`` or ``None``."""
+    if not isinstance(query, str):
+        return None
+    stripped = strip_cypher_literals(query)
+    if _PROC_DDL_RE.match(stripped):
+        return "fulltext"
+    match = _DDL_RE.match(stripped)
+    if not match:
+        return None
+    if (match.group("qualifier") or "").upper() == "FULLTEXT":
+        return "fulltext"
+    return match.group("object").lower()

--- a/tests/unit/core/test_cypher_ddl_classification.py
+++ b/tests/unit/core/test_cypher_ddl_classification.py
@@ -1,0 +1,92 @@
+"""Regression tests for DDL classification and nested-function containment."""
+import inspect
+
+import pytest
+
+from codegraphcontext.utils.cypher_ddl import ddl_kind, is_schema_ddl, strip_cypher_literals
+
+REAL_DDL = [
+    ("CREATE INDEX IF NOT EXISTS FOR (f:Function) ON (f.name)", "index"),
+    ("CREATE INDEX function_lang IF NOT EXISTS FOR (f:Function) ON (f.lang)", "index"),
+    ("  create index for (c:Class) on (c.name)", "index"),
+    ("DROP INDEX foo", "index"),
+    ("CREATE CONSTRAINT c1 IF NOT EXISTS FOR (f:File) REQUIRE f.path IS UNIQUE", "constraint"),
+    ("CREATE FULLTEXT INDEX code_search FOR (n:Function) ON EACH [n.name]", "fulltext"),
+    ("CALL db.idx.fulltext.createNodeIndex('Function', 'name', 'source')", "fulltext"),
+]
+
+# Data queries that merely *mention* the DDL keywords.
+NOT_DDL = [
+    'MATCH (f:Function) WHERE f.source CONTAINS "CREATE INDEX" RETURN count(f) AS c',
+    'MATCH (f:Function) WHERE f.source CONTAINS "CREATE FULLTEXT INDEX" RETURN count(f) AS c',
+    "MATCH (f) WHERE f.name = 'CREATE CONSTRAINT' RETURN f",
+    "MATCH (f) WHERE f.doc = 'DROP INDEX' RETURN f",
+    "// CREATE INDEX in a comment\nMATCH (n) RETURN n",
+    "/* CREATE CONSTRAINT */ MATCH (n) RETURN n",
+    "MATCH (n) RETURN n",
+    "MERGE (n:Function {name: 'CREATE INDEX'}) RETURN n",
+    "MATCH (n:`CREATE INDEX`) RETURN n",
+]
+
+
+@pytest.mark.parametrize("query,kind", REAL_DDL)
+def test_real_ddl_is_classified(query, kind):
+    assert is_schema_ddl(query) is True
+    assert ddl_kind(query) == kind
+
+
+@pytest.mark.parametrize("query", NOT_DDL)
+def test_data_queries_are_not_ddl(query):
+    """A substring search over the whole query text also matched these words
+    inside string literals, so an ordinary read query was silently replaced
+    with `RETURN 1` — a fabricated value of the wrong shape, with no error:
+
+        cgc query 'MATCH (f:Function) WHERE f.source CONTAINS "CREATE INDEX"
+                   RETURN count(f) AS c'
+        -> [ { "1": 1 } ]      instead of  [ { "c": 5 } ]
+
+    `execute_cypher_query` is the designated expert fallback for agents, so an
+    agent inspecting CGC's own schema code hits this directly.
+    """
+    assert is_schema_ddl(query) is False
+    assert ddl_kind(query) is None
+
+
+def test_strip_cypher_literals_preserves_length():
+    query = "MATCH (n) WHERE n.x = 'abc' RETURN n"
+    assert len(strip_cypher_literals(query)) == len(query)
+    assert "abc" not in strip_cypher_literals(query)
+
+
+def test_both_backends_use_the_anchored_classifier():
+    from codegraphcontext.core import database_embedded_kuzu, database_falkordb
+
+    kuzu_src = inspect.getsource(database_embedded_kuzu)
+    falkor_src = inspect.getsource(database_falkordb)
+
+    assert 'any(x in query.upper() for x in ["CREATE CONSTRAINT", "CREATE INDEX"])' not in kuzu_src
+    assert "is_schema_ddl(query)" in kuzu_src
+    assert 'if "CREATE FULLTEXT INDEX" in q_upper' not in falkor_src
+    assert "ddl_kind(query)" in falkor_src
+
+
+def test_nested_containment_carries_the_outer_line():
+    """The nested-function CONTAINS write matched the outer function by name
+    and path only. The parser already knew the enclosing definition's line
+    (`_get_parent_context` returns name, type, line) but discarded it, so a
+    file with two same-named functions — the same method on two classes, which
+    is extremely common — got a false containment edge from each."""
+    from codegraphcontext.tools.indexing.persistence import writer as writer_mod
+
+    source = inspect.getsource(writer_mod)
+    assert '"outer_line": outer_line' in source
+    assert "row.outer_line < 0 OR outer.line_number = row.outer_line" in source
+
+
+def test_python_parser_reports_the_enclosing_definition_line():
+    from codegraphcontext.tools.languages import python as python_lang
+
+    source = inspect.getsource(python_lang)
+    assert "context, context_type, context_line = self._get_parent_context" in source
+    assert '"context_line"' in source
+    assert '"class_context_line"' in source


### PR DESCRIPTION
Two independent correctness bugs from the 0.5.2 audit. Both silently return wrong answers rather than failing.

## 1. Data queries were rewritten into `RETURN 1` (`G-M07`)

Query classification was a substring search over the whole query text:

```python
q_upper = query.upper()
if "CREATE FULLTEXT INDEX" in q_upper:
    return "RETURN 1"
if "CREATE CONSTRAINT" in q_upper:
    return "RETURN 1"
```

That also matches those words inside a **string literal**. Reproduced on `main`:

```
$ cgc query 'MATCH (f:Function) WHERE f.source CONTAINS "CREATE INDEX" RETURN count(f) AS c'
[ { "1": 1 } ]        ← query replaced: wrong shape, fabricated value, no error

$ cgc query 'MATCH (f:Function) WHERE f.source CONTAINS "CREATE FULLTEXT INDEX" RETURN count(f) AS c'
[ { "c": 0 } ]        ← after the fix, correct shape on both
```

`execute_cypher_query` is the designated **"Expert Fallback"** in `prompts.py`, so an agent investigating CGC's own schema-management code walks straight into this.

Both backends had the pattern — FalkorDB's `_translate_schema_query` and Kùzu's `_rewrite_kuzu_compat_patterns` — so detection moves into a shared `utils/cypher_ddl.py` that blanks string literals and comments, then anchors on the statement's leading keyword. Real DDL (`CREATE INDEX`, `DROP INDEX`, `CREATE CONSTRAINT`, `CREATE FULLTEXT INDEX`, `CALL db.idx.*`) still classifies correctly, including lowercase and leading whitespace.

## 2. Nested-function containment was matched by name only (`I-M10`)

```cypher
MATCH (outer:Function {name: row.outer, path: $file_path})   -- no line_number
MATCH (inner:Function {name: row.inner_name, path: $file_path, line_number: row.inner_line})
MERGE (outer)-[:CONTAINS]->(inner)
```

Any file with two same-named functions — the same method name on two classes — got a false containment edge from **each** of them. Reproduced:

```python
class Alpha:
    def run(self):                 # line 2
        def inner_helper(): ...    # line 3
class Beta:
    def run(self): ...             # line 8
```

```
before:  inner_helper  CONTAINED BY  run@2  AND  run@8      ← run@8 is false
after:   inner_helper  CONTAINED BY  run@2
```

**The audit's suggested fix did not work as written**, and finding out why took the interesting turn here. It proposes carrying `outer_ctx[2]` from the writer's `context` tuple — but by the time the writer sees it, `context` is a plain **string** (`'run'`), not a 3-tuple. The line is discarded much earlier, in the parser:

```python
context, context_type, _ = self._get_parent_context(func_node)   # line thrown away
```

So the fix has to start there. `context_line` is now carried through to the writer and used to disambiguate. I also populated `class_context_line`, which the sibling `class_fn_batch` query already reads but which the Python parser never set — the audit notes that query's disambiguation was dead for exactly that reason.

Parsers that do not report a line pass `-1`, which preserves the old name-only behaviour rather than dropping the edge.

## Tests

20 new tests: 7 real DDL statements classified correctly, 9 data queries that merely mention the keywords (in literals, comments, backtick-quoted labels) correctly *not* classified, literal-stripping preserves length, both backends use the anchored classifier, and both halves of the nested-containment fix are wired.

- Full unit suite: **752 passed, 7 skipped, 0 failed**
- **All 20 parser golden tests pass**, so the added parser fields do not change existing extraction. (Worth noting: the Kotlin golden that currently fails in CI passes locally — consistent with a tree-sitter version drift in CI rather than a code problem.)

Excludes `test_cgcignore_patterns.py` from the unit run — flaky on `main` independently, see #1422.