### PR TITLE
ci(docker): lowercase the GHCR image name in the smoke test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,12 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
+          # Container registries reject uppercase in image names, and
+          # ${{ github.repository }} is "CodeGraphContext/CodeGraphContext".
+          # docker/metadata-action lowercases its own tags, so the pushed image
+          # is ghcr.io/codegraphcontext/... — anything we reference by hand has
+          # to be lowercased too or `docker run` fails with exit 125.
+          GHCR_LC=$(echo "${{ env.GHCR_IMAGE }}" | tr '[:upper:]' '[:lower:]')
           if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
             echo "has_dockerhub=true" >> "$GITHUB_OUTPUT"
             # Multi-line outputs need the heredoc form; the old %0A escape only
@@ -43,7 +49,7 @@ jobs:
             {
               echo "images<<CGC_EOF"
               echo "${{ env.DOCKERHUB_IMAGE }}"
-              echo "${{ env.GHCR_IMAGE }}"
+              echo "$GHCR_LC"
               echo "CGC_EOF"
             } >> "$GITHUB_OUTPUT"
             echo "primary_image=${{ env.DOCKERHUB_IMAGE }}" >> "$GITHUB_OUTPUT"
@@ -52,10 +58,10 @@ jobs:
             echo "has_dockerhub=false" >> "$GITHUB_OUTPUT"
             {
               echo "images<<CGC_EOF"
-              echo "${{ env.GHCR_IMAGE }}"
+              echo "$GHCR_LC"
               echo "CGC_EOF"
             } >> "$GITHUB_OUTPUT"
-            echo "primary_image=${{ env.GHCR_IMAGE }}" >> "$GITHUB_OUTPUT"
+            echo "primary_image=$GHCR_LC" >> "$GITHUB_OUTPUT"
             echo "::warning::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not configured; publishing to GHCR only."
           fi
 


### PR DESCRIPTION
Follow-up to #1437, fixing a bug **I introduced** there.

#1437 got the workflow past the Docker Hub login — the image now builds and **pushes to GHCR successfully** — but the next step failed:

```
Run docker run --rm ghcr.io/CodeGraphContext/CodeGraphContext:main cgc --version
##[error]Process completed with exit code 125
```

Container registries reject uppercase in image names, and `${{ github.repository }}` is `CodeGraphContext/CodeGraphContext`. `docker/metadata-action` lowercases its own tags — the same run log shows it pushed `ghcr.io/codegraphcontext/codegraphcontext:main` — but the `primary_image` output I added in #1437 carried the raw mixed-case value straight into `docker run`.

Fix: lowercase `GHCR_IMAGE` once, use it for both the metadata image list and `primary_image`. The Docker Hub image is already a lowercase literal, so that branch is unaffected.

Step status from the #1437 run, for context — everything up to the smoke test is now working:

```
success  Detect Docker Hub credentials
skipped  Log in to Docker Hub            <- correctly skipped, secrets absent
success  Log in to GitHub Container Registry
success  Extract metadata (tags, labels) for Docker
success  Build and push Docker image     <- pushed to GHCR
failure  Test Docker image               <- this PR
```