### PR TITLE
test(cli): cover the prompt sub-app in the canonical command smoke matrix

### DIFF
--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -433,7 +433,7 @@ def test_cli_inventory_grouped_from_source():
         assert inventory["context"] == {"list", "create", "delete", "mode", "default"}
 
 
-def test_all_canonical_cli_commands_run_with_kuzudb(kuzudb_env, cli_test_stubs):
+def test_all_canonical_cli_commands_run_with_kuzudb(kuzudb_env, cli_test_stubs, tmp_path):
     bundle_file = str(cli_test_stubs["bundle_file"])
     bundle_export = str(cli_test_stubs["bundle_export"])
 
@@ -520,6 +520,19 @@ def test_all_canonical_cli_commands_run_with_kuzudb(kuzudb_env, cli_test_stubs):
                 ["datasource", "mysql", "--host", "localhost", "--user", "root", "--password", "pw", "--database", "demo"],
                 ["datasource", "cassandra", "--host", "localhost", "--keyspace", "demo"],
                 ["datasource", "redis", "--host", "localhost"],
+            ]
+        )
+    if "prompt" in source_inventory:
+        # The prompt sub-app was added without matrix entries, so this test —
+        # which asserts every command in the source inventory is smoke-tested —
+        # has been failing on main. `add` and `remove` take a path argument.
+        prompt_file = tmp_path / "ci-prompt.md"
+        prompt_file.write_text("# ci prompt\n", encoding="utf-8")
+        command_matrix.extend(
+            [
+                ["prompt", "list"],
+                ["prompt", "add", str(prompt_file)],
+                ["prompt", "remove", str(prompt_file)],
             ]
         )
 


### PR DESCRIPTION
Fixes the last remaining `Build Test` failure on `main`.

`test_all_canonical_cli_commands_run_with_kuzudb` asserts that **every** command discovered in `main.py` is exercised by the smoke matrix. The `prompt` sub-app (`add` / `list` / `remove`) was added without corresponding matrix entries:

```
Extra items in the right set:
('prompt', 'list')
('prompt', 'remove')
('prompt', 'add')
```

**Pre-existing, not from the audit-fix batch** — confirmed by checking out `6be7627` (main immediately before those merges) and reproducing it there.

Adds the three entries. `add` and `remove` take a path argument, so the test writes a throwaway prompt file under `tmp_path` (added to the test signature; `cli_test_stubs` already uses the same fixture).

```
tests/integration/cli/test_cli_commands.py  ->  17 passed
tests/unit + tests/integration/cli          ->  918 passed, 7 skipped, 0 failed
```

With this and #1428, `Build Test` should be green on `main`.