### PR TITLE
fix(calls): make CALLS resolution deterministic and stop dropping File-target edges

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -824,6 +824,24 @@ class GraphWriter:
                 if called_label in labels_with_context:
                     called_context_clause = 'AND (row.called_context = "" OR called.context = row.called_context)'
 
+                # ...and which have a 'line_number'. File and Directory do not:
+                # the Kùzu File table is (path, name, relative_path, package_name,
+                # is_dependency). Referencing called.line_number against them raises
+                # a binder exception on strongly-typed backends, which the caller
+                # swallows via _is_binder_exception -> continue, silently dropping
+                # the ENTIRE Function->File batch. Neo4j is untyped here and
+                # evaluates the predicate to null, so it kept those edges — which is
+                # why dynamic-import edges existed on Neo4j and nowhere else.
+                labels_without_line_number = {"File", "Directory"}
+                predicates = []
+                if called_label not in labels_without_line_number:
+                    predicates.append(
+                        "(row.called_line_number <= 0 OR called.line_number = row.called_line_number)"
+                    )
+                if called_context_clause:
+                    predicates.append(called_context_clause.removeprefix("AND ").strip())
+                where_clause = ("WHERE " + "\n                              AND ".join(predicates)) if predicates else ""
+
                 def _write_batch(batch_rows: List[Dict[str, Any]], relation_label: str) -> None:
                     if not batch_rows:
                         return
@@ -832,8 +850,7 @@ class GraphWriter:
                             UNWIND $batch AS row
                             MATCH (caller:File {{path: row.caller_file_path}})
                             MATCH (called:{called_label} {{name: row.called_name, path: row.called_file_path}})
-                            WHERE (row.called_line_number <= 0 OR called.line_number = row.called_line_number)
-                              {called_context_clause}
+                            {where_clause}
                             MERGE (caller)-[call:{relation_label} {{line_number: row.line_number, full_call_name: row.full_call_name, args_key: row.args_key}}]->(called)
                             SET call.args = row.args
                             SET call.confidence = row.confidence
@@ -845,8 +862,7 @@ class GraphWriter:
                             UNWIND $batch AS row
                             MATCH (caller:{caller_label} {{name: row.caller_name, path: row.caller_file_path, line_number: row.caller_line_number}})
                             MATCH (called:{called_label} {{name: row.called_name, path: row.called_file_path}})
-                            WHERE (row.called_line_number <= 0 OR called.line_number = row.called_line_number)
-                              {called_context_clause}
+                            {where_clause}
                             MERGE (caller)-[call:{relation_label} {{line_number: row.line_number, full_call_name: row.full_call_name, args_key: row.args_key}}]->(called)
                             SET call.args = row.args
                             SET call.confidence = row.confidence

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -201,7 +201,17 @@ async def run_tree_sitter_index_async(
         for failure in parse_failures[:10]:
             warning_logger(f"  parse failed: {failure['path']}: {failure['error']}")
 
-    all_file_data = [file_data for file_data in all_file_data if "error" not in file_data]
+    # Sort before post-processing. Files are appended in `asyncio.as_completed`
+    # order, so the list order varies run to run with task scheduling. Everything
+    # downstream that builds a map by iterating it — global_class_bases,
+    # interface_implementors, class_method_index — then inherits that ordering,
+    # and any last-writer-wins or first-match-wins choice becomes
+    # nondeterministic. The graph write loop already sorted for exactly this
+    # reason; resolution was left unsorted.
+    all_file_data = sorted(
+        (file_data for file_data in all_file_data if "error" not in file_data),
+        key=lambda data: str(data.get("path") or ""),
+    )
 
     info_logger(
         f"File processing complete. {len(all_file_data)} files parsed. "

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -2908,12 +2908,21 @@ def build_function_call_groups(
                 call_to_resolve.get("call_kind") == "dynamic_import"
                 and caller_lang in ("typescript", "javascript")
             ):
-                static_imports = [
-                    imp for imp in file_data.get("imports", [])
-                    if imp.get("source") and imp.get("name") not in ("*",)
-                ]
-                if static_imports:
-                    source = static_imports[0]["source"]
+                # Resolve from the dynamic import's OWN specifier. This used to
+                # take static_imports[0] — the first *static* import in the file —
+                # which has nothing to do with the module being imported, so
+                #     await import(`./tough_dynamic_${name}`)
+                # produced an edge to whatever the file happened to import first.
+                # A template literal or variable specifier is not knowable at
+                # index time, so emit nothing rather than guess.
+                raw_args = call_to_resolve.get("args") or []
+                specifier = (raw_args[0] or "").strip() if raw_args else ""
+                is_string_literal = len(specifier) >= 2 and (
+                    (specifier[0] == specifier[-1] == '"')
+                    or (specifier[0] == specifier[-1] == "'")
+                )
+                if is_string_literal:
+                    source = specifier[1:-1]
                     caller_dir = Path(caller_file_path).parent
                     target = (caller_dir / source).resolve()
                     if not target.suffix:
@@ -3003,6 +3012,17 @@ def build_function_call_groups(
                             )
                         for impl_fn in impl_entries:
                             impl_path = _resolved_posix(impl_fn["path"])
+                            # This fan-out speculatively widens an already-resolved
+                            # call to every implementor of the interface, keyed on a
+                            # bare simple name. Without a language check a Java
+                            # `Processor.process` collides with an unrelated Kotlin
+                            # `Processor.process` in a different project and emits a
+                            # cross-language edge that no build could ever produce.
+                            # Java/Kotlin interop is real, but it is scoped to a
+                            # shared module — a bare name match across source roots
+                            # is not evidence of it.
+                            if detect_lang_from_path(impl_path) != caller_lang:
+                                continue
                             impl_line = impl_fn.get("line_number")
                             if (
                                 impl_path == resolved.get("called_file_path")

--- a/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
+++ b/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
@@ -632,7 +632,23 @@ class TestCrossLangCallResolutionPatterns:
             for row in part_links
         )
 
-    def test_typescript_dynamic_import_calls_static_import_file(self, manager):
+    def test_typescript_dynamic_import_with_non_literal_specifier_is_not_resolved(self, manager):
+        """A dynamic import whose specifier is not a static string literal must
+        produce no CALLS edge.
+
+        This test previously asserted the opposite — that
+        ``await import(`./tough_dynamic_${moduleName}`)`` resolves to
+        ``tough_circular_b.ts`` — and was named
+        ``..._calls_static_import_file`` accordingly. That edge was fabricated:
+        the resolver ignored the dynamic specifier entirely and used
+        ``static_imports[0]``, i.e. whichever module the file happened to
+        ``import`` first. ``tough_circular_b`` is unrelated to the dynamic
+        import, and no ``tough_dynamic_*`` file exists in the fixture at all.
+
+        Besides being wrong, the edge pointed at a File node with
+        ``called_line_number = 0``, which the backends bind differently — it was
+        one of the edges making the Database Parity Check flaky.
+        """
         wrapper = _parser(manager, "typescript")
         parser = TypescriptTreeSitterParser(wrapper)
         base = FIXTURES / "sample_project_typescript"
@@ -649,13 +665,15 @@ class TestCrossLangCallResolutionPatterns:
                 "imports": parsed.get("imports", []),
             })
         *_, fn_to_file = build_function_call_groups(files, {})
-        edge = next(
+
+        fabricated = [
             e for e in fn_to_file
             if e.get("caller_name") == "loadModuleDynamically"
+        ]
+        assert fabricated == [], (
+            "a template-literal dynamic import specifier is not statically "
+            f"knowable and must not produce an edge; got {fabricated}"
         )
-        assert edge["line_number"] == 31
-        assert edge["called_name"] == "tough_circular_b.ts"
-        assert edge["called_file_path"].endswith("tough_circular_b.ts")
 
     def test_typescript_decorated_by_validate_on_update_age(self, manager):
         wrapper = _parser(manager, "typescript")


### PR DESCRIPTION
Fixes #1440. `Database Parity Check` now passes — all four backends agree exactly.

```
REL_CALLS   | KuzuDB | LadybugDB | FalkorDB | Neo4j | Match?
before      |   647  |    648    |   649    |  648  |  NO    <- and it varied run to run
after       |   651  |    651    |   651    |  651  |  YES

union=640   common-to-all=640   differing=0
tests/e2e/test_verify_databases_parity.py  ->  1 passed
```

**None of the four defects were in the database layer.** The parity test was just the thing that noticed.

### 1. Resolution input was nondeterministic — `pipeline.py`

`all_file_data` is appended in `asyncio.as_completed` order, so its order varies with task scheduling. Everything built by iterating it — `global_class_bases`, `interface_implementors`, `class_method_index` — inherited that order, and the last-writer-wins assignments then produced a different graph per run. The graph write loop already sorted for exactly this reason; resolution didn't. This is why the same backend gave different numbers in different CI runs.

### 2. Unguarded Java implementor fan-out — `calls.py`

After `resolve_function_call` returns, extra edges are appended for every implementor of the resolved interface, gated only on `caller_lang == "java"` — no language, package or source-root check. `interface_implementors` is keyed on the **bare simple class name across the whole index**, so Java's nested `Processor` and Kotlin's `models.Processor` collided and a Java call acquired a Kotlin callee in an unrelated fixture project.

Note `languages_are_compatible` was never consulted here — and it deliberately permits java↔kotlin, since JVM interop is real. The fix gates the *speculative* fan-out on the implementor's language matching the caller's; genuine same-module interop is unaffected.

### 3. Fabricated dynamic-import edges — `calls.py`

The TS/JS branch never read the dynamic import's own specifier:

```python
static_imports = [imp for imp in file_data.get("imports", []) if ...]
if static_imports:
    source = static_imports[0]["source"]     # the first *static* import in the file
```

So ``await import(`./tough_dynamic_${moduleName}`)`` resolved to whatever the file imported first — an unrelated module. The heuristic was exactly inverted: `modules-namespaces.ts` has **four** statically resolvable literal specifiers and no static imports at all, so all four were silently dropped. Now resolved from the call's own argument, emitting nothing when the specifier isn't a static string literal.

### 4. File-target CALLS edges silently dropped on Kùzu/Ladybug — `writer.py`

The CALLS write emitted this for **every** target label:

```cypher
WHERE (row.called_line_number <= 0 OR called.line_number = row.called_line_number)
```

`File` nodes have no `line_number` — the Kùzu table is `File(path, name, relative_path, package_name, is_dependency)`. Neo4j and FalkorDB are untyped and evaluate the property to null, so the `<= 0` disjunct short-circuits and the edge writes. Kùzu and Ladybug are typed, so it fails at **bind** time, which no runtime short-circuit can rescue — and the error is swallowed as a binder exception, discarding the whole `Function -> File` batch.

Reproduced directly against kuzu 0.11.3:

```
WITH line predicate    -> RAISED: Binder exception: Cannot find property line_number for called.
WITHOUT line predicate -> OK, edge written
```

This is **real data loss on the default embedded backends**, not just a parity artefact: every dynamic-import edge was missing from Kùzu, Ladybug and any KùzuDB-backed graph. The predicate is now built per label, the same way `called_context_clause` already was.

### A test that locked in the bug

`test_typescript_dynamic_import_calls_static_import_file` asserted the fabricated edge:

```python
assert edge["called_name"] == "tough_circular_b.ts"
```

Its name says "dynamic import calls static import file". It is rewritten to assert that a non-literal specifier produces **no** edge, with the history recorded in its docstring. Flagging it explicitly — it's the one change here that deliberately inverts an existing assertion.

### Verification

- `tests/e2e/test_verify_databases_parity.py` — **1 passed**, all four backends at 651, `differing=0`
- `tests/unit/` + `tests/integration/` (what Build Test runs) — **967 passed, 7 skipped, 0 failed**
- Root causes independently re-derived and adversarially reviewed before implementing; the writer failure was reproduced against raw kuzu rather than inferred

### Not changed

`allowed_spread` is untouched at `{"REL_IMPORTS": 6, "REL_CALLS": 1}`. The spread is now 0, so widening it would have hidden four real bugs.
