### PR TITLE
fix(deps): don't require kuzu where it has no Python 3.14 wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.5.2"
+version = "0.5.3"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"
@@ -58,7 +58,20 @@ dependencies = [
     "falkordblite>=0.7,<0.10; sys_platform != 'win32' and python_version >= '3.12'",
     "requests>=2.28.0",
     "protobuf>=3.20,<3.21",
-    "kuzu; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
+    # ------------------------------------------------------------------
+    # KùzuDB was archived upstream on 2025-10-10; 0.11.3 is the final
+    # release and its wheel matrix stops at cp313 for macOS and Windows.
+    # Only Linux (manylinux x86_64 / aarch64) got cp314 wheels. Without a
+    # marker, `pip install codegraphcontext` on macOS/Windows + Python 3.14
+    # falls back to the kuzu sdist and tries a full C++/CMake source build,
+    # which fails and takes the whole install down with it.
+    #
+    # Keep kuzu where a wheel actually exists; elsewhere the backend is
+    # simply absent and `database_kuzu` reports its install hint at runtime.
+    # LadybugDB (the maintained Kùzu fork, see issue #852) publishes cp314
+    # wheels for all three platforms and remains the unconditional default.
+    # ------------------------------------------------------------------
+    "kuzu; python_version < '3.14' or sys_platform == 'linux'",
     "ladybug; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
     "mcp>=1.0.0",
     "fastapi>=0.100.0",
@@ -85,7 +98,9 @@ falkordb-remote = [
     "redis>=5,<6",
 ]
 kuzu = [
-    "kuzu; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
+    # Same wheel-availability marker as the core dependency above: no
+    # cp314 wheels exist for macOS/Windows and the sdist cannot be built.
+    "kuzu; python_version < '3.14' or sys_platform == 'linux'",
 ]
 ladybug = [
     "ladybug; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",


### PR DESCRIPTION
## Problem

`pip install codegraphcontext` on **macOS/Windows with Python 3.14** does not use a kuzu wheel — there isn't one. It falls back to the 19.4 MB source tarball and builds Kùzu's C++ tree from scratch.

KùzuDB was archived upstream on **2025-10-10**; `0.11.3` is its final release, and its wheel matrix stops at cp313 for macOS and Windows:

| Platform | py3.13 | py3.14 |
|---|---|---|
| Linux (x86_64 / aarch64) | wheel | **wheel** |
| macOS | wheel | **none → sdist** |
| Windows | wheel | **none → sdist** |

This is not hypothetical — it is happening in this repo's own macOS CI on every run. From the latest `macOS CI` run on main (30209875681):

```
Collecting kuzu (from codegraphcontext==0.5.2)
  Downloading kuzu-0.11.3.tar.gz (19.4 MB)
  Building wheel for kuzu (pyproject.toml): started      16:13:30
  Building wheel for kuzu (pyproject.toml): still running...   (x8)
  Building wheel for kuzu (pyproject.toml): finished     16:22:33
  Created wheel for kuzu: kuzu-0.11.3-cp314-cp314-macosx_26_0_universal2.whl
```

**9 minutes 3 seconds** of source build, every macOS run. It only succeeds because GitHub's runners ship a full Xcode/clang toolchain. On a developer machine without one the build fails and takes the entire `pip install codegraphcontext` down with it — the reported workaround was installing every dependency by hand and then running `pip install codegraphcontext --no-deps`.

The existing marker never prevented any of this:

```
sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')
```

Given `requires-python = ">=3.10"`, that expression is a tautology — it always evaluates true and excludes nothing.

## Fix

```
kuzu; python_version < '3.14' or sys_platform == 'linux'
```

Applied to both the core dependency and the `kuzu` extra.

Note this deliberately does **not** drop kuzu from 3.14 wholesale — Linux does have cp314 wheels, and a blanket removal would delete a working backend for every Linux user. The marker tracks actual wheel availability.

Where kuzu is absent, nothing breaks: backends are imported lazily by module name, so `database_kuzu` just reports its existing `Run 'pip install kuzu'` hint at runtime. **LadybugDB** — the maintained Kùzu fork from #852 — publishes cp314 wheels on all three platforms and remains an unconditional dependency, so every 3.14 user keeps a working embedded backend.

Expected side benefit: the macOS CI job should lose ~9 minutes of wall clock.

## Verification

Resolved the built wheel's actual `Requires-Dist` metadata against each target:

```
linux    py3.13 -> kuzu INSTALLED     linux    py3.14 -> kuzu INSTALLED
macos    py3.13 -> kuzu INSTALLED     macos    py3.14 -> kuzu skipped (resolve OK)
windows  py3.13 -> kuzu INSTALLED     windows  py3.14 -> kuzu skipped (resolve OK)
```

Additionally, on a real Python 3.14.6 Linux venv:

- `pip install` pulls `kuzu-0.11.3-cp314-cp314-manylinux…whl` and a live `CREATE NODE TABLE` / `MATCH` round-trip returns correctly.
- With kuzu uninstalled (simulating the macOS/Windows 3.14 state), the package imports and `cgc --help` exits 0.

CI here covers the affected combination directly: `test.yml` runs a `3.14` matrix leg, and `macos.yml` / `e2e-tests.yml` / `db-parity-check.yml` all pin 3.14.

## Also

- Bumps version to **0.5.3**. Golden fixtures embed `PYv0.5.2` in `metadata.json`, but that file is only written on `--update-goldens` and never asserted against — the comparison covers nodes and edges only, so the bump does not affect those tests.

## Follow-ups (not in this PR)

- Since kuzu is archived and will never gain macOS/Windows 3.14 wheels, demoting it to an opt-in extra is the real long-term move.
- `ladybug` pins `requires-python <3.15`, so when 3.15 lands `pip install codegraphcontext` will hard-fail on every platform until upstream relaxes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
