### PR TITLE
test(parity): print the differing CALLS edges in the CI output

### DIFF
--- a/tests/e2e/test_verify_databases_parity.py
+++ b/tests/e2e/test_verify_databases_parity.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Tuple, Dict
 
 # We run indexing as a subprocess to keep PyBind11 namespace and database environments isolated
-async def run_indexing_in_process(db_type: str, project_path: Path, temp_test_dir: Path) -> Tuple[float, Dict[str, int]]:
+async def run_indexing_in_process(db_type: str, project_path: Path, temp_test_dir: Path) -> Tuple[float, Dict[str, int], list]:
     print(f"\n================= RUNNING {db_type.upper()} INDEXING IN SUBPROCESS =================")
     
     db_path = (temp_test_dir / f"{db_type}_test_db").as_posix()
@@ -81,8 +81,35 @@ async def run():
             res = session.run(f"MATCH ()-[r:`{{rel}}`]->() RETURN count(r)")
             stats[f"REL_{{rel}}"] = res.single()[0]
             
+        # Diagnostic: dump the CALLS edge set so a REL_CALLS mismatch can be
+        # attributed to specific edges instead of just a count. Keys are stable
+        # across backends (source paths, not internal node ids).
+        calls_edges = []
+        try:
+            res = session.run(
+                "MATCH (caller)-[r:`CALLS`]->(callee) "
+                "RETURN caller.name AS cn, caller.path AS cp, caller.line_number AS cl, "
+                "callee.name AS en, callee.path AS ep, callee.line_number AS el, "
+                "r.line_number AS rl"
+            )
+            base = str(project_path)
+            for rec in res:
+                d = dict(rec)
+                def _rel(v):
+                    v = "" if v is None else str(v)
+                    return v[len(base):].lstrip("/") if v.startswith(base) else v
+                calls_edges.append(
+                    f"{{_rel(d.get('cp'))}}:{{d.get('cn')}}@{{d.get('cl')}}"
+                    f" -> {{_rel(d.get('ep'))}}:{{d.get('en')}}@{{d.get('el')}}"
+                    f" [call_line={{d.get('rl')}}]"
+                )
+        except Exception as _e:
+            calls_edges = ["<edge dump failed: " + str(_e) + ">"]
+
     db_mgr.close_driver()
+    stats["REL_CALLS_DISTINCT"] = len(set(calls_edges))
     print("STATS_JSON:" + json.dumps(stats))
+    print("CALLS_EDGES_JSON:" + json.dumps(calls_edges))
 
 async def main():
     try:
@@ -116,12 +143,14 @@ asyncio.run(main())
         
     # Extract stats from stdout
     stats = {}
+    calls_edges = []
     for line in stdout.decode().splitlines():
         if line.startswith("STATS_JSON:"):
             stats = json.loads(line[len("STATS_JSON:"):])
-            break
-            
-    return duration, stats
+        elif line.startswith("CALLS_EDGES_JSON:"):
+            calls_edges = json.loads(line[len("CALLS_EDGES_JSON:"):])
+
+    return duration, stats, calls_edges
 
 
 @pytest.mark.e2e
@@ -146,10 +175,11 @@ async def _run_database_parity_e2e(temp_test_dir):
     
     for db_type in db_types:
         try:
-            duration, stats = await run_indexing_in_process(db_type, project_path, temp_test_dir)
+            duration, stats, calls_edges = await run_indexing_in_process(db_type, project_path, temp_test_dir)
             results[db_type] = {
                 "duration": duration,
-                "stats": stats
+                "stats": stats,
+                "calls_edges": calls_edges,
             }
         except Exception as e:
             if db_type == "neo4j" and "failed to connect" in str(e).lower():
@@ -161,7 +191,10 @@ async def _run_database_parity_e2e(temp_test_dir):
     print(f"{'Metric':<25} | {'KuzuDB':<8} | {'LadybugDB':<9} | {'FalkorDB':<8} | {'Neo4j':<8} | Match?")
     print("-" * 78)
     
-    keys_to_compare = sorted(list(results["neo4j"]["stats"].keys()))
+    # REL_CALLS_DISTINCT is a diagnostic, not a parity metric.
+    keys_to_compare = sorted(
+        k for k in results["neo4j"]["stats"].keys() if k != "REL_CALLS_DISTINCT"
+    )
     # Some relationship resolvers dedupe differently across embedded backends.
     # REL_CALLS: KuzuDB/LadybugDB may drop ≤1 edge when the Neo4j fast/slow MATCH
     # split cannot bind an exact called_line_number (binder/UNWIND fallback).
@@ -186,5 +219,53 @@ async def _run_database_parity_e2e(temp_test_dir):
         
     print("-" * 78)
     print(f"{'Indexing Duration (s)':<25} | {results['kuzudb']['duration']:<8.2f} | {results['ladybugdb']['duration']:<9.2f} | {results['falkordb']['duration']:<8.2f} | {results['neo4j']['duration']:<8.2f} | -")
-    
+
+    _report_calls_edge_diff(results, db_types)
+
     assert all_match, "❌ Database statistics do not match!"
+
+
+def _report_calls_edge_diff(results, db_types):
+    """Print which specific CALLS edges differ between backends.
+
+    REL_CALLS is the only metric that drifts between backends, and a bare count
+    cannot distinguish "this backend dropped an edge" from "that backend wrote a
+    duplicate". This prints, per backend: total vs distinct edges (a gap means
+    duplicates, which Neo4j can produce because the writer uses CREATE rather
+    than MERGE there), and the edges unique to each backend relative to the
+    union across all of them.
+    """
+    edge_sets = {
+        db: set(results.get(db, {}).get("calls_edges") or [])
+        for db in db_types
+    }
+    if not any(edge_sets.values()):
+        print("\n[CALLS DIAG] no edge data captured.")
+        return
+
+    print("\n================= CALLS EDGE DIAGNOSTICS =================")
+    for db in db_types:
+        raw = results.get(db, {}).get("calls_edges") or []
+        dupes = len(raw) - len(set(raw))
+        print(f"{db:<12} total={len(raw):<6} distinct={len(set(raw)):<6} duplicates={dupes}")
+
+    union = set().union(*edge_sets.values())
+    common = set.intersection(*edge_sets.values()) if all(edge_sets.values()) else set()
+    print(f"\nunion={len(union)}  common-to-all={len(common)}  differing={len(union) - len(common)}")
+
+    for db in db_types:
+        missing = sorted(union - edge_sets[db])
+        extra = sorted(edge_sets[db] - common) if common else []
+        if missing:
+            print(f"\n--- MISSING from {db} ({len(missing)}) ---")
+            for e in missing[:40]:
+                print(f"    {e}")
+            if len(missing) > 40:
+                print(f"    ... and {len(missing) - 40} more")
+        if extra:
+            print(f"\n--- ONLY in {db} ({len(extra)}) ---")
+            for e in extra[:40]:
+                print(f"    {e}")
+            if len(extra) > 40:
+                print(f"    ... and {len(extra) - 40} more")
+    print("=" * 58)


### PR DESCRIPTION
Makes the `Database Parity Check` failure diagnosable from the Actions log, per #1440.

`REL_CALLS` is the only metric that drifts, and a bare count can't distinguish *"this backend dropped an edge"* from *"that backend wrote a duplicate"*. Each backend subprocess now also emits its CALLS edge set — keyed on **source locations**, not internal node ids, so the sets are comparable across backends — and the report prints per-backend totals, duplicate counts, and the edges unique to or missing from each.

`REL_CALLS_DISTINCT` is excluded from the pass/fail comparison; it's a diagnostic, not a parity metric. No behaviour change.

## It already answers the question

Run locally against an isolated Neo4j, this narrows a spread of 2 to exactly **two** edges:

```
================= CALLS EDGE DIAGNOSTICS =================
kuzudb       total=648    distinct=637    duplicates=11
ladybugdb    total=648    distinct=637    duplicates=11
falkordb     total=647    distinct=636    duplicates=11
neo4j        total=649    distinct=638    duplicates=11

union=638  common-to-all=636  differing=2

--- MISSING from falkordb (2) ---
    sample_project_java/src/com/example/app/ToughCases.java:testAnonymous@42
        -> sample_project_kotlin/Main.kt:process@4 [call_line=54]
    sample_project_typescript/src/tough_cases.ts:loadModuleDynamically@29
        -> sample_project_typescript/src/tough_circular_b.ts:tough_circular_b.ts@None [call_line=31]
```

Both look wrong **independently of any backend**:

1. **A Java → Kotlin edge.** `ToughCases.java:testAnonymous` calling `Main.kt:process` — two unrelated fixture projects. `languages_are_compatible` is supposed to prevent cross-language CALLS; the audit spot-checked `.py → .js/.java/.go` and found none, so Java→Kotlin slipped through.
2. **A callee that is a file, not a function.** `tough_circular_b.ts:tough_circular_b.ts@None` — the callee's `name` is a filename and its `line_number` is null. That is the exact shape the existing tolerance comment blames for the drift ("cannot bind an exact `called_line_number`").

Neither is a legitimate edge, so the fix is to stop emitting them rather than to widen the tolerance. That also explains why backends disagree: unresolved edges with a null line are exactly what the fast/slow MATCH split handles differently.

Also surfaced: **11 duplicate edges on every backend** (648 total vs 637 distinct by caller→callee@call_line). Consistent across all four, so it isn't a parity problem, but it may be worth checking whether those are genuinely multiple calls on one line.

## What this PR does not do

It does not make the workflow pass. The tolerance is untouched — see #1440 for why I don't think widening it is right. This is the diagnostic that makes the real fix possible, and it will print on the next run so the numbers can be read straight from the Actions output.