### PR TITLE
fix(deps): cap mcp below 2.0 so the SSE gateway imports again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,13 @@ dependencies = [
     # ------------------------------------------------------------------
     "kuzu; python_version < '3.14' or sys_platform == 'linux'",
     "ladybug; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
-    "mcp>=1.0.0",
+    # ------------------------------------------------------------------
+    # Capped below 2.0: mcp 2.x dropped the `Server.list_tools()` /
+    # `Server.call_tool()` decorators that `api/mcp_sse.py` registers its
+    # handlers with, so an unpinned install breaks the SSE gateway at import
+    # time. Lift the cap only together with a migration to the 2.x API.
+    # ------------------------------------------------------------------
+    "mcp>=1.0.0,<2",
     "fastapi>=0.100.0",
     "uvicorn>=0.22.0"
 ]


### PR DESCRIPTION
mcp 2.0.0 removed the `Server.list_tools()` and `Server.call_tool()` decorators that `api/mcp_sse.py` registers its handlers with. The dependency was declared as an open `mcp>=1.0.0`, so every fresh install resolved to 2.x and failed at import time.

**Impact:** `Build Test` has been red on `main` for all of 3.12 / 3.13 / 3.14, blocking every open PR:

```
ERROR tests/unit/api/test_api_auth.py - AttributeError: 'Server' object has no attribute 'list_tools'
ERROR tests/unit/api/test_health.py   - AttributeError: 'Server' object has no attribute 'list_tools'
!!!!!!! Interrupted: 2 errors during collection !!!!!!!
```

**Fix:** cap at `mcp>=1.0.0,<2` until the handlers are migrated to the 2.x API. `api/mcp_sse.py` is the only module touching the SDK `Server` decorators, so the cap is the whole surface.

**Verified locally:** with the cap, mcp resolves to 1.29.0 and `tests/unit/api/` goes from *2 collection errors* to **19 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)