### PR TITLE
fix(parsers): stop silently dropping non-UTF-8 source files

### DIFF
--- a/src/codegraphcontext/tools/languages/css.py
+++ b/src/codegraphcontext/tools/languages/css.py
@@ -17,7 +17,7 @@ class CSSTreeSitterParser:
 
     def parse(self, path: Path, is_dependency: bool = False, index_source: bool = False) -> Dict[str, Any]:
         """Parses a CSS file and returns its structure."""
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
             source_code = f.read()
 
         tree = self.parser.parse(bytes(source_code, "utf8"))

--- a/src/codegraphcontext/tools/languages/elixir.py
+++ b/src/codegraphcontext/tools/languages/elixir.py
@@ -475,7 +475,7 @@ def pre_scan_elixir(files: list[Path], parser_wrapper) -> dict:
 
     for path in files:
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 source = f.read()
             tree = parser_wrapper.parser.parse(bytes(source, "utf8"))
             _pre_scan_recursive(tree.root_node, path, imports_map)

--- a/src/codegraphcontext/tools/languages/go.py
+++ b/src/codegraphcontext/tools/languages/go.py
@@ -177,7 +177,7 @@ class GoTreeSitterParser:
     def parse(self, path: Path, is_dependency: bool = False, index_source: bool = False) -> Dict:
         """Parses a file and returns its structure in a standardized dictionary format."""
         self.index_source = index_source
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
             source_code = f.read()
 
         # Extract Go package declaration for package_name field on File nodes
@@ -607,7 +607,7 @@ def pre_scan_go(files: list[Path], parser_wrapper) -> dict:
 
     for path in files:
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 tree = parser_wrapper.parser.parse(bytes(f.read(), "utf8"))
 
             for capture, _ in execute_query(parser_wrapper.language, query_str, tree.root_node):

--- a/src/codegraphcontext/tools/languages/html.py
+++ b/src/codegraphcontext/tools/languages/html.py
@@ -39,7 +39,7 @@ class HTMLTreeSitterParser:
 
     def parse(self, path: Path, is_dependency: bool = False, index_source: bool = False) -> Dict[str, Any]:
         """Parses an HTML file and returns its structure."""
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
             source_code = f.read()
 
         tree = self.parser.parse(bytes(source_code, "utf8"))

--- a/src/codegraphcontext/tools/languages/javascript.py
+++ b/src/codegraphcontext/tools/languages/javascript.py
@@ -631,7 +631,7 @@ def pre_scan_javascript(files: list[Path], parser_wrapper) -> dict:
 
     for path in files:
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 tree = parser_wrapper.parser.parse(bytes(f.read(), "utf8"))
 
             for capture, _ in execute_query(parser_wrapper.language, query_str, tree.root_node):

--- a/src/codegraphcontext/tools/languages/python.py
+++ b/src/codegraphcontext/tools/languages/python.py
@@ -134,7 +134,7 @@ class PythonTreeSitterParser:
         try:
             if is_notebook:
                 info_logger(f"Converting notebook {path} to temporary Python file.")
-                with open(path, 'r', encoding='utf-8') as f:
+                with open(path, 'r', encoding='utf-8', errors="ignore") as f:
                     notebook_node = nbformat.read(f, as_version=4)
                 
                 exporter = PythonExporter()
@@ -147,7 +147,7 @@ class PythonTreeSitterParser:
                 # The file to be parsed is now the temporary file
                 path = temp_py_file
 
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 source_code = f.read()
             
             tree = self.parser.parse(bytes(source_code, "utf8"))
@@ -658,17 +658,17 @@ def pre_scan_python(files: list[Path], parser_wrapper) -> dict:
         try:
             source_to_parse = ""
             if path.suffix == '.ipynb':
-                with open(path, 'r', encoding='utf-8') as f:
+                with open(path, 'r', encoding='utf-8', errors="ignore") as f:
                     notebook_node = nbformat.read(f, as_version=4)
                 exporter = PythonExporter()
                 python_code, _ = exporter.from_notebook_node(notebook_node)
                 with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.py', encoding='utf-8') as tf:
                     tf.write(python_code)
                     temp_py_file = Path(tf.name)
-                with open(temp_py_file, "r", encoding="utf-8") as f:
+                with open(temp_py_file, "r", encoding="utf-8", errors="ignore") as f:
                     source_to_parse = f.read()
             else:
-                with open(path, "r", encoding="utf-8") as f:
+                with open(path, "r", encoding="utf-8", errors="ignore") as f:
                     source_to_parse = f.read()
 
             tree = parser_wrapper.parser.parse(bytes(source_to_parse, "utf8"))

--- a/src/codegraphcontext/tools/languages/ruby.py
+++ b/src/codegraphcontext/tools/languages/ruby.py
@@ -553,7 +553,7 @@ def pre_scan_ruby(files: list[Path], parser_wrapper) -> dict:
 
     for path in files:
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 tree = parser_wrapper.parser.parse(bytes(f.read(), "utf8"))
 
             for capture, _ in execute_query(parser_wrapper.language, query_str, tree.root_node):

--- a/src/codegraphcontext/tools/languages/typescript.py
+++ b/src/codegraphcontext/tools/languages/typescript.py
@@ -585,7 +585,7 @@ def pre_scan_typescript(files: list[Path], parser_wrapper) -> dict:
     
     for path in files:
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 source_code = f.read()
                 tree = parser_wrapper.parser.parse(bytes(source_code, "utf8"))
             

--- a/src/codegraphcontext/tools/languages/typescriptjsx.py
+++ b/src/codegraphcontext/tools/languages/typescriptjsx.py
@@ -18,7 +18,7 @@ def pre_scan_typescript(files: list[Path], parser_wrapper) -> dict:
     ]
     for path in files:
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 source_code = f.read()
                 tree = parser_wrapper.parser.parse(bytes(source_code, "utf8"))
             for query_str in query_strings:
@@ -81,7 +81,7 @@ class TypescriptJSXTreeSitterParser(TypescriptTreeSitterParser):
         Indexes components, functions, imports, and exports.
         """
         self.index_source = index_source
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
             source_code = f.read()
         tree = self.parser.parse(bytes(source_code, "utf8"))
         root_node = tree.root_node

--- a/tests/unit/tools/test_parser_encoding_resilience.py
+++ b/tests/unit/tools/test_parser_encoding_resilience.py
@@ -1,0 +1,67 @@
+"""Regression tests: a non-UTF-8 source file must not be silently dropped."""
+import glob
+import re
+
+import pytest
+
+# open(...) calls that specify encoding but no errors= handler.
+_UNGUARDED = re.compile(
+    r"open\((?![^)]*errors=)[^)]*encoding=['\"]utf-8['\"][^)]*\)"
+)
+
+_PARSER_FILES = sorted(glob.glob("src/codegraphcontext/tools/languages/*.py")) or sorted(
+    glob.glob("**/codegraphcontext/tools/languages/*.py", recursive=True)
+)
+
+
+def test_parser_files_were_found():
+    assert _PARSER_FILES, "could not locate the language parser sources"
+
+
+@pytest.mark.parametrize("path", _PARSER_FILES, ids=lambda p: p.split("/")[-1])
+def test_every_parser_decodes_defensively(path):
+    """Seven of the most-used parsers (Python, JS, TS, TSX, Go, CSS, HTML)
+    opened source files with `encoding="utf-8"` and no `errors=` handler, while
+    the other 20 passed `errors="ignore"`.
+
+    A `UnicodeDecodeError` was caught upstream and turned into a result with an
+    `error` key but no `unsupported` key, which the pipeline treats exactly like
+    a `.md` file: the file got a bare `File` node, contributed no symbols, and
+    the run still reported "Successfully finished indexing" with no failure
+    count. A codebase with legacy latin-1 files lost them entirely.
+    """
+    source = open(path, encoding="utf-8").read()
+    unguarded = _UNGUARDED.findall(source)
+    assert not unguarded, (
+        f"{path} opens source without an errors= handler: {unguarded[:2]}"
+    )
+
+
+def test_latin1_source_still_yields_symbols(tmp_path):
+    """End-to-end at the parser level: a latin-1 file must parse, not raise."""
+    from codegraphcontext.tools.languages.python import PythonTreeSitterParser
+    from codegraphcontext.tools.graph_builder import GraphBuilder
+
+    target = tmp_path / "latin.py"
+    target.write_bytes(
+        "def caf\xe9_handler():\n    return 1\n\ndef plain_one():\n    return 2\n".encode("latin-1")
+    )
+
+    import asyncio
+    from unittest.mock import MagicMock
+
+    builder = GraphBuilder.__new__(GraphBuilder)
+    GraphBuilder.__init__(
+        builder,
+        db_manager=MagicMock(),
+        job_manager=MagicMock(),
+        loop=asyncio.new_event_loop(),
+    )
+    data = builder.parse_file(tmp_path, target)
+
+    assert "error" not in data, f"latin-1 file failed to parse: {data.get('error')}"
+    names = {f["name"] for f in data.get("functions", [])}
+    assert "plain_one" in names, f"pure-ASCII function lost; got {names}"
+    # The non-ASCII byte is dropped by errors="ignore", so the identifier is
+    # mangled but present and still distinct.
+    assert any(n.endswith("_handler") for n in names), f"got {names}"


### PR DESCRIPTION
Fixes #1390.

## The bug

Nine parsers opened source with `encoding="utf-8"` and **no `errors=` handler**, while the other 20 already passed `errors="ignore"`. The nine include the most-used languages — Python, JavaScript, TypeScript, TSX, Go, CSS, HTML, Ruby, Elixir — across 15 `open()` call sites.

The resulting `UnicodeDecodeError` is caught upstream and returned as `{"path": …, "error": …}` with **no `unsupported` key**, which `pipeline.py` treats exactly like a `.md` file. So the file got a bare `File` node, contributed no symbols, and the run still reported *"Successfully finished indexing"* with no failure count anywhere.

Verified end to end on a latin-1 encoded `.py`:

```
before: Function nodes from latin.py = NONE
after:  caf_handler, plain_one
```

## A deliberate deviation from the audit

The report recommends `errors="replace"`. I implemented that first, measured it, and switched to `errors="ignore"`:

```
replace -> 'def caf�_handler():'  -> tree-sitter extracts "_handler"
ignore  -> 'def caf_handler():'        -> tree-sitter extracts "caf_handler"
```

`U+FFFD` is not a valid identifier character, so `replace` makes tree-sitter *truncate the symbol name* at the bad byte. `ignore` yields a usable, still-distinct identifier — and matches the convention already present in the other 20 parsers. Happy to switch back if you'd rather have the replacement character visible.

## Tests

28 tests, **10 fail against unpatched `main`**: a parametrized check that *every* parser file decodes defensively (so a newly-added parser cannot reintroduce this), plus an end-to-end parse of a latin-1 file asserting symbols come out.

- Full unit suite: **760 passed, 7 skipped, 0 failed**
- **All 20 parser golden tests pass** — extraction for well-formed sources is unchanged.

## Not included: #1392

I attempted #1392 (shared `Module` nodes destroyed by a per-file delete) in this branch and **backed it out**, because my fix did not actually work and I would rather report that than ship something unverified. Details in a comment on #1392 — the short version is that the audit's proposed `WHERE element.path = $path` filter does not help, because the `Module` node in the failing case *does* carry the defining file's path. The bug is real and I reproduced it precisely; the fix needs a label predicate whose syntax differs between Kùzu (`label(n)`) and Neo4j (`labels(n)`).

Closes #1390