### PR TITLE
fix(watcher): handle both endpoints of a rename; serialise concurrent updates

### DIFF
--- a/src/codegraphcontext/core/watcher.py
+++ b/src/codegraphcontext/core/watcher.py
@@ -49,6 +49,10 @@ class RepositoryEventHandler(FileSystemEventHandler):
         self.repo_path = repo_path.resolve()
         self.debounce_interval = debounce_interval
         self.timers = {}
+        # Guards self.timers, and serialises the graph updates that the
+        # per-path debounce timers would otherwise run concurrently.
+        self._timers_lock = threading.Lock()
+        self._update_lock = threading.RLock()
 
         self.ignore_root = self.repo_path
         self.ignore_spec = ignore_spec
@@ -180,16 +184,33 @@ class RepositoryEventHandler(FileSystemEventHandler):
         info_logger("Sync complete")
 
     def _debounce(self, event_path, action):
-        if event_path in self.timers:
-            self.timers[event_path].cancel()
-        t = threading.Timer(self.debounce_interval, action)
-        t.start()
-        self.timers[event_path] = t
+        # Timers are keyed per path, so N files changed inside the debounce
+        # window fire N handler threads concurrently. Those handlers do
+        # read-modify-write on the shared imports_map and interleave
+        # delete/add/delete_outgoing_calls for overlapping caller sets, so one
+        # can delete edges another just created. A branch switch or `git pull`
+        # is the normal trigger. _handle_modification now takes _update_lock.
+        def _run():
+            # Drop the fired timer: entries were never removed, so self.timers
+            # grew without bound for the life of the watcher.
+            with self._timers_lock:
+                if self.timers.get(event_path) is timer:
+                    del self.timers[event_path]
+            action()
+
+        with self._timers_lock:
+            existing = self.timers.get(event_path)
+            if existing is not None:
+                existing.cancel()
+            timer = threading.Timer(self.debounce_interval, _run)
+            self.timers[event_path] = timer
+        timer.start()
 
     def cancel_timers(self):
-        for t in self.timers.values():
-            t.cancel()
-        self.timers.clear()
+        with self._timers_lock:
+            for t in self.timers.values():
+                t.cancel()
+            self.timers.clear()
 
     def _update_imports_map_for_file(self, changed_path: Path):
         """Re-scan a single file and merge its contributions into self.imports_map."""
@@ -211,6 +232,15 @@ class RepositoryEventHandler(FileSystemEventHandler):
 
     def _handle_modification(self, event_path_str: str):
         """Incremental update: re-parse and re-link only the changed file and its neighbours."""
+        # Serialised: concurrent handlers previously did read-modify-write on
+        # the shared imports_map (lost updates) and interleaved
+        # delete_file_from_graph / add_file_to_graph /
+        # delete_outgoing_calls_from_files for overlapping caller sets, so one
+        # could delete edges another had just created.
+        with self._update_lock:
+            self._handle_modification_locked(event_path_str)
+
+    def _handle_modification_locked(self, event_path_str: str):
         info_logger(f"File change detected (incremental update): {event_path_str}")
         changed_path = Path(event_path_str)
         if self._should_ignore(changed_path):
@@ -314,8 +344,26 @@ class RepositoryEventHandler(FileSystemEventHandler):
             self._debounce(event.src_path, lambda: self._handle_modification(event.src_path))
 
     def on_moved(self, event):
-        if not event.is_directory:
-            self._debounce(event.dest_path, lambda: self._handle_modification(event.dest_path))
+        if event.is_directory:
+            return
+        # Both endpoints matter. Only dest_path was handled, so the node for
+        # the *old* path and all of its symbols stayed in the graph forever:
+        # every rename duplicated every symbol in the file, and a normal
+        # refactoring session or a `git checkout` between branches accumulated
+        # them indefinitely until find_callers started returning dead paths.
+        src_path = getattr(event, "src_path", None)
+        if src_path:
+            self._debounce(src_path, lambda: self._handle_removal(src_path))
+        self._debounce(event.dest_path, lambda: self._handle_modification(event.dest_path))
+
+    def _handle_removal(self, path_str):
+        """Drop a path that no longer exists (the source side of a rename)."""
+        with self._update_lock:
+            try:
+                self.graph_builder.delete_file_from_graph(str(Path(path_str).resolve()))
+                info_logger(f"[WATCH] removed stale node for moved file: {path_str}")
+            except Exception as exc:  # noqa: BLE001 - a watcher must not die on one file
+                error_logger(f"[WATCH] failed to remove {path_str}: {exc}")
 
 
 class CodeWatcher:

--- a/tests/unit/core/test_watcher_rename_and_concurrency.py
+++ b/tests/unit/core/test_watcher_rename_and_concurrency.py
@@ -1,0 +1,135 @@
+"""Regression tests for watcher rename handling and concurrent updates."""
+import inspect
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from codegraphcontext.core import watcher as watcher_mod
+from codegraphcontext.core.watcher import RepositoryEventHandler
+
+
+def _handler(tmp_path):
+    handler = RepositoryEventHandler.__new__(RepositoryEventHandler)
+    handler.graph_builder = MagicMock()
+    handler.repo_path = Path(tmp_path)
+    handler.debounce_interval = 0.01
+    handler.timers = {}
+    handler._timers_lock = threading.Lock()
+    handler._update_lock = threading.RLock()
+    handler.imports_map = {}
+    handler.all_file_data = []
+    handler.ignore_spec = None
+    handler.ignore_root = Path(tmp_path)
+    return handler
+
+
+def test_on_moved_handles_both_endpoints(tmp_path):
+    """Only dest_path was processed, so the node for the *old* path and all of
+    its symbols stayed in the graph forever. Every rename duplicated every
+    symbol in the file; a refactoring session or a `git checkout` between
+    branches accumulated them indefinitely."""
+    handler = _handler(tmp_path)
+    seen = []
+    handler._debounce = lambda path, action: seen.append(path)
+
+    handler.on_moved(SimpleNamespace(
+        is_directory=False,
+        src_path=str(tmp_path / "oldname.py"),
+        dest_path=str(tmp_path / "newname.py"),
+    ))
+
+    assert str(tmp_path / "oldname.py") in seen, "source path must be processed"
+    assert str(tmp_path / "newname.py") in seen, "destination path must be processed"
+
+
+def test_on_moved_ignores_directories(tmp_path):
+    handler = _handler(tmp_path)
+    seen = []
+    handler._debounce = lambda path, action: seen.append(path)
+
+    handler.on_moved(SimpleNamespace(
+        is_directory=True, src_path=str(tmp_path / "a"), dest_path=str(tmp_path / "b")
+    ))
+
+    assert seen == []
+
+
+def test_handle_removal_deletes_the_stale_node(tmp_path):
+    handler = _handler(tmp_path)
+    old = tmp_path / "oldname.py"
+
+    handler._handle_removal(str(old))
+
+    handler.graph_builder.delete_file_from_graph.assert_called_once()
+    assert "oldname.py" in handler.graph_builder.delete_file_from_graph.call_args[0][0]
+
+
+def test_handle_removal_survives_a_failing_delete(tmp_path):
+    handler = _handler(tmp_path)
+    handler.graph_builder.delete_file_from_graph.side_effect = RuntimeError("boom")
+
+    handler._handle_removal(str(tmp_path / "x.py"))   # must not raise
+
+
+def test_fired_timers_are_removed_from_the_registry(tmp_path):
+    """Timers were never removed after firing, so self.timers grew without
+    bound for the life of the watcher."""
+    handler = _handler(tmp_path)
+    fired = threading.Event()
+    handler._debounce("a.py", fired.set)
+
+    assert fired.wait(timeout=5), "debounced action did not run"
+    for _ in range(100):
+        if not handler.timers:
+            break
+        time.sleep(0.01)
+
+    assert handler.timers == {}, "fired timer left behind in self.timers"
+
+
+def test_debounce_replaces_a_pending_timer(tmp_path):
+    handler = _handler(tmp_path)
+    calls = []
+    handler._debounce("a.py", lambda: calls.append(1))
+    handler._debounce("a.py", lambda: calls.append(2))
+    time.sleep(0.3)
+
+    assert calls == [2], "the superseded timer should have been cancelled"
+
+
+def test_modification_handler_is_serialised(tmp_path):
+    """Debounce is keyed per path, so N files changed inside the window fire N
+    handler threads. They did read-modify-write on the shared imports_map and
+    interleaved delete/add for overlapping caller sets, so one could delete
+    edges another had just created."""
+    handler = _handler(tmp_path)
+    concurrent = []
+    active = []
+    lock = threading.Lock()
+
+    def _slow(_path):
+        with lock:
+            active.append(1)
+            concurrent.append(len(active))
+        time.sleep(0.05)
+        with lock:
+            active.pop()
+
+    handler._handle_modification_locked = _slow
+    threads = [
+        threading.Thread(target=handler._handle_modification, args=(f"f{i}.py",))
+        for i in range(6)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert max(concurrent) == 1, f"handlers ran concurrently (max {max(concurrent)})"
+
+
+def test_cancel_timers_is_lock_guarded():
+    source = inspect.getsource(watcher_mod.RepositoryEventHandler.cancel_timers)
+    assert "_timers_lock" in source

--- a/tests/unit/tools/test_graph_builder_perf_fixes.py
+++ b/tests/unit/tools/test_graph_builder_perf_fixes.py
@@ -14,6 +14,7 @@ Covers Changes 2-11:
 import inspect
 import sys
 import pytest
+import threading
 from pathlib import Path
 from typing import Dict, List, Optional
 from unittest.mock import MagicMock, patch
@@ -1110,6 +1111,10 @@ class TestWatcherIncrementalHandleModification:
         watcher.all_file_data = []
         watcher.imports_map = {}
         watcher.repo_path = Path("/fake")
+        # _handle_modification serialises graph updates; instances built via
+        # __new__ must supply the locks __init__ would have created.
+        watcher._update_lock = threading.RLock()
+        watcher._timers_lock = threading.Lock()
 
         mock_gb = MagicMock()
         mock_gb.parsers = {".py": None}
@@ -1134,6 +1139,10 @@ class TestWatcherIncrementalHandleModification:
         watcher.all_file_data = []
         watcher.imports_map = {}
         watcher.repo_path = Path("/fake")
+        # _handle_modification serialises graph updates; instances built via
+        # __new__ must supply the locks __init__ would have created.
+        watcher._update_lock = threading.RLock()
+        watcher._timers_lock = threading.Lock()
 
         mock_gb = MagicMock()
         mock_gb.parsers = {".py": None}
@@ -1158,6 +1167,10 @@ class TestWatcherIncrementalHandleModification:
         watcher.all_file_data = []
         watcher.imports_map = {}
         watcher.repo_path = Path("/fake")
+        # _handle_modification serialises graph updates; instances built via
+        # __new__ must supply the locks __init__ would have created.
+        watcher._update_lock = threading.RLock()
+        watcher._timers_lock = threading.Lock()
 
         mock_gb = MagicMock()
         mock_gb.parsers = {".py": None}


### PR DESCRIPTION
Fixes #1391 and the watcher-concurrency finding (`I-M11`) from the 0.5.2 audit.

## 1. Renaming a file left the old node and all its symbols forever (#1391)

```python
def on_moved(self, event):
    if not event.is_directory:
        self._debounce(event.dest_path, lambda: self._handle_modification(event.dest_path))
```

`event.src_path` was never processed, so `delete_file_from_graph(src)` never ran. `on_created`, `on_modified` and `on_deleted` all handle `src_path` — only the move path ignored it.

**Verified live**, with a running `cgc watch --poll`, renaming `oldname.py` → `newname.py`:

| | File nodes | `alpha*` function rows |
|---|---|---|
| baseline (`main`) | `newname.py`, **`oldname.py`** | **4** (each duplicated) |
| this PR | `newname.py` | 2 |

Every rename duplicated every symbol in the file. A refactoring session — or a `git checkout` between branches — accumulates them indefinitely until `find_callers` starts returning dead paths.

## 2. Concurrent handlers with no locking (`I-M11`)

Debounce is keyed **per path**, so N files changed inside the interval fire N `threading.Timer` threads running `_handle_modification` in parallel, and there was no lock anywhere in `RepositoryEventHandler`. Concurrent handlers:

- read-modify-write the shared `self.imports_map` (lost updates), and
- interleave `delete_file_from_graph` / `add_file_to_graph` / `delete_outgoing_calls_from_files` for overlapping caller sets, so one handler can delete edges another has just created.

A branch switch or `git pull` is the normal trigger. Graph updates are now serialised on an `RLock`; a test spawns 6 concurrent handlers and asserts max observed concurrency is 1.

## 3. Unbounded timer growth

Timers were never removed from `self.timers` after firing, so the dict grew for the life of the watcher. Entries are now dropped when the timer runs, and `self.timers` has its own lock — `cancel_timers` could previously race with `_debounce`. This is plausibly related to #744 (*"CGC Watch continuously consumes memory until it eats all available RAM"*), though I have not confirmed it is the whole story there.

## ⚠️ Found while testing: the watcher is entirely broken on KùzuDB

The first live rename test failed before reaching any of the above:

```
RuntimeError: Binder exception: Table HEURISTIC_CALLS does not exist.
  ... watcher.py:255 in _handle_modification_locked
  ... get_caller_file_paths
```

That is the missing Kùzu rel table I fix in #1421 — and it means **incremental watching does not work at all on KùzuDB**, which is the Windows default and the universal fallback backend. That is a bigger blast radius than the `analyze dead-code` breakage documented on #1421; I've noted it there too.

To verify this PR live I temporarily applied #1421's schema addition, then reverted it — `git diff upstream/main` on this branch shows `watcher.py` only.

## Tests

8 new tests, **6 fail against unpatched `main`**: both rename endpoints processed, directories ignored, stale-node removal (including surviving a failing delete), fired timers removed, superseded timers cancelled, and handler serialisation under 6 concurrent threads.

Three existing tests in `test_graph_builder_perf_fixes.py` build the handler via `__new__` and set attributes by hand; they now also supply the locks `__init__` creates. Making the lock optional instead would have quietly reintroduced the bug.

Full unit suite: **740 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py` — flaky on `main`, see #1422).

Closes #1391