### PR TITLE
test(parity): write the CALLS edge dump to a file, not stdout

### DIFF
--- a/tests/e2e/test_verify_databases_parity.py
+++ b/tests/e2e/test_verify_databases_parity.py
@@ -32,6 +32,10 @@ async def run_indexing_in_process(db_type: str, project_path: Path, temp_test_di
     
     project_path_str = project_path.resolve().as_posix()
     dotenv_path_str = (Path.home() / ".codegraphcontext" / ".env").as_posix()
+    # The CALLS edge dump is ~650 entries. Printing it to stdout floods the
+    # Actions step log and GitHub truncates the whole step — including the
+    # comparison table. Pass it through a file so only the small diff is logged.
+    edges_out_str = (temp_test_dir / f"{db_type}_calls_edges.json").as_posix()
     
     # Construct a python command to run the indexing
     cmd = f"""
@@ -108,8 +112,9 @@ async def run():
 
     db_mgr.close_driver()
     stats["REL_CALLS_DISTINCT"] = len(set(calls_edges))
+    with open(r'{edges_out_str}', "w") as _f:
+        json.dump(calls_edges, _f)
     print("STATS_JSON:" + json.dumps(stats))
-    print("CALLS_EDGES_JSON:" + json.dumps(calls_edges))
 
 async def main():
     try:
@@ -143,12 +148,17 @@ asyncio.run(main())
         
     # Extract stats from stdout
     stats = {}
-    calls_edges = []
     for line in stdout.decode().splitlines():
         if line.startswith("STATS_JSON:"):
             stats = json.loads(line[len("STATS_JSON:"):])
-        elif line.startswith("CALLS_EDGES_JSON:"):
-            calls_edges = json.loads(line[len("CALLS_EDGES_JSON:"):])
+            break
+
+    calls_edges = []
+    try:
+        with open(edges_out_str) as _f:
+            calls_edges = json.load(_f)
+    except (OSError, ValueError):
+        pass
 
     return duration, stats, calls_edges
 


### PR DESCRIPTION
Fixes a problem **I introduced** in #1441.

#1441 printed each backend's whole CALLS edge set as a single JSON line (~650 entries, ~100 KB). GitHub truncated the step log as a result — the Actions output stopped right after the first backend's `STATS_JSON`, so neither the comparison table nor the new diagnostics were visible. Exactly the opposite of the intent.

```
$ gh run view <id> --log-failed | wc -l
29        # truncated mid-run, after the kuzudb leg
```

The subprocess now writes its edge list to `<temp_test_dir>/<backend>_calls_edges.json` and the parent reads that file, leaving only the small human-readable diff in the log.

Verified locally:

```
log size:            12 KB      (was ~100 KB on a single line)
longest single line: 831 chars
```

and the diagnostics still print in full:

```
================= CALLS EDGE DIAGNOSTICS =================
kuzudb       total=648    distinct=637    duplicates=11
ladybugdb    total=648    distinct=637    duplicates=11
falkordb     total=647    distinct=636    duplicates=11
neo4j        total=649    distinct=638    duplicates=11

union=638  common-to-all=636  differing=2

--- MISSING from falkordb (2) ---
    …ToughCases.java:testAnonymous@42 -> …Main.kt:process@4 [call_line=54]
    …tough_cases.ts:loadModuleDynamically@29 -> …tough_circular_b.ts:tough_circular_b.ts@None [call_line=31]
```