### PR TITLE
fix(mcp): expose supported handler inputs

### DIFF
--- a/src/codegraphcontext/tool_definitions.py
+++ b/src/codegraphcontext/tool_definitions.py
@@ -116,6 +116,10 @@ TOOLS = {
                     "type": "string",
                     "description": "Optional file path for precise results."
                 },
+                "depth": {
+                    "type": "integer",
+                    "description": "Optional traversal depth for transitive caller and callee queries (1-20)."
+                },
                 "repo_path": {
                     "type": "string",
                     "description": "Optional repository path."
@@ -150,6 +154,11 @@ TOOLS = {
                 "cypher_query": {
                     "type": "string",
                     "description": "The Cypher query to execute"
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Optional named parameters passed to the Cypher query.",
+                    "default": {}
                 },
                 "graph_name": _GRAPH_NAME_PROP
             },
@@ -206,6 +215,7 @@ TOOLS = {
             "type": "object",
             "properties": {
                 "function_name": {"type": "string"},
+                "path": {"type": "string", "description": "Optional file path to disambiguate the function."},
                 "repo_path": {"type": "string"},
                 "graph_name": _GRAPH_NAME_PROP
             },

--- a/tests/unit/test_tool_definitions.py
+++ b/tests/unit/test_tool_definitions.py
@@ -1,0 +1,17 @@
+"""MCP tool schemas must expose every handler-supported public input."""
+
+from codegraphcontext.tool_definitions import TOOLS
+
+
+def test_schemas_expose_existing_handler_inputs():
+    analyze_properties = TOOLS["analyze_code_relationships"]["inputSchema"]["properties"]
+    cypher_properties = TOOLS["execute_cypher_query"]["inputSchema"]["properties"]
+    complexity_properties = TOOLS["calculate_cyclomatic_complexity"]["inputSchema"]["properties"]
+
+    assert analyze_properties["depth"]["type"] == "integer"
+    assert cypher_properties["params"] == {
+        "type": "object",
+        "description": "Optional named parameters passed to the Cypher query.",
+        "default": {},
+    }
+    assert complexity_properties["path"]["type"] == "string"


### PR DESCRIPTION
## Summary
- expose `depth` for transitive relationship traversal
- expose named `params` for parameterized read-only Cypher queries
- expose `path` to disambiguate cyclomatic-complexity lookups
- add a schema contract regression test

## Verification
- `PYTHONPATH=src uv run pytest tests/unit/test_tool_definitions.py tests/unit/tools/test_cypher_query_readonly.py tests/unit/tools/test_kuzu_relationship_queries.py -q` (11 passed)
- `uv run ruff check src/codegraphcontext/tool_definitions.py tests/unit/test_tool_definitions.py`
- `PYTHONPATH=src uv run pytest tests/unit -q` *(741 passed, 19 skipped; 3 pre-existing Kotlin tests fail only on macOS `/private/var` versus `/var` temporary-path aliasing)*

Fixes #1399

Assisted-by: Codex