### PR TITLE
ci(docker): gate the Docker Hub description update on credentials too

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -129,8 +129,11 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+      # Needs the Docker Hub credentials; without them peter-evans/
+      # dockerhub-description fails with "Required input 'username' is missing"
+      # and takes the whole job red even though the image published fine.
       - name: Update Docker Hub Description
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && steps.cfg.outputs.has_dockerhub == 'true'
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Third step in this workflow that needs the Docker Hub secrets, and the last one.

```
Run peter-evans/dockerhub-description@v4
Error: Required input 'username' is missing.
```

It was masked until now: in the #1437 run this step showed as `skipped`, but only because "Test Docker image" failed ahead of it. #1438 fixed that, so execution finally reached it — and it failed for exactly the same missing-secret reason as the original login.

Gated on `steps.cfg.outputs.has_dockerhub`, same as the login step.

## Why this took three PRs, and why it stops here

I fixed the symptom I could see each time instead of auditing the whole file up front. So this time I parsed the workflow and checked every step that references `secrets.DOCKERHUB` for a guard:

```
       Checkout repository
       Detect Docker Hub credentials
       Set up QEMU
       Set up Docker Buildx
GATED  Log in to Docker Hub
       Log in to GitHub Container Registry
       Extract metadata (tags, labels) for Docker
       Build and push Docker image
       Test Docker image
       Generate artifact attestation
GATED  Update Docker Hub Description

ungated steps still needing Docker Hub secrets: NONE
```

`Test Docker image` and `Generate artifact attestation` reference `primary_image`, which resolves to the lowercase GHCR image when Docker Hub is unconfigured, so they need no gate.

## Unrelated warnings in that log

Both are informational, not failures, and neither is worth chasing now:

- `Node 20 is being deprecated. This workflow is running with Node 24 by default.` — no action needed unless an action pins Node 20.
- `[DEP0040] punycode module is deprecated` — from a transitive dependency inside the action.