### PR TITLE
feat(jobs): add JobManager.cancel_job() (#1228)

### DIFF
--- a/src/codegraphcontext/core/jobs.py
+++ b/src/codegraphcontext/core/jobs.py
@@ -121,6 +121,27 @@ class JobManager:
                     
             return None
 
+    def cancel_job(self, job_id: str) -> bool:
+        """Mark a pending or running job as cancelled.
+
+        Returns ``True`` when the job moved to ``CANCELLED``, and ``False`` for
+        an unknown job or one that already reached a terminal state — so a
+        caller can tell "cancelled it" apart from "there was nothing to
+        cancel" without inspecting the job again.
+
+        This records intent only; a worker still has to observe the status and
+        stop on its own.
+        """
+        with self.lock:
+            job = self.jobs.get(job_id)
+            if job is None:
+                return False
+            if job.status not in (JobStatus.PENDING, JobStatus.RUNNING):
+                return False
+            job.status = JobStatus.CANCELLED
+            job.end_time = datetime.now()
+            return True
+
     def cleanup_old_jobs(self, max_age_hours: int = 24):
         """Removes old jobs from memory to prevent memory leaks.
 

--- a/tests/unit/core/test_jobs.py
+++ b/tests/unit/core/test_jobs.py
@@ -33,3 +33,46 @@ class TestJobManager:
         job = manager.get_job("non_existent_id")
         assert job is None
 
+    def test_cancel_pending_job(self):
+        manager = JobManager()
+        job_id = manager.create_job("/tmp")
+
+        assert manager.cancel_job(job_id) is True
+
+        job = manager.get_job(job_id)
+        assert job.status == JobStatus.CANCELLED
+        assert job.end_time is not None
+
+    def test_cancel_running_job(self):
+        manager = JobManager()
+        job_id = manager.create_job("/tmp")
+        manager.update_job(job_id, status=JobStatus.RUNNING)
+
+        assert manager.cancel_job(job_id) is True
+        assert manager.get_job(job_id).status == JobStatus.CANCELLED
+
+    def test_cancel_is_false_for_unknown_job(self):
+        manager = JobManager()
+        assert manager.cancel_job("non_existent_id") is False
+
+    def test_cancel_does_not_reopen_a_finished_job(self):
+        """A COMPLETED job must keep its status and its original end_time."""
+        manager = JobManager()
+        job_id = manager.create_job("/tmp")
+        manager.update_job(job_id, status=JobStatus.COMPLETED)
+        finished_at = manager.get_job(job_id).end_time
+
+        assert manager.cancel_job(job_id) is False
+
+        job = manager.get_job(job_id)
+        assert job.status == JobStatus.COMPLETED
+        assert job.end_time == finished_at
+
+    def test_cancel_is_idempotent(self):
+        manager = JobManager()
+        job_id = manager.create_job("/tmp")
+
+        assert manager.cancel_job(job_id) is True
+        assert manager.cancel_job(job_id) is False
+        assert manager.get_job(job_id).status == JobStatus.CANCELLED
+


### PR DESCRIPTION
Closes #1228

`JobStatus.CANCELLED` was defined but **unreachable** — nothing in `JobManager` ever set it, so a started job could not be cancelled programmatically.

`cancel_job()` moves a `PENDING` or `RUNNING` job to `CANCELLED` and stamps `end_time`, under the existing lock.

Two deliberate choices beyond the issue sketch:
- It returns `True` **only when it actually performed the transition**, so a caller can tell "cancelled it" from "nothing to cancel" without re-reading the job.
- Terminal jobs are left untouched, which also makes repeat calls idempotent and means a `COMPLETED` job keeps its original `end_time`.

Recording intent is all this does — a worker still has to observe the status and stop on its own. Noted in the docstring so callers don't assume it kills work.

5 new tests (pending, running, unknown id, already-finished, idempotency). **Full `test_jobs.py` passes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)