### PR TITLE
fix(server): restore LLM_SYSTEM_PROMPT import so MCP `initialize` succeeds

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Coroutine, Optional, List, Set
 
 from .utils.gcf_encoder import encode_response
 
-from .prompts import build_system_prompt
+from .prompts import LLM_SYSTEM_PROMPT, build_system_prompt
 from .core import get_database_manager
 from .core.jobs import JobManager, JobStatus
 from .core.watcher import CodeWatcher

--- a/tests/integration/mcp/test_mcp_server.py
+++ b/tests/integration/mcp/test_mcp_server.py
@@ -1,7 +1,9 @@
 
 import pytest
 import asyncio
+import io
 import json
+import sys
 from unittest.mock import MagicMock, AsyncMock, patch
 from codegraphcontext.server import MCPServer
 
@@ -28,6 +30,36 @@ class TestMCPServer:
                 # Let's mock the internal handlers instead.
                 
                 return server
+
+    def test_initialize_returns_result_not_internal_error(self, mock_server, monkeypatch, capsys):
+        """The stdio `initialize` handshake must return a result, not an internal error.
+
+        Regression guard: server.py once referenced the module-level LLM_SYSTEM_PROMPT
+        while importing only build_system_prompt, so every `initialize` request raised
+        NameError and was returned as a -32603 error. That fails the handshake, which
+        makes the server unusable for any stdio MCP client.
+        """
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0"},
+            },
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(request) + "\n"))
+
+        async def run_test():
+            await mock_server._run_loop(asyncio.get_running_loop())
+
+        asyncio.run(run_test())
+
+        response = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+        assert "error" not in response, response.get("error")
+        assert response["result"]["instructions"]
+        assert response["result"]["serverInfo"]["systemPrompt"]
 
     def test_tool_routing(self, mock_server):
         """Test that handle_tool_call routes to the correct internal method."""


### PR DESCRIPTION
Fixes #1451.

## Problem

On 0.5.3 and current `main`, every stdio MCP `initialize` request fails:

```json
{"jsonrpc": "2.0", "id": 1, "error": {"code": -32603, "message": "Internal error: name 'LLM_SYSTEM_PROMPT' is not defined"}}
```

The handshake never completes, so the server is unusable for any stdio MCP client (Claude Code, Cursor, ...). It still starts and logs normally, so it looks healthy.

`server.py` referenced the module-level `LLM_SYSTEM_PROMPT` at L808 while importing only `build_system_prompt` at L19. c9a9f7e (#613) changed that import and left the L808 reference in place.

Both names are genuinely needed, so this restores the import rather than reverting the call site:

- `build_system_prompt()` — L795
- `LLM_SYSTEM_PROMPT` — L808 (`instructions`)

0.5.2 and earlier are unaffected; 0.5.3 shipped the same day #613 merged.

## Change

```diff
-from .prompts import build_system_prompt
+from .prompts import LLM_SYSTEM_PROMPT, build_system_prompt
```

## Test

`tests/integration/mcp/test_mcp_server.py` had no coverage of the `initialize` handshake at all — only tool routing — which is how this reached a release. Added `test_initialize_returns_result_not_internal_error`, which feeds a real `initialize` request through `_run_loop` via a patched `sys.stdin` and asserts the response carries a result rather than an error.

Verified it actually guards the regression:

- **Without** the one-line fix: fails with `AssertionError: {'code': -32603, 'message': "Internal error: name 'LLM_SYSTEM_PROMPT' is not defined"}` — the exact production error.
- **With** the fix: passes.

`tests/integration/mcp/` → 6 passed.

Wider run: `tests/unit` + `tests/integration/mcp` → **920 passed, 10 failed**. All 10 failures reproduce identically on pristine `main` with these changes reverted (`test_mcp_sse_disconnect`, `test_kotlin_parser`, `test_scip_pipeline_*`) and are unrelated to this change — they look environmental in my setup rather than genuine breakage.

## Verified end to end

Against the real entry point, on the reproduction from the issue:

```
initialize -> proto 2025-03-26 | server CodeGraphContext 0.5.3 | instructions len 6494
tools/list -> 29 tools
```

The server then connected successfully from Claude Code.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
