### PR TITLE
fix(falkordb): save the embedded database on shutdown

### DIFF
--- a/src/codegraphcontext/core/database_falkordb.py
+++ b/src/codegraphcontext/core/database_falkordb.py
@@ -423,10 +423,18 @@ class FalkorDBManager:
             self.shutdown()
 
     def shutdown(self):
-        """Kills the subprocess on exit."""
+        """Persist and stop the embedded server before terminating its worker."""
         if self._process:
             if self._process.poll() is None:
                 info_logger("Stopping FalkorDB subprocess...")
+                try:
+                    from redis import Redis
+
+                    Redis(unix_socket_path=self.socket_path).shutdown(save=True)
+                except Exception as exc:
+                    # Redis closes the control connection after accepting SHUTDOWN;
+                    # worker termination remains the fallback if that did not happen.
+                    info_logger(f"FalkorDB shutdown command did not return cleanly: {exc}")
                 self._process.terminate()
                 try:
                     self._process.wait(timeout=5)

--- a/src/codegraphcontext/core/falkor_worker.py
+++ b/src/codegraphcontext/core/falkor_worker.py
@@ -23,6 +23,11 @@ db_instance = None
 
 def handle_signal(signum, frame):
     logger.info(f"Received signal {signum}. Stopping FalkorDB worker...")
+    if db_instance is not None:
+        try:
+            db_instance.shutdown(save=True)
+        except Exception as exc:
+            logger.warning(f"Could not save FalkorDB before shutdown: {exc}")
     sys.exit(0)
 
 def get_falkordb_port():

--- a/tests/unit/core/test_falkordb_shutdown.py
+++ b/tests/unit/core/test_falkordb_shutdown.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.core import falkor_worker
+from codegraphcontext.core.database_falkordb import FalkorDBManager
+
+
+def test_worker_signal_saves_embedded_database_before_exiting(monkeypatch):
+    database = MagicMock()
+    monkeypatch.setattr(falkor_worker, "db_instance", database)
+
+    with pytest.raises(SystemExit) as exc_info:
+        falkor_worker.handle_signal(15, None)
+
+    assert exc_info.value.code == 0
+    database.shutdown.assert_called_once_with(save=True)
+
+
+def test_manager_shutdown_saves_server_before_terminating_worker(monkeypatch):
+    import redis
+
+    manager = object.__new__(FalkorDBManager)
+    manager.socket_path = "/tmp/falkordb.sock"
+    manager._process = MagicMock()
+    manager._process.poll.return_value = None
+    redis_client = MagicMock()
+    redis_client.shutdown.side_effect = redis.ConnectionError("server closed connection")
+    monkeypatch.setattr(redis, "Redis", MagicMock(return_value=redis_client))
+
+    manager.shutdown()
+
+    redis.Redis.assert_called_once_with(unix_socket_path="/tmp/falkordb.sock")
+    redis_client.shutdown.assert_called_once_with(save=True)
+    manager._process.terminate.assert_called_once()


### PR DESCRIPTION
## Summary
- send `SHUTDOWN SAVE` over FalkorDB Lite’s Unix socket before terminating its worker
- make the worker’s signal handler explicitly call redislite `shutdown(save=True)`
- retain worker termination as a fallback if the shutdown connection closes early
- add regressions for both parent and worker shutdown paths

Fixes #1389

## Tests
- `PYTHONPATH=src .venv/bin/pytest tests/unit/core/test_falkordb_shutdown.py tests/unit/core/test_database_falkordb_wrapper.py tests/unit/core/test_database_falkordb_remote.py tests/unit/tools/test_falkordb_kuzu_session_kwargs.py tests/unit/tools/test_falkordb_schema_and_watcher_fixes.py -q`
- `.venv/bin/ruff check tests/unit/core/test_falkordb_shutdown.py`
- `git diff --check`

Note: full Ruff checks on `database_falkordb.py` report existing unrelated lint violations.