### PR TITLE
fix(cli): continue partial directory indexes

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -331,10 +331,16 @@ def index_helper(path: str, context: Optional[str] = None):
                 file_count = record["file_count"] if record else 0
                 
                 if file_count > 0:
-                    console.print(f"[yellow]Repository '{path}' is already indexed with {file_count} files. Skipping.[/yellow]")
-                    console.print("[dim]💡 Tip: Use 'cgc index --force' to re-index[/dim]")
-                    db_manager.close_driver()
-                    return
+                    expected = graph_builder.estimate_processing_time(path_obj) if path_obj.is_dir() else None
+                    expected_file_count = expected[0] if expected else None
+                    if expected_file_count is None or file_count >= expected_file_count:
+                        console.print(f"[yellow]Repository '{path}' is already indexed with {file_count} files. Skipping.[/yellow]")
+                        console.print("[dim]💡 Tip: Use 'cgc index --force' to re-index[/dim]")
+                        db_manager.close_driver()
+                        return
+                    console.print(
+                        f"[yellow]Repository '{path}' has only {file_count} of {expected_file_count} files indexed. Continuing.[/yellow]"
+                    )
                 else:
                     console.print(f"[yellow]Repository '{path}' exists but has no files (likely interrupted). Re-indexing...[/yellow]")
         except Exception as e:

--- a/tests/unit/cli/test_index_exit_codes.py
+++ b/tests/unit/cli/test_index_exit_codes.py
@@ -21,6 +21,7 @@ def _services(tmp_path):
 
 def test_index_helper_exits_nonzero_on_indexing_failure(tmp_path):
     services = _services(tmp_path)
+    services[1].estimate_processing_time.return_value = (2, 0.1)
     with (
         patch.object(cli_helpers, "_initialize_services", return_value=services),
         patch.object(cli_helpers, "_run_index_with_progress", side_effect=_failing_index),
@@ -43,3 +44,25 @@ def test_reindex_helper_exits_nonzero_on_indexing_failure(tmp_path):
 
     assert exc_info.value.exit_code == 1
     services[0].close_driver.assert_called_once()
+
+
+def test_index_helper_does_not_skip_directory_with_partial_index(tmp_path):
+    """A prior one-file scan must not mark its parent directory complete."""
+    (tmp_path / "indexed.py").write_text("pass\n", encoding="utf-8")
+    (tmp_path / "missing.py").write_text("pass\n", encoding="utf-8")
+    services = _services(tmp_path)
+    services[1].estimate_processing_time.return_value = (2, 0.1)
+    services[2].list_indexed_repositories.return_value = [{"path": str(tmp_path)}]
+
+    session = MagicMock()
+    session.run.return_value.single.return_value = {"file_count": 1}
+    services[0].get_driver.return_value.session.return_value.__enter__.return_value = session
+
+    with (
+        patch.object(cli_helpers, "_initialize_services", return_value=services),
+        patch.object(cli_helpers, "_run_index_with_progress") as run_index,
+        patch.object(cli_helpers, "_print_index_execution_summary"),
+    ):
+        cli_helpers.index_helper(str(tmp_path))
+
+    run_index.assert_called_once()


### PR DESCRIPTION
## Summary
- compare discovered and indexed file counts before skipping a directory index
- continue indexing when an existing repository contains only a partial file set
- add regression coverage for the single-file-then-directory sequence

## Verification
- `PYTHONPATH=src uv run pytest tests/unit/cli/test_index_exit_codes.py -q` (3 passed)
- `git diff --check`
- `ruff check` on `cli_helpers.py` is currently blocked by 15 unrelated, pre-existing violations outside this diff

Fixes #1395

Assisted-by: Codex