### PR TITLE
fix(falkordb): scope failed startup to its database context

### DIFF
--- a/src/codegraphcontext/core/__init__.py
+++ b/src/codegraphcontext/core/__init__.py
@@ -20,7 +20,9 @@ from pathlib import Path
 from typing import Union, Optional
 import importlib.util
 
-# Set when FalkorDB Lite fails in-process so we skip repeated startup/retry storms.
+# Retained for compatibility with callers that inspect this module attribute.
+# FalkorDB startup failures are now tracked by FalkorDBManager per database
+# configuration, rather than disabling the backend for the whole process.
 _FALKORDB_DISABLED = False
 
 
@@ -49,14 +51,12 @@ def _fallback_db_path_for(db_path: Optional[str], target_backend: str) -> Option
 
 
 def mark_falkordb_unavailable() -> None:
-    """Remember that FalkorDB Lite cannot run in this process."""
-    global _FALKORDB_DISABLED
-    _FALKORDB_DISABLED = True
+    """Compatibility hook; startup failures are scoped by FalkorDBManager."""
 
 
 def is_falkordb_usable() -> bool:
-    """True when FalkorDB Lite is installed and has not failed this session."""
-    return _is_falkordb_available() and not _FALKORDB_DISABLED
+    """True when FalkorDB Lite is available on this system."""
+    return _is_falkordb_available()
 
 def _is_kuzudb_available() -> bool:
     """Check if KùzuDB is installed."""
@@ -142,10 +142,7 @@ def get_database_manager(db_path: Optional[str] = None) -> Union['DatabaseManage
 
         elif db_type == 'falkordb':
             if not is_falkordb_usable():
-                if _FALKORDB_DISABLED:
-                    info_logger("FalkorDB Lite disabled for this process after earlier failure. Falling back to an available backend.")
-                else:
-                    info_logger("FalkorDB Lite is not supported or not installed. Falling back to an available backend.")
+                info_logger("FalkorDB Lite is not supported or not installed. Falling back to an available backend.")
                 if _is_kuzudb_available():
                     from .database_kuzu import KuzuDBManager
                     return KuzuDBManager(db_path=_fallback_db_path_for(db_path, 'kuzudb'))

--- a/src/codegraphcontext/core/database_falkordb.py
+++ b/src/codegraphcontext/core/database_falkordb.py
@@ -81,7 +81,7 @@ class FalkorDBManager:
     _driver = None
     _graphs = {}
     _lock = threading.Lock()
-    _startup_failed = False
+    _failed_configurations: set[tuple[str, str]] = set()
     _STARTUP_TIMEOUT_SEC = 5
 
     def __new__(cls, *args, **kwargs):
@@ -123,6 +123,9 @@ class FalkorDBManager:
             return
 
         if hasattr(self, '_initialized') and getattr(self, 'db_path', None) != new_db_path:
+            previous_configuration = getattr(self, '_configuration_key', None)
+            if previous_configuration is not None:
+                FalkorDBManager._failed_configurations.discard(previous_configuration)
             self.shutdown()
             self._driver = None
             self._graph = None
@@ -144,6 +147,7 @@ class FalkorDBManager:
                 config_socket_path or str(Path.home() / '.codegraphcontext' / 'global' / 'falkordb.sock')
             )
         self.socket_path = os.path.abspath(self.socket_path)
+        self._configuration_key = (self.db_path, self.socket_path)
         
         self.graph_name = os.getenv('FALKORDB_GRAPH_NAME', 'codegraph')
         self._initialized = True
@@ -166,9 +170,9 @@ class FalkorDBManager:
         import platform
         graph_name = graph_name or self.graph_name
 
-        if FalkorDBManager._startup_failed:
+        if self._configuration_key in FalkorDBManager._failed_configurations:
             raise FalkorDBUnavailableError(
-                "FalkorDB Lite previously failed to start in this process."
+                "FalkorDB Lite previously failed to start for this database configuration."
             )
 
         if platform.system() == "Windows":
@@ -236,10 +240,10 @@ class FalkorDBManager:
                         )
                         raise ValueError("FalkorDB client missing.") from e
                     except FalkorDBUnavailableError:
-                        FalkorDBManager._startup_failed = True
+                        FalkorDBManager._failed_configurations.add(self._configuration_key)
                         raise
                     except Exception as e:
-                        FalkorDBManager._startup_failed = True
+                        FalkorDBManager._failed_configurations.add(self._configuration_key)
                         error_logger(f"Failed to initialize FalkorDB: {e}")
                         raise
 
@@ -421,6 +425,7 @@ class FalkorDBManager:
             self._graphs = {}
         if teardown:
             self.shutdown()
+            FalkorDBManager._failed_configurations.discard(self._configuration_key)
 
     def shutdown(self):
         """Kills the subprocess on exit."""

--- a/tests/unit/core/test_database_falkordb_wrapper.py
+++ b/tests/unit/core/test_database_falkordb_wrapper.py
@@ -1,6 +1,12 @@
 from unittest.mock import MagicMock
 
-from codegraphcontext.core.database_falkordb import FalkorDBSessionWrapper
+import pytest
+
+from codegraphcontext.core.database_falkordb import (
+    FalkorDBManager,
+    FalkorDBSessionWrapper,
+    FalkorDBUnavailableError,
+)
 
 
 def test_run_translates_single_unique_constraint_to_graph_constraint():
@@ -58,3 +64,56 @@ def test_run_keeps_regular_queries_on_graph_query():
 
     graph.query.assert_called_once()
     graph.execute_command.assert_not_called()
+
+
+def test_startup_failure_for_one_path_does_not_disable_another_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(FalkorDBManager, "_instance", None)
+    monkeypatch.setattr(FalkorDBManager, "_process", None)
+    monkeypatch.setattr(FalkorDBManager, "_driver", None)
+    monkeypatch.setattr(FalkorDBManager, "_graphs", {})
+    monkeypatch.setattr(FalkorDBManager, "_failed_configurations", set())
+
+    unavailable = FalkorDBManager(db_path=str(tmp_path / "unavailable" / "falkordb.db"))
+    monkeypatch.setattr(
+        unavailable,
+        "_ensure_server_running",
+        MagicMock(side_effect=FalkorDBUnavailableError("test startup failure")),
+    )
+
+    with pytest.raises(FalkorDBUnavailableError, match="test startup failure"):
+        unavailable.get_driver()
+
+    available = FalkorDBManager(db_path=str(tmp_path / "available" / "falkordb.db"))
+    graph = MagicMock()
+    available._driver = MagicMock()
+    available._graphs = {available.graph_name: graph}
+
+    assert available.get_driver().graph is graph
+
+
+def test_factory_retries_falkordb_for_a_different_database_path(monkeypatch):
+    from codegraphcontext import core
+    from codegraphcontext.core import database_falkordb, database_kuzu
+
+    class FallbackKuzuManager:
+        def __init__(self, db_path):
+            self.db_path = db_path
+
+    class PathScopedFalkorManager:
+        def __init__(self, db_path):
+            self.db_path = db_path
+
+        def get_driver(self):
+            if self.db_path == "/repo/failed/falkordb":
+                raise FalkorDBUnavailableError("test startup failure")
+
+    monkeypatch.setenv("DEFAULT_DATABASE", "falkordb")
+    monkeypatch.delenv("CGC_RUNTIME_DB_TYPE", raising=False)
+    monkeypatch.setattr(core, "_FALKORDB_DISABLED", False)
+    monkeypatch.setattr(core, "_is_falkordb_available", lambda: True)
+    monkeypatch.setattr(core, "_is_kuzudb_available", lambda: True)
+    monkeypatch.setattr(database_falkordb, "FalkorDBManager", PathScopedFalkorManager)
+    monkeypatch.setattr(database_kuzu, "KuzuDBManager", FallbackKuzuManager)
+
+    assert isinstance(core.get_database_manager("/repo/failed/falkordb"), FallbackKuzuManager)
+    assert isinstance(core.get_database_manager("/repo/working/falkordb"), PathScopedFalkorManager)


### PR DESCRIPTION
## Summary
- track FalkorDB startup failures by `(db_path, socket_path)` instead of poisoning the process globally
- allow a later context with a distinct database path to initialize FalkorDB normally
- clear a failed context when it is torn down or replaced during a context switch
- add direct-manager and factory regression coverage

Fixes #1388

## Tests
- `PYTHONPATH=src .venv/bin/pytest tests/unit/core/test_database_falkordb_wrapper.py tests/unit/core/test_database_falkordb_remote.py tests/unit/tools/test_falkordb_kuzu_session_kwargs.py tests/unit/tools/test_falkordb_schema_and_watcher_fixes.py -q`
- `.venv/bin/ruff check tests/unit/core/test_database_falkordb_wrapper.py`
- `git diff --check`

Note: full Ruff checks on the two modified core modules report pre-existing errors (undefined lazy type references, imports after a class docstring, and unused imports).