### PR TITLE
fix(indexer): preserve shared modules during file updates

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -1265,6 +1265,17 @@ class GraphWriter:
             )
             parent_paths = [record["path"] for record in parents_res]
 
+            # Module nodes are shared by their name: a module definition can be
+            # contained by this file while other files keep INCLUDES or IMPORTS
+            # edges to the same node. Remove only this file's containment edge
+            # before deleting the file-owned graph elements.
+            session.run(
+                """
+                MATCH (f:File {path: $path})-[r:CONTAINS]->(:Module)
+                DELETE r
+                """,
+                path=file_path_str,
+            )
             session.run(
                 """
                 MATCH (f:File {path: $path})
@@ -1287,6 +1298,7 @@ class GraphWriter:
                 )
 
         execute_write_operation(self.driver, backend, _work)
+        self._purge_dangling_pathless_nodes()
     def write_cpp_class_function_links(self, repo_path_str: str) -> None:
         """Post-pass: create Class-[:CONTAINS]->Function edges for C++ files.
 

--- a/tests/unit/tools/test_kuzu_import_indexing.py
+++ b/tests/unit/tools/test_kuzu_import_indexing.py
@@ -150,6 +150,66 @@ def test_kuzu_indexes_import_rows_with_missing_optional_fields(tmp_path):
         manager.close_driver()
 
 
+def test_kuzu_file_deletion_preserves_module_included_by_other_files(tmp_path):
+    """Deleting a defining file must not detach other files from its Module."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    module_file = repo / "shared.rb"
+    alpha_file = repo / "alpha.rb"
+    beta_file = repo / "beta.rb"
+    for path in (module_file, alpha_file, beta_file):
+        path.write_text("# fixture\n", encoding="utf-8")
+
+    manager, driver = _new_kuzu_driver(tmp_path)
+    try:
+        writer = GraphWriter(driver)
+        writer.add_repository_to_graph(repo)
+        writer.add_file_to_graph(
+            {
+                "path": str(module_file),
+                "repo_path": str(repo),
+                "lang": "ruby",
+                "modules": [{"name": "Shared", "line_number": 1}],
+                "functions": [],
+                "classes": [],
+                "variables": [],
+            },
+            repo.name,
+            {},
+            repo_path_str=str(repo.resolve()),
+        )
+        for path, class_name in ((alpha_file, "Alpha"), (beta_file, "Beta")):
+            writer.add_file_to_graph(
+                {
+                    "path": str(path),
+                    "repo_path": str(repo),
+                    "lang": "ruby",
+                    "classes": [{"name": class_name, "line_number": 1}],
+                    "module_inclusions": [{"class": class_name, "module": "Shared"}],
+                    "functions": [],
+                    "variables": [],
+                },
+                repo.name,
+                {},
+                repo_path_str=str(repo.resolve()),
+            )
+
+        writer.delete_file_from_graph(str(module_file))
+
+        with driver.session() as session:
+            rows = session.run(
+                """
+                MATCH (c:Class)-[:INCLUDES]->(m:Module {name: 'Shared'})
+                RETURN c.name AS class_name
+                ORDER BY class_name
+                """
+            ).data()
+
+        assert rows == [{"class_name": "Alpha"}, {"class_name": "Beta"}]
+    finally:
+        manager.close_driver()
+
+
 def test_kuzu_migrates_existing_module_schema_without_full_import_name(tmp_path):
     db_path = tmp_path / "db"
     db = kuzu.Database(str(db_path))


### PR DESCRIPTION
## Summary
- preserve shared Module nodes when an owning file is removed during incremental indexing
- purge modules only after their file containment edge is removed, so live IMPORTS/INCLUDES edges survive
- add a Kùzu regression test covering two files that include a module from a re-indexed file

## Verification
- `PYTHONPATH=src uv run pytest tests/unit/tools/test_kuzu_import_indexing.py tests/unit/tools/test_writer_path_normalization.py -q`
- `PYTHONPATH=src uv run pytest tests/unit/tools -q`
- `PYTHONPATH=src uv run bash tests/run_tests.sh fast` *(805 passed; 1 existing unrelated CLI inventory failure: prompt subcommands missing from its command matrix)*
- `uv run ruff check --ignore F841 src/codegraphcontext/tools/indexing/persistence/writer.py tests/unit/tools/test_kuzu_import_indexing.py`

Fixes #1392

Assisted-by: Codex