### PR TITLE
fix(watcher): preserve indexed files during Windows disk sync

### DIFF
--- a/src/codegraphcontext/core/watcher.py
+++ b/src/codegraphcontext/core/watcher.py
@@ -151,7 +151,7 @@ class RepositoryEventHandler(FileSystemEventHandler):
         info_logger(f"Syncing: {self.repo_path}")
 
         current_files = self._iter_supported_files()
-        current_paths = {str(p.resolve()) for p in current_files}
+        current_paths = {p.resolve().as_posix() for p in current_files}
         indexed = self.graph_builder.get_repo_file_paths(self.repo_path)
 
         self.imports_map = self.graph_builder.pre_scan_imports(current_files)

--- a/tests/unit/core/test_watcher_startup_sync.py
+++ b/tests/unit/core/test_watcher_startup_sync.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
@@ -59,6 +59,31 @@ def test_startup_sync_reconciles_current_and_deleted_files(tmp_path: Path):
     assert set(graph_builder.delete_inherits_for_files.call_args.args[0]) == refreshed_paths
     graph_builder.link_function_calls.assert_called_once()
     graph_builder.link_inheritance.assert_called_once()
+
+
+def test_startup_sync_does_not_delete_windows_paths_that_are_still_on_disk(tmp_path: Path):
+    class WindowsFilePath:
+        def __init__(self, path: str):
+            self.path = PureWindowsPath(path)
+
+        def resolve(self) -> PureWindowsPath:
+            return self.path
+
+    current_file = WindowsFilePath("C:/repo/src/app.py")
+    graph_builder = MagicMock()
+    graph_builder.get_repo_file_paths.return_value = {"C:/repo/src/app.py"}
+    graph_builder.pre_scan_imports.return_value = {}
+    graph_builder.update_file_in_graph.return_value = None
+
+    handler = RepositoryEventHandler.__new__(RepositoryEventHandler)
+    handler.repo_path = tmp_path
+    handler.graph_builder = graph_builder
+    handler.imports_map = {}
+
+    with patch.object(RepositoryEventHandler, "_iter_supported_files", return_value=[current_file]):
+        handler.synchronize_with_disk()
+
+    graph_builder.delete_file_from_graph.assert_not_called()
 
 
 def test_code_watcher_forwards_startup_sync_option(tmp_path: Path):


### PR DESCRIPTION
## Summary
- normalize discovered file paths to POSIX form before comparing them with graph paths
- prevent Windows path separators from causing every indexed file to be treated as stale
- add a regression test covering the normalized graph path contract

Fixes #1394

## Tests
- `PYTHONPATH=src .venv/bin/pytest tests/unit/core/test_watcher_startup_sync.py tests/unit/core/test_watcher_cgcignore.py tests/unit/core/test_watcher_polling_observer.py -q`
- `.venv/bin/ruff check tests/unit/core/test_watcher_startup_sync.py`
- `git diff --check`

Note: `ruff check src/codegraphcontext/core/watcher.py` still reports two unrelated pre-existing unused imports.