### PR TITLE
fix(falkordb): isolate embedded contexts by port

### DIFF
--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -87,6 +87,8 @@ DEFAULT_CONFIG = {
     "DEFAULT_DATABASE": "falkordb",
     "FALKORDB_PATH": str(CONFIG_DIR / "global" / "db" / "falkordb"),
     "FALKORDB_SOCKET_PATH": str(CONFIG_DIR / "global" / "db" / "falkordb.sock"),
+    # Empty selects a deterministic port derived from each embedded DB socket.
+    "FALKORDB_PORT": "",
     "LADYBUGDB_PATH": str(CONFIG_DIR / "global" / "db" / "ladybugdb"),
     "KUZUDB_PATH": str(CONFIG_DIR / "global" / "db" / "kuzudb"),
     "INDEX_VARIABLES": "true",
@@ -142,6 +144,7 @@ CONFIG_DESCRIPTIONS = {
     "DEFAULT_DATABASE": "Default database backend (neo4j|falkordb|falkordb-remote|kuzudb|nornic|ladybugdb)",
     "FALKORDB_PATH": "Path to FalkorDB database file",
     "FALKORDB_SOCKET_PATH": "Path to FalkorDB Unix socket",
+    "FALKORDB_PORT": "Optional FalkorDB port override (empty = per-database port)",
     "LADYBUGDB_PATH": "Path to LadybugDB database directory",
     "KUZUDB_PATH": "Path to KuzuDB database directory",
     "INDEX_VARIABLES": "Index variable nodes in the graph (lighter graph if false)",

--- a/src/codegraphcontext/core/database_falkordb.py
+++ b/src/codegraphcontext/core/database_falkordb.py
@@ -290,9 +290,7 @@ class FalkorDBManager:
                     pass
 
         # 2. Start Subprocess
-        env = os.environ.copy()
-        env['FALKORDB_PATH'] = self.db_path
-        env['FALKORDB_SOCKET_PATH'] = self.socket_path
+        env = self._build_worker_environment()
         
         # Determine python executable
         python_exe = sys.executable
@@ -405,6 +403,18 @@ class FalkorDBManager:
         raise FalkorDBUnavailableError(
             f"Timed out waiting for FalkorDB Lite to start. Last error: {last_error}"
         )
+
+    def _build_worker_environment(self) -> dict[str, str]:
+        """Pass a deterministic, per-context port to the FalkorDB worker."""
+        from .falkor_worker import get_falkordb_port
+        from codegraphcontext.cli.config_manager import get_config_value
+
+        env = os.environ.copy()
+        env["FALKORDB_PATH"] = self.db_path
+        env["FALKORDB_SOCKET_PATH"] = self.socket_path
+        configured_port = os.getenv("FALKORDB_PORT") or get_config_value("FALKORDB_PORT")
+        env["FALKORDB_PORT"] = configured_port or str(get_falkordb_port(self.socket_path))
+        return env
 
     def list_graphs(self):
         """Return names of all graphs in this FalkorDB instance."""

--- a/src/codegraphcontext/core/falkor_worker.py
+++ b/src/codegraphcontext/core/falkor_worker.py
@@ -3,6 +3,7 @@ import sys
 import os
 import time
 import signal
+import hashlib
 from pathlib import Path
 import logging
 import socket
@@ -25,14 +26,21 @@ def handle_signal(signum, frame):
     logger.info(f"Received signal {signum}. Stopping FalkorDB worker...")
     sys.exit(0)
 
-def get_falkordb_port():
-    return int(os.getenv("FALKORDB_PORT", "6379"))
+def get_falkordb_port(socket_path: str | None = None) -> int:
+    """Return an explicit port or a stable port unique to a Unix socket path."""
+    configured_port = os.getenv("FALKORDB_PORT")
+    if configured_port:
+        return int(configured_port)
+    if socket_path:
+        digest = hashlib.sha256(socket_path.encode("utf-8")).digest()
+        return 20_000 + int.from_bytes(digest[:4], "big") % 20_000
+    return 6379
 
 def run_worker():
 
     db_path = os.getenv('FALKORDB_PATH')
     socket_path = os.getenv('FALKORDB_SOCKET_PATH')
-    port = get_falkordb_port()
+    port = get_falkordb_port(socket_path)
 
     global db_instance
     

--- a/tests/unit/core/test_falkordb_port_selection.py
+++ b/tests/unit/core/test_falkordb_port_selection.py
@@ -1,0 +1,37 @@
+from codegraphcontext.core.falkor_worker import get_falkordb_port
+from codegraphcontext.core.database_falkordb import FalkorDBManager
+from codegraphcontext.cli.config_manager import DEFAULT_CONFIG
+
+
+def test_falkordb_port_is_stable_and_distinct_for_each_socket(monkeypatch):
+    monkeypatch.delenv("FALKORDB_PORT", raising=False)
+
+    first = get_falkordb_port("/tmp/one/falkordb.sock")
+    second = get_falkordb_port("/tmp/two/falkordb.sock")
+
+    assert 20_000 <= first < 40_000
+    assert first == get_falkordb_port("/tmp/one/falkordb.sock")
+    assert first != second
+
+
+def test_falkordb_port_honors_explicit_override(monkeypatch):
+    monkeypatch.setenv("FALKORDB_PORT", "16379")
+
+    assert get_falkordb_port("/tmp/one/falkordb.sock") == 16_379
+
+
+def test_manager_forwards_its_socket_specific_port_to_worker(monkeypatch):
+    monkeypatch.delenv("FALKORDB_PORT", raising=False)
+    manager = object.__new__(FalkorDBManager)
+    manager.db_path = "/tmp/one/falkordb"
+    manager.socket_path = "/tmp/one/falkordb.sock"
+
+    worker_env = manager._build_worker_environment()
+
+    assert worker_env["FALKORDB_PATH"] == manager.db_path
+    assert worker_env["FALKORDB_SOCKET_PATH"] == manager.socket_path
+    assert worker_env["FALKORDB_PORT"] == str(get_falkordb_port(manager.socket_path))
+
+
+def test_falkordb_port_is_an_exposed_optional_configuration():
+    assert DEFAULT_CONFIG["FALKORDB_PORT"] == ""


### PR DESCRIPTION
## Summary
- derive a stable embedded FalkorDB port from each context’s Unix socket path
- forward that port from the manager to its worker
- preserve explicit `FALKORDB_PORT` overrides
- expose the optional port setting in the configuration reference
- add regression coverage for port selection and worker environment propagation

Fixes #1387

## Tests
- `PYTHONPATH=src .venv/bin/pytest tests/unit/core/test_falkordb_port_selection.py tests/unit/core/test_database_falkordb_wrapper.py tests/unit/core/test_database_falkordb_remote.py tests/unit/tools/test_falkordb_kuzu_session_kwargs.py tests/unit/tools/test_falkordb_schema_and_watcher_fixes.py tests/unit/cli/test_model_defaults.py tests/unit/cli/test_bug001_config_override.py -q`
- `.venv/bin/ruff check tests/unit/core/test_falkordb_port_selection.py`
- `git diff --check`

Note: full Ruff checks on modified source modules report existing unrelated violations.