### PR TITLE
feat(ai): add Atlas Cloud query provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ PYTHONDONTWRITEBYTECODE=1
 # Optional: Logging
 # LOG_LEVEL=INFO
 
+# Optional: Atlas Cloud for natural-language graph queries (OpenAI-compatible)
+# ATLASCLOUD_API_KEY=CHANGE_ME
+# ATLASCLOUD_API_BASE=https://api.atlascloud.ai/v1
+# ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro
+
 # Remote FalkorDB (set DEFAULT_DATABASE=falkordb-remote or set FALKORDB_HOST)
 # FALKORDB_HOST=127.0.0.1
 # FALKORDB_PORT=6379

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -331,9 +331,12 @@ async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str]
 def call_llm(system_prompt: str, user_prompt: str) -> str:
     gemini_key = os.getenv("GEMINI_API_KEY")
     openai_key = os.getenv("OPENAI_API_KEY")
+    atlascloud_key = os.getenv("ATLASCLOUD_API_KEY") or os.getenv("ATLAS_CLOUD_API_KEY")
     
-    if not gemini_key and not openai_key:
-        raise ValueError("Neither GEMINI_API_KEY nor OPENAI_API_KEY environment variable is set.")
+    if not gemini_key and not openai_key and not atlascloud_key:
+        raise ValueError(
+            "GEMINI_API_KEY, OPENAI_API_KEY, or ATLASCLOUD_API_KEY environment variable is required."
+        )
     
     if gemini_key:
         url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key={gemini_key}"
@@ -354,13 +357,26 @@ def call_llm(system_prompt: str, user_prompt: str) -> str:
         except (KeyError, IndexError) as e:
             raise RuntimeError(f"Failed to parse Gemini API response: {data}") from e
     else:
-        url = "https://api.openai.com/v1/chat/completions"
+        if openai_key:
+            provider_name = "OpenAI"
+            api_key = openai_key
+            url = "https://api.openai.com/v1/chat/completions"
+            model = "gpt-4o-mini"
+        else:
+            provider_name = "Atlas Cloud"
+            api_key = atlascloud_key
+            base_url = os.getenv("ATLASCLOUD_API_BASE") or os.getenv("ATLAS_CLOUD_API_BASE")
+            base_url = (base_url or "https://api.atlascloud.ai/v1").rstrip("/")
+            url = f"{base_url}/chat/completions"
+            model = os.getenv("ATLASCLOUD_MODEL") or os.getenv("ATLAS_CLOUD_MODEL")
+            model = model or "deepseek-ai/deepseek-v4-pro"
+
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {openai_key}"
+            "Authorization": f"Bearer {api_key}"
         }
         payload = {
-            "model": "gpt-4o-mini",
+            "model": model,
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
@@ -368,12 +384,12 @@ def call_llm(system_prompt: str, user_prompt: str) -> str:
         }
         res = requests.post(url, json=payload, headers=headers, timeout=30)
         if res.status_code != 200:
-            raise RuntimeError(f"OpenAI API returned error {res.status_code}: {res.text}")
+            raise RuntimeError(f"{provider_name} API returned error {res.status_code}: {res.text}")
         data = res.json()
         try:
             return data["choices"][0]["message"]["content"]
         except (KeyError, IndexError) as e:
-            raise RuntimeError(f"Failed to parse OpenAI API response: {data}") from e
+            raise RuntimeError(f"Failed to parse {provider_name} API response: {data}") from e
 
 
 def parse_json_from_llm(text: str) -> dict:
@@ -515,11 +531,15 @@ async def ai_query(request: AIQueryRequest):
         
     gemini_key = os.getenv("GEMINI_API_KEY")
     openai_key = os.getenv("OPENAI_API_KEY")
+    atlascloud_key = os.getenv("ATLASCLOUD_API_KEY") or os.getenv("ATLAS_CLOUD_API_KEY")
     
-    if not gemini_key and not openai_key:
+    if not gemini_key and not openai_key and not atlascloud_key:
         raise HTTPException(
             status_code=400,
-            detail="AI querying requires GEMINI_API_KEY or OPENAI_API_KEY environment variable. Please set it in your configuration or .env."
+            detail=(
+                "AI querying requires GEMINI_API_KEY, OPENAI_API_KEY, or ATLASCLOUD_API_KEY. "
+                "Please set one in your configuration or .env."
+            )
         )
         
     query = request.query

--- a/tests/unit/api/test_ai_query.py
+++ b/tests/unit/api/test_ai_query.py
@@ -7,9 +7,11 @@ from codegraphcontext.viz.server import app, set_db_manager
 client = TestClient(app)
 
 def test_ai_query_no_api_keys(monkeypatch):
-    # Ensure neither key is in env
+    # Ensure no supported provider key is in env
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.delenv("ATLAS_CLOUD_API_KEY", raising=False)
     
     # Mock db_manager
     mock_db = MagicMock()
@@ -19,6 +21,63 @@ def test_ai_query_no_api_keys(monkeypatch):
     
     assert response.status_code == 400
     assert "AI querying requires" in response.json()["detail"]
+
+
+@patch("codegraphcontext.viz.server.requests.post")
+def test_call_llm_with_atlascloud(mock_post, monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "fake-atlas-key")
+    monkeypatch.setenv("ATLASCLOUD_API_BASE", "https://api.atlascloud.ai/v1/")
+    monkeypatch.setenv("ATLASCLOUD_MODEL", "qwen/qwen3.5-flash")
+
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {
+        "choices": [{"message": {"content": "MATCH (n) RETURN n"}}]
+    }
+
+    from codegraphcontext.viz.server import call_llm
+
+    result = call_llm("system prompt", "user prompt")
+
+    assert result == "MATCH (n) RETURN n"
+    mock_post.assert_called_once_with(
+        "https://api.atlascloud.ai/v1/chat/completions",
+        json={
+            "model": "qwen/qwen3.5-flash",
+            "messages": [
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": "user prompt"},
+            ],
+        },
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer fake-atlas-key",
+        },
+        timeout=30,
+    )
+
+
+@patch("codegraphcontext.viz.server.requests.post")
+def test_call_llm_with_atlas_cloud_alias_defaults(mock_post, monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.delenv("ATLASCLOUD_API_BASE", raising=False)
+    monkeypatch.delenv("ATLASCLOUD_MODEL", raising=False)
+    monkeypatch.setenv("ATLAS_CLOUD_API_KEY", "fake-atlas-key")
+
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {
+        "choices": [{"message": {"content": "default response"}}]
+    }
+
+    from codegraphcontext.viz.server import call_llm
+
+    assert call_llm("system", "user") == "default response"
+    _, kwargs = mock_post.call_args
+    assert mock_post.call_args.args[0] == "https://api.atlascloud.ai/v1/chat/completions"
+    assert kwargs["json"]["model"] == "deepseek-ai/deepseek-v4-pro"
 
 
 @patch("codegraphcontext.viz.server.call_llm")


### PR DESCRIPTION
## Summary

- add Atlas Cloud as an OpenAI-compatible backend for natural-language graph queries
- support `ATLASCLOUD_*` and `ATLAS_CLOUD_*` API key, base URL, and model environment variables
- preserve the existing Gemini/OpenAI priority and use `https://api.atlascloud.ai/v1` with `deepseek-ai/deepseek-v4-pro` by default
- add focused coverage for custom configuration, aliases, defaults, and missing-key validation

## Testing

- `PYTHONPATH=src python3 -m pytest -q tests/unit/api/test_ai_query.py` (`4 passed`)
- `python3 -m compileall -q src/codegraphcontext/viz/server.py tests/unit/api/test_ai_query.py`
- `git diff --check`
- Atlas Cloud `/v1/models`: HTTP 200, 121 models; confirmed `deepseek-ai/deepseek-v4-pro` and `qwen/qwen3.5-flash`

## Notes

- No README, documentation, logo, sponsor, credits, or partner changes.
- `.env.example` only documents the optional runtime configuration.
- Full-file Ruff checks still report pre-existing style and unused-import findings in `viz/server.py` and `test_ai_query.py`; this PR avoids unrelated formatting churn.
