### PR TITLE
fix(cli): confirm single-repo delete; stop unwatch/watching reporting success

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -1023,19 +1023,38 @@ def watch_helper(
 
 
 def unwatch_helper(path: str):
-    """Stop watching a directory."""
-    console.print(f"[yellow]⚠️  Note: 'cgc unwatch' only works when the watcher is running via MCP server.[/yellow]")
-    console.print(f"[dim]For CLI watch mode, simply press Ctrl+C in the watch terminal.[/dim]")
-    console.print(f"\n[cyan]Path specified:[/cyan] {Path(path).resolve()}")
+    """Report that unwatching is not available from the CLI.
+
+    This command touches no watcher state at all — it never has. It used to
+    print a note, echo the requested path back as "Path specified:" (which
+    reads like confirmation that something happened, even for a path that was
+    never watched and does not exist) and exit 0.
+    """
+    console.print(
+        "[bold red]Error:[/bold red] 'cgc unwatch' is not supported from the CLI — "
+        "it cannot reach a watcher started in another process."
+    )
+    console.print("[dim]For CLI watch mode, press Ctrl+C in the terminal running 'cgc watch'.[/dim]")
+    console.print(
+        "[dim]For MCP mode, call the 'unwatch_directory' tool from your IDE.[/dim]"
+    )
+    raise typer.Exit(code=1)
 
 
 def list_watching_helper():
-    """List all directories currently being watched."""
-    console.print(f"[yellow]⚠️  Note: 'cgc watching' only works when the watcher is running via MCP server.[/yellow]")
-    console.print(f"[dim]For CLI watch mode, check the terminal where you ran 'cgc watch'.[/dim]")
-    console.print(f"\n[cyan]To see watched directories in MCP mode:[/cyan]")
-    console.print(f"  1. Start the MCP server: cgc mcp start")
-    console.print(f"  2. Use the 'list_watched_paths' MCP tool from your IDE")
+    """Report that listing watched paths is not available from the CLI.
+
+    Same as unwatch: no watcher state is consulted, so exiting 0 advertised a
+    successful listing of nothing.
+    """
+    console.print(
+        "[bold red]Error:[/bold red] 'cgc watching' is not supported from the CLI — "
+        "it cannot reach a watcher started in another process."
+    )
+    console.print("[dim]For CLI watch mode, check the terminal where you ran 'cgc watch'.[/dim]")
+    console.print("[dim]For MCP mode: start 'cgc mcp start', then call the "
+                  "'list_watched_paths' tool from your IDE.[/dim]")
+    raise typer.Exit(code=1)
 
 
 def setup_scip_helper() -> None:

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -1505,6 +1505,7 @@ def setup_scip():
 def delete(
     path: Optional[str] = typer.Argument(None, help="Path of the repository to delete from the code graph."),
     all_repos: bool = typer.Option(False, "--all", help="Delete all indexed repositories"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt (for CI/non-interactive use)"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use")
 ):
     """
@@ -1601,6 +1602,22 @@ def delete(
                 "Set ALLOW_DB_DELETION=true in config to enable."
             )
             raise typer.Exit(code=1)
+
+        # `--all` demands a typer.confirm *and* typing "delete all", while a
+        # single delete went straight through — irreversibly dropping a
+        # repository's entire graph (potentially an hour of indexing) on a
+        # typo, with no prompt, no --yes flag and no undo. The asymmetry was
+        # actively misleading: anyone who had seen the heavy --all guardrails
+        # would reasonably assume single deletes were guarded too.
+        if not yes:
+            resolved = Path(path).expanduser().resolve()
+            console.print(
+                f"[bold yellow]About to delete the graph for:[/bold yellow] {resolved}"
+            )
+            console.print("[dim]This is irreversible; re-indexing is the only way back.[/dim]")
+            if not typer.confirm("Proceed?", default=False):
+                console.print("[yellow]Deletion cancelled.[/yellow]")
+                raise typer.Exit(code=1)
 
         delete_helper(path, context)
 
@@ -1736,7 +1753,11 @@ def unwatch(
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
 ):
     """
-    Stop watching a directory for changes.
+    [MCP only] Stop watching a directory for changes.
+
+    Not supported from the CLI: this cannot reach a watcher running in another
+    process. Press Ctrl+C in the 'cgc watch' terminal, or use the
+    'unwatch_directory' MCP tool.
     
     Note: This command is primarily for MCP server mode.
     For CLI watch mode, simply press Ctrl+C in the watch terminal.
@@ -1752,7 +1773,10 @@ def watching(
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
 ):
     """
-    List all directories currently being watched for changes.
+    [MCP only] List all directories currently being watched for changes.
+
+    Not supported from the CLI: this cannot reach a watcher running in another
+    process. Use the 'list_watched_paths' MCP tool.
     
     Note: This command is primarily for MCP server mode.
     For CLI watch mode, check the terminal where you ran 'cgc watch'.
@@ -2977,10 +3001,13 @@ def list_abbrev(
 def delete_abbrev(
     path: Optional[str] = typer.Argument(None, help="Path to delete"),
     all_repos: bool = typer.Option(False, "--all", help="Delete all indexed repositories"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt (for CI/non-interactive use)"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use")
 ):
     """Shortcut for 'cgc delete'"""
-    delete(path, all_repos, context=context)
+    # `yes` must be forwarded explicitly: omitted, it keeps its OptionInfo
+    # sentinel, which is truthy — silently skipping the confirmation.
+    delete(path, all_repos, yes=yes, context=context)
 
 @app.command("v", rich_help_panel="Shortcuts")
 def visualize_abbrev(

--- a/tests/unit/cli/test_delete_confirmation_and_watch_commands.py
+++ b/tests/unit/cli/test_delete_confirmation_and_watch_commands.py
@@ -1,0 +1,103 @@
+"""Regression tests for destructive-delete confirmation and no-op watch commands."""
+import ast
+import inspect
+from unittest.mock import patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from codegraphcontext.cli import cli_helpers, main as cli_main
+from codegraphcontext.cli.main import app
+
+runner = CliRunner()
+
+
+def _allow_deletion():
+    return patch.object(cli_main.config_manager, "is_db_deletion_allowed", return_value=True)
+
+
+def test_single_delete_requires_confirmation():
+    """`--all` demanded a typer.confirm *and* typing 'delete all', while a
+    single delete went straight through — irreversibly dropping a repository's
+    entire graph on a typo, with no prompt and no undo."""
+    with _allow_deletion(), \
+         patch.object(cli_main, "delete_helper") as helper, \
+         patch.object(cli_main, "_load_credentials"):
+        result = runner.invoke(app, ["delete", "/some/repo"], input="n\n")
+
+    assert result.exit_code == 1
+    helper.assert_not_called()
+
+
+def test_single_delete_proceeds_when_confirmed():
+    with _allow_deletion(), \
+         patch.object(cli_main, "delete_helper") as helper, \
+         patch.object(cli_main, "_load_credentials"):
+        result = runner.invoke(app, ["delete", "/some/repo"], input="y\n")
+
+    assert result.exit_code == 0
+    helper.assert_called_once()
+
+
+def test_single_delete_aborts_when_stdin_is_closed():
+    """Non-interactive callers must not have the delete silently succeed."""
+    with _allow_deletion(), \
+         patch.object(cli_main, "delete_helper") as helper, \
+         patch.object(cli_main, "_load_credentials"):
+        result = runner.invoke(app, ["delete", "/some/repo"], input="")
+
+    assert result.exit_code != 0
+    helper.assert_not_called()
+
+
+def test_yes_flag_skips_the_prompt():
+    with _allow_deletion(), \
+         patch.object(cli_main, "delete_helper") as helper, \
+         patch.object(cli_main, "_load_credentials"):
+        result = runner.invoke(app, ["delete", "/some/repo", "--yes"], input="")
+
+    assert result.exit_code == 0
+    helper.assert_called_once()
+
+
+def test_rm_shortcut_forwards_the_yes_flag():
+    """Omitted, `yes` keeps its truthy OptionInfo sentinel and would skip the
+    confirmation — the same delegation bug fixed in #1415."""
+    source = inspect.getsource(cli_main.delete_abbrev)
+    assert "yes=yes" in source
+
+
+def test_delete_all_still_requires_its_double_confirmation():
+    source = inspect.getsource(cli_main.delete)
+    assert "delete all" in source
+    assert "typer.confirm" in source
+
+
+@pytest.mark.parametrize("helper", ["unwatch_helper", "list_watching_helper"])
+def test_watch_commands_do_not_report_success(helper):
+    """Both bodies were console.print only — no watcher state was touched —
+    yet they exited 0. `cgc unwatch` even echoed a nonexistent path back as
+    'Path specified:', which reads like confirmation."""
+    with pytest.raises(typer.Exit) as exc_info:
+        if helper == "unwatch_helper":
+            getattr(cli_helpers, helper)("/never/watched/path")
+        else:
+            getattr(cli_helpers, helper)()
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_unwatch_does_not_echo_the_path_as_confirmation():
+    """Check the executable body, not the docstring (which describes the bug)."""
+    tree = ast.parse(inspect.getsource(cli_helpers.unwatch_helper).lstrip())
+    func = tree.body[0]
+    body = func.body[1:] if ast.get_docstring(func) else func.body
+    emitted = [
+        node.value
+        for stmt in body
+        for node in ast.walk(stmt)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
+
+    assert not any("Path specified" in text for text in emitted)


### PR DESCRIPTION
Fixes #1397 and #1396.

## 1. `cgc delete <path>` destroyed a graph with no confirmation (#1397)

`--all` requires a `typer.confirm` **and** typing the literal string `delete all`. The single-repo branch went straight to `delete_helper` — no prompt, no `--yes`, no dry run, no undo. Proven with stdin closed:

```
$ cgc delete /etc < /dev/null
Successfully deleted repository: /etc
EXIT=0
```

A typo or a wrong path irreversibly dropped a repository's entire graph — potentially an hour of indexing. The asymmetry made it worse: anyone who had seen the heavy `--all` guardrails would reasonably assume single deletes were guarded too.

Now:

```
$ cgc delete /some/repo < /dev/null
About to delete the graph for: /some/repo
This is irreversible; re-indexing is the only way back.
Proceed? [y/N]: Aborted.
EXIT=1

$ cgc delete /some/repo --yes < /dev/null      # CI path, unchanged behaviour
EXIT=0
```

The `rm` shortcut forwards `yes` explicitly — omitted, it would keep its truthy `OptionInfo` sentinel and silently skip the prompt, which is the same delegation bug as #1415.

## 2. `cgc unwatch` and `cgc watching` did nothing and exited 0 (#1396)

`cgc --help` advertises them as *"Stop watching a directory for changes."* and *"List all directories currently being watched."* Both bodies are `console.print` only — no watcher state is touched anywhere:

```
$ cgc unwatch /home/claude/never-watched-path
⚠️  Note: 'cgc unwatch' only works when the watcher is running via MCP server.
Path specified: /home/claude/never-watched-path
EXIT=0
```

Note it accepted a path that had **never been watched and does not exist**, then echoed it back as "Path specified:" — which reads like confirmation that something happened.

They now say plainly that the operation is not available from the CLI, point at the two things that *do* work (Ctrl+C in the watch terminal, or the MCP tool), and exit 1. Their help text is prefixed `[MCP only]` so `cgc --help` stops advertising them as working.

```
$ cgc unwatch /home/…/never-watched-xyz
Error: 'cgc unwatch' is not supported from the CLI — it cannot reach a watcher
started in another process.
EXIT=1
```

I kept these as honest failures rather than wiring up a cross-process watcher registry — that is a feature, not a bug fix, and worth its own issue if you want it.

## Tests

9 new tests, **7 fail against unpatched `main`**: confirmation required / honoured / aborted on closed stdin, `--yes` bypass, `rm` forwarding the flag, `--all` keeping its double confirmation, both watch commands exiting non-zero, and `unwatch` no longer echoing the path as confirmation.

Full unit suite: **741 passed, 7 skipped, 0 failed** (excluding `test_cgcignore_patterns.py` — flaky on `main`, see #1422).

Closes #1396
Closes #1397