### PR TITLE
ci(docker): publish to GHCR when Docker Hub credentials are absent

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,40 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # The `secrets` context cannot be used in a step-level `if`, so probe the
+      # credentials once here and gate the Docker Hub steps on this output.
+      # Without it the whole workflow failed at "Log in to Docker Hub" with
+      # "Username and password required" on every push to main, taking the
+      # GHCR publish down with it.
+      - name: Detect Docker Hub credentials
+        id: cfg
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "has_dockerhub=true" >> "$GITHUB_OUTPUT"
+            # Multi-line outputs need the heredoc form; the old %0A escape only
+            # worked with the deprecated ::set-output command.
+            {
+              echo "images<<CGC_EOF"
+              echo "${{ env.DOCKERHUB_IMAGE }}"
+              echo "${{ env.GHCR_IMAGE }}"
+              echo "CGC_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "primary_image=${{ env.DOCKERHUB_IMAGE }}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docker Hub credentials found; publishing to Docker Hub and GHCR."
+          else
+            echo "has_dockerhub=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "images<<CGC_EOF"
+              echo "${{ env.GHCR_IMAGE }}"
+              echo "CGC_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "primary_image=${{ env.GHCR_IMAGE }}" >> "$GITHUB_OUTPUT"
+            echo "::warning::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not configured; publishing to GHCR only."
+          fi
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -32,7 +66,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.cfg.outputs.has_dockerhub == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -50,9 +84,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.DOCKERHUB_IMAGE }}
-            ${{ env.GHCR_IMAGE }}
+          images: ${{ steps.cfg.outputs.images }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -81,13 +113,13 @@ jobs:
       - name: Test Docker image
         if: github.event_name != 'pull_request'
         run: |
-          docker run --rm ${{ env.DOCKERHUB_IMAGE }}:${{ steps.meta.outputs.version }} cgc --version
+          docker run --rm ${{ steps.cfg.outputs.primary_image }}:${{ steps.meta.outputs.version }} cgc --version
 
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.DOCKERHUB_IMAGE }}
+          subject-name: ${{ steps.cfg.outputs.primary_image }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 


### PR DESCRIPTION
`Docker Build & Publish` has failed on **every** push to `main`. The cause is one step:

```
##[error]Username and password required
   step: Log in to Docker Hub
```

`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` are not configured for this repository. Because the login ran unconditionally, the job aborted there — taking down the **GHCR** publish, the image smoke test and the provenance attestation with it, even though GHCR authenticates with the built-in `GITHUB_TOKEN` and needs no extra secret.

## Fix

The `secrets` context is **not available in a step-level `if`**, so the credentials are probed once in a new step that exposes outputs:

```yaml
- name: Detect Docker Hub credentials
  id: cfg
  env:
    DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
    DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
```

- Docker Hub login is gated on `steps.cfg.outputs.has_dockerhub == 'true'`
- `docker/metadata-action` tags only the registries we can actually push to
- the smoke test and attestation follow `primary_image`

Verified both branches by simulating the step:

```
creds absent   -> has_dockerhub=false   images = ghcr.io/…            (+ ::warning::)
creds present  -> has_dockerhub=true    images = dockerhub + ghcr.io
```

**Behaviour is unchanged once the secrets are added** — both images tagged and pushed exactly as before. Until then the job publishes to GHCR and emits a warning instead of failing.

Multi-line outputs use the heredoc form; the `%0A` escape only worked with the deprecated `::set-output` command. YAML validated with `yaml.safe_load`.

## Note

This makes the job *pass*, but it doesn't publish to Docker Hub — that still needs the two secrets adding in repo settings. The `::warning::` makes that visible rather than silent.