### PR TITLE
test(cli): strip ANSI before asserting on Rich-rendered help output

### DIFF
--- a/tests/unit/cli/test_command_delegation_and_exit_codes.py
+++ b/tests/unit/cli/test_command_delegation_and_exit_codes.py
@@ -1,4 +1,5 @@
 """Regression tests for command-to-command delegation and `cgc index` exit codes."""
+import re
 import ast
 import inspect
 from unittest.mock import patch
@@ -11,6 +12,20 @@ from codegraphcontext.cli import main as cli_main
 from codegraphcontext.cli.main import app
 
 runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI escapes and collapse whitespace.
+
+    Rich emits colour codes (and soft-wraps) whenever it thinks the terminal
+    supports them — which it does in CI but not always locally. Asserting on
+    raw `result.output` therefore passes on a dev machine and fails in CI with
+    the expected text plainly visible, just interleaved with \x1b[1;36m codes.
+    """
+    return " ".join(_ANSI_RE.sub("", text).split())
+
 
 
 def _command_functions(tree):
@@ -112,4 +127,4 @@ def test_index_still_exits_zero_on_success():
 def test_bundle_load_accepts_a_context_flag():
     result = runner.invoke(app, ["bundle", "load", "--help"])
     assert result.exit_code == 0
-    assert "--context" in " ".join(result.output.split())
+    assert "--context" in _plain(result.output)

--- a/tests/unit/cli/test_delete_and_flag_conventions.py
+++ b/tests/unit/cli/test_delete_and_flag_conventions.py
@@ -1,3 +1,4 @@
+import re
 """Regression tests for CLI exit codes and short-flag conventions."""
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,20 @@ from codegraphcontext.cli import cli_helpers
 from codegraphcontext.cli.main import app
 
 runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI escapes and collapse whitespace.
+
+    Rich emits colour codes (and soft-wraps) whenever it thinks the terminal
+    supports them — which it does in CI but not always locally. Asserting on
+    raw `result.output` therefore passes on a dev machine and fails in CI with
+    the expected text plainly visible, just interleaved with \x1b[1;36m codes.
+    """
+    return " ".join(_ANSI_RE.sub("", text).split())
+
 
 
 def _services():
@@ -65,13 +80,13 @@ def test_short_h_is_help_on_subcommands(command):
     `visualize`, so `cgc visualize -h` failed with 'requires an argument'."""
     result = runner.invoke(app, [command, "-h"])
     assert result.exit_code == 0
-    assert "Usage:" in result.output
+    assert "Usage:" in _plain(result.output)
 
 
 def test_visualize_host_moved_to_capital_h():
     result = runner.invoke(app, ["visualize", "--help"])
     assert result.exit_code == 0
-    normalised = " ".join(result.output.split())
+    normalised = _plain(result.output)
     assert "--host -H" in normalised
 
 

--- a/tests/unit/cli/test_stats_counts_and_doctor.py
+++ b/tests/unit/cli/test_stats_counts_and_doctor.py
@@ -9,6 +9,20 @@ from codegraphcontext.cli.main import app
 
 runner = CliRunner()
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI escapes and collapse whitespace.
+
+    Rich emits colour codes (and soft-wraps) whenever it thinks the terminal
+    supports them — which it does in CI but not always locally. Asserting on
+    raw `result.output` therefore passes on a dev machine and fails in CI with
+    the expected text plainly visible, just interleaved with \x1b[1;36m codes.
+    """
+    return " ".join(_ANSI_RE.sub("", text).split())
+
+
 
 def _stats_source():
     return inspect.getsource(cli_helpers.stats_helper)
@@ -53,7 +67,7 @@ def test_report_accepts_a_repo_flag():
     silently picked the one with the most files."""
     result = runner.invoke(app, ["report", "--help"])
     assert result.exit_code == 0
-    normalised = " ".join(result.output.split())
+    normalised = _plain(result.output)
     assert "--repo" in normalised
 
     source = inspect.getsource(cli_main.report)


### PR DESCRIPTION
Fixes three test failures **I introduced** on `main`. Reporting them plainly rather than leaving them to be discovered.

## What broke

Three tests I added assert on `result.output` from Typer's `CliRunner`. Rich emits ANSI colour codes (and soft-wraps) whenever it believes the terminal supports them — which it does on CI, but not in a plain local run. So they passed locally and failed on `main`:

```
FAILED tests/unit/cli/test_delete_and_flag_conventions.py::test_visualize_host_moved_to_capital_h
FAILED tests/unit/cli/test_stats_counts_and_doctor.py::test_report_accepts_a_repo_flag
FAILED tests/unit/cli/test_command_delegation_and_exit_codes.py::test_bundle_load_accepts_a_context_flag
```

The failure message shows the flag is actually there, just interleaved with escapes:

```
assert '--host -H' in '...\x1b[1;36m-\x1b[0m\x1b[1;36m-host\x1b[0m \x1b[1;32m-H\x1b[0m...'
```

So this is a **test defect, not a product defect** — `--host -H`, `--repo` and `--context` are all present and working. I verified each by running the CLI directly.

## Fix

Each file normalises with a local `_plain()` that strips ANSI and collapses whitespace before asserting.

Verified under both conditions:

```
FORCE_COLOR=1 pytest tests/unit  ->  901 passed, 7 skipped, 0 failed
pytest tests/unit               ->  901 passed, 7 skipped, 0 failed
```

The helper is duplicated across the three files rather than shared: `tests/` has no `__init__.py` anywhere, and adding one to enable a relative import would change pytest's collection mode. Three lines duplicated seemed the smaller risk — happy to move it into `tests/conftest.py` as a fixture if you'd prefer.

## One remaining `Build Test` failure is not mine

`tests/integration/cli/test_cli_commands.py::test_all_canonical_cli_commands_run_with_kuzudb` also fails:

```
Extra items in the right set:
('prompt', 'list')
('prompt', 'remove')
('prompt', 'add')
```

I confirmed this is **pre-existing** by checking out `6be7627` — `main` immediately before my merges — and reproducing it there. The `prompt` sub-app commands are in the test's expected set but not discovered from the CLI. I have not touched that sub-app and did not investigate further.