### PR TITLE
fix(viz): handle real FalkorDB Node/Edge shape in offline renderer

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -608,13 +608,20 @@ def _render_offline_visualization(
     def _ident(value) -> Optional[str]:
         return None if value is None else str(value)
 
-    # Neo4j/Falkor return driver objects carrying .labels / .type; Kùzu and
-    # Ladybug return plain dicts carrying _label plus _src/_dst. Check the
-    # driver attributes first — a driver object may also be dict-like.
+    # Neo4j returns driver objects carrying .labels / .type that support
+    # dict()/Mapping access. FalkorDB's own driver objects also carry
+    # .labels on nodes, but are NOT dict-convertible — their properties live
+    # in a plain `.properties` dict, and its Edge exposes `.relation` /
+    # `.src_node` / `.dest_node` instead of `.type` / `.start_node` /
+    # `.end_node`. Kùzu and Ladybug return plain dicts carrying _label plus
+    # _src/_dst. Check the driver attributes first — a driver object may
+    # also be dict-like.
     def _is_relationship(value) -> bool:
         if hasattr(value, "labels"):
             return False
         if hasattr(value, "type"):
+            return True
+        if hasattr(value, "relation") and hasattr(value, "src_node"):
             return True
         return isinstance(value, dict) and "_src" in value and "_dst" in value
 
@@ -623,13 +630,17 @@ def _render_offline_visualization(
             return True
         if hasattr(value, "type"):
             return False
+        if hasattr(value, "relation") and hasattr(value, "src_node"):
+            return False
         # Kùzu relationships also carry _label, so _src/_dst is what
         # distinguishes them from nodes.
         return isinstance(value, dict) and "_label" in value and "_src" not in value
 
     def _node_payload(value) -> Dict[str, Any]:
         if hasattr(value, "labels"):
-            props = dict(value)
+            # FalkorDB's Node keeps properties in `.properties` and is not
+            # itself iterable; Neo4j's Node supports dict() via Mapping.
+            props = dict(value.properties) if hasattr(value, "properties") else dict(value)
             labels = list(getattr(value, "labels", []) or [])
             label = labels[0] if labels else "Node"
             node_id = getattr(value, "element_id", None) or getattr(value, "id", None)
@@ -647,13 +658,15 @@ def _render_offline_visualization(
         }
 
     def _edge_payload(value) -> Optional[Dict[str, Any]]:
-        start = getattr(value, "start_node", None)
-        end = getattr(value, "end_node", None)
+        # Neo4j: .start_node/.end_node/.type. FalkorDB: .src_node/.dest_node/
+        # .relation.
+        start = getattr(value, "start_node", None) or getattr(value, "src_node", None)
+        end = getattr(value, "end_node", None) or getattr(value, "dest_node", None)
         if start is not None and end is not None:
             return {
                 "source": _ident(getattr(start, "element_id", None) or getattr(start, "id", None)),
                 "target": _ident(getattr(end, "element_id", None) or getattr(end, "id", None)),
-                "type": getattr(value, "type", "RELATED"),
+                "type": getattr(value, "type", None) or getattr(value, "relation", "RELATED"),
             }
         if isinstance(value, dict):
             return {

--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -657,15 +657,26 @@ def _render_offline_visualization(
             "line_number": props.get("line_number"),
         }
 
+    def _node_ref_id(ref) -> Any:
+        # Neo4j's start_node/end_node are full Node objects; FalkorDB's
+        # src_node/dest_node are already the bare node id (an int).
+        if isinstance(ref, (int, str)):
+            return ref
+        return getattr(ref, "element_id", None) or getattr(ref, "id", None)
+
     def _edge_payload(value) -> Optional[Dict[str, Any]]:
         # Neo4j: .start_node/.end_node/.type. FalkorDB: .src_node/.dest_node/
         # .relation.
-        start = getattr(value, "start_node", None) or getattr(value, "src_node", None)
-        end = getattr(value, "end_node", None) or getattr(value, "dest_node", None)
+        start = getattr(value, "start_node", None)
+        if start is None:
+            start = getattr(value, "src_node", None)
+        end = getattr(value, "end_node", None)
+        if end is None:
+            end = getattr(value, "dest_node", None)
         if start is not None and end is not None:
             return {
-                "source": _ident(getattr(start, "element_id", None) or getattr(start, "id", None)),
-                "target": _ident(getattr(end, "element_id", None) or getattr(end, "id", None)),
+                "source": _ident(_node_ref_id(start)),
+                "target": _ident(_node_ref_id(end)),
                 "type": getattr(value, "type", None) or getattr(value, "relation", "RELATED"),
             }
         if isinstance(value, dict):

--- a/tests/unit/cli/test_offline_visualization.py
+++ b/tests/unit/cli/test_offline_visualization.py
@@ -65,15 +65,46 @@ _N1 = _Node("4:1", ["File"], path="/repo/a.py", name="a.py")
 _N2 = _Node("4:2", ["Function"], name="alpha", path="/repo/a.py", line_number=3)
 NEO4J_RECORDS = [_Record([_N1, _Rel("CONTAINS", _N1, _N2), _N2])]
 
+# --- Real FalkorDB shape: driver objects with `.labels` but NOT dict-like,
+# properties live in `.properties`, and edges use `.src_node`/`.dest_node`/
+# `.relation` instead of Neo4j's `.start_node`/`.end_node`/`.type`. -----------
+
+class _FalkorNode:
+    def __init__(self, node_id, labels, properties):
+        self.id = node_id
+        self.labels = labels
+        self.properties = properties
+
+
+class _FalkorEdge:
+    def __init__(self, src_node, relation, dest_node, properties=None):
+        self.src_node = src_node
+        self.relation = relation
+        self.dest_node = dest_node
+        self.properties = properties or {}
+
+
+_FN1 = _FalkorNode(1, ["File"], {"path": "/repo/a.py", "name": "a.py"})
+_FN2 = _FalkorNode(2, ["Function"], {"name": "alpha", "path": "/repo/a.py", "line_number": 3})
+FALKORDB_RECORDS = [_Record([_FN1, _FalkorEdge(_FN1, "CONTAINS", _FN2), _FN2])]
+
 
 @pytest.mark.parametrize(
     "records,label",
-    [(KUZU_RECORDS, "kuzu-style dicts"), (NEO4J_RECORDS, "neo4j-style objects")],
+    [
+        (KUZU_RECORDS, "kuzu-style dicts"),
+        (NEO4J_RECORDS, "neo4j-style objects"),
+        (FALKORDB_RECORDS, "real falkordb-style objects"),
+    ],
 )
 def test_offline_renderer_handles_both_driver_shapes(records, label, tmp_path, monkeypatch):
-    """Kùzu/Ladybug return plain dicts carrying `_label`/`_src`/`_dst`, while
-    Neo4j and FalkorDB return driver objects with `.labels`/`.type`. The
-    renderer must understand both or it silently produces an empty graph."""
+    """Kùzu/Ladybug return plain dicts carrying `_label`/`_src`/`_dst`. Neo4j
+    returns driver objects with `.labels`/`.type` that are dict-convertible.
+    FalkorDB also carries `.labels` but is NOT dict-convertible (properties
+    live in `.properties`), and its edges use `.src_node`/`.dest_node`/
+    `.relation` rather than `.start_node`/`.end_node`/`.type`. The renderer
+    must understand all three shapes or it crashes (FalkorDB) or silently
+    produces an empty graph."""
     monkeypatch.setattr("webbrowser.open", lambda *_a, **_k: True)
     out = tmp_path / "graph.html"
 

--- a/tests/unit/cli/test_offline_visualization.py
+++ b/tests/unit/cli/test_offline_visualization.py
@@ -78,6 +78,9 @@ class _FalkorNode:
 
 class _FalkorEdge:
     def __init__(self, src_node, relation, dest_node, properties=None):
+        # The real falkordb.Edge carries the bare integer node id here, NOT
+        # a Node object — confirmed against an actual query result:
+        # `r.src_node` is `<class 'int'>`, not `falkordb.node.Node`.
         self.src_node = src_node
         self.relation = relation
         self.dest_node = dest_node
@@ -86,7 +89,7 @@ class _FalkorEdge:
 
 _FN1 = _FalkorNode(1, ["File"], {"path": "/repo/a.py", "name": "a.py"})
 _FN2 = _FalkorNode(2, ["Function"], {"name": "alpha", "path": "/repo/a.py", "line_number": 3})
-FALKORDB_RECORDS = [_Record([_FN1, _FalkorEdge(_FN1, "CONTAINS", _FN2), _FN2])]
+FALKORDB_RECORDS = [_Record([_FN1, _FalkorEdge(_FN1.id, "CONTAINS", _FN2.id), _FN2])]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What's broken

`cgc visualize` (with the default FalkorDB Lite backend) crashes:

```
TypeError: 'Node' object is not iterable
```

This happens in the offline-viz fallback added in #1419. `_node_payload`/`_is_relationship`/`_edge_payload` in `cli_helpers.py` assume any driver object carrying `.labels` is Neo4j-shaped — dict-convertible via `dict(value)`, with edges exposing `.start_node`/`.end_node`/`.type` as full Node objects.

FalkorDB's own driver objects also carry `.labels` on nodes, but:
- `falkordb.Node` is **not iterable** — properties live in `.properties`, not exposed via `__iter__`/Mapping protocol.
- `falkordb.Edge` exposes `.src_node`/`.dest_node`/`.relation`, not `.start_node`/`.end_node`/`.type`, and has neither `.labels` nor `.type` — so `_is_relationship` returned `False` for it.
- `falkordb.Edge.src_node`/`.dest_node` are the **bare integer node id**, not a `Node` object (confirmed against a live query — `type(edge.src_node) == int`). Neo4j's `start_node`/`end_node` are always full `Node` objects.

Since FalkorDB Lite is the default backend for new installs, this makes `cgc visualize` broken out of the box for most users on first `pip install`.

## Why the existing test didn't catch it (and why my first fix was still incomplete)

`tests/unit/cli/test_offline_visualization.py` has a "neo4j-style objects" fixture (`_Node(dict)`) that subclasses `dict` while also carrying `.labels`/`.element_id` — it satisfies the code's shape check but isn't a faithful stand-in for FalkorDB's actual (non-dict) runtime objects, so it never exercised this path.

My first commit here fixed the node crash and the relationship-detection gap, but its own test fixture made the same category of mistake: it passed `Node` *objects* as `_FalkorEdge`'s src/dest args instead of bare ints. Real-object testing against a live FalkorDB Lite instance (indexing `sktime`, 1879 files) caught this — the offline renderer ran without crashing but silently produced **0 edges** instead of the expected ~300. The second commit fixes that and corrects the fixture to match the real driver shape.

## Fix (2 commits)

1. `_node_payload`: read `value.properties` when present (FalkorDB), fall back to `dict(value)` (Neo4j). `_is_relationship`/`_is_node`: recognize FalkorDB edges via `.relation` + `.src_node`. `_edge_payload`: accept `.src_node`/`.dest_node`/`.relation` alongside `.start_node`/`.end_node`/`.type`.
2. `_edge_payload`/new `_node_ref_id` helper: resolve a node reference to its id whether it's a bare int/str (FalkorDB) or a Node-like object (Neo4j), instead of assuming the latter unconditionally.

## Test plan

Added a fixture (`_FalkorNode`/`_FalkorEdge`) mirroring the real `falkordb.Node`/`falkordb.Edge` shape, parametrized into the existing shape-coverage test. Verified the fixture matches reality by querying a live embedded FalkorDB instance directly:

```python
>>> type(edge), type(edge.src_node)
(<class 'falkordb.edge.Edge'>, <class 'int'>)
>>> [a for a in dir(edge) if not a.startswith('_')]
['alias', 'dest_node', 'id', 'properties', 'relation', 'src_node', 'to_string']
```

```
$ pytest tests/unit/cli/test_offline_visualization.py -v
7 passed

# confirmed each fixed case fails on the pre-fix code:
$ git stash; pytest ... -k falkordb   # TypeError: '_FalkorNode' object is not iterable
$ git stash pop
# (repeated for the src_node/dest_node int-id case against commit 1 alone → 0 edges rendered)
```

End-to-end proof against a real repo (not just unit tests): indexed `sktime` (1879 files, FalkorDB Lite, the default backend) and ran `cgc visualize`:

- Before fix: `TypeError: 'Node' object is not iterable`
- After commit 1 alone: no crash, but `Rendered 263 nodes and 0 edges`
- After commit 2: `Rendered 263 nodes and 300 edges`

Full fast suite (`./tests/run_tests.sh fast`, minus 5 pre-existing unrelated failures in `tests/unit/api/` from an `mcp` SDK version mismatch — `AttributeError: 'Server' object has no attribute 'list_tools'`, reproduced identically on a clean checkout of `main`, not touched by this diff):

```
943 passed, 19 skipped
```