### PR TITLE
feat(sandbox): allow GitLab-hosted bundle downloads (#1234)

### DIFF
--- a/src/codegraphcontext/utils/path_sandbox.py
+++ b/src/codegraphcontext/utils/path_sandbox.py
@@ -9,12 +9,16 @@ from urllib.parse import urlparse
 
 MAX_DISCOVERY_DEPTH = 10
 
-# Hugging Face dataset raw URLs and GitHub release assets only.
+# Hugging Face dataset raw URLs plus GitHub/GitLab release and raw assets.
+# Each entry also matches its subdomains (see is_safe_download_url), so
+# "gitlab.com" already covers GitLab's raw URLs — those are served from
+# gitlab.com/<project>/-/raw/... rather than a separate raw host.
 _ALLOWED_DOWNLOAD_HOST_SUFFIXES = (
     "huggingface.co",
     "hf.co",
     "github.com",
     "raw.githubusercontent.com",
+    "gitlab.com",
 )
 
 

--- a/tests/unit/utils/test_path_sandbox_security.py
+++ b/tests/unit/utils/test_path_sandbox_security.py
@@ -18,6 +18,17 @@ def test_is_safe_download_url_allows_registry_hosts():
     assert not is_safe_download_url("https://169.254.169.254/latest/meta-data")
 
 
+def test_is_safe_download_url_allows_gitlab_hosted_bundles():
+    """GitLab serves raw files from gitlab.com itself, and the suffix match
+    covers its subdomains too."""
+    assert is_safe_download_url("https://gitlab.com/group/project/-/raw/main/foo.cgc")
+    assert is_safe_download_url("https://raw.gitlab.com/group/project/foo.cgc")
+    # Suffix matching must not turn into a substring match.
+    assert not is_safe_download_url("https://gitlab.com.evil.net/foo.cgc")
+    assert not is_safe_download_url("https://notgitlab.com/foo.cgc")
+    assert not is_safe_download_url("http://gitlab.com/group/project/-/raw/main/foo.cgc")
+
+
 def test_clamp_discovery_depth():
     assert clamp_discovery_depth(1000) == 10
     assert clamp_discovery_depth(-3) == 0


### PR DESCRIPTION
Closes #1234

`is_safe_download_url()` allowed Hugging Face and GitHub hosts only, so bundles hosted on GitLab could not be downloaded. Adds `gitlab.com`.

**One deviation from the issue:** it also proposed `raw.gitlab.com`, which I left out — it isn't a real GitLab host (GitLab serves raw files from `gitlab.com/<project>/-/raw/...`), and `is_safe_download_url()` already matches subdomains via `host.endswith('.' + suffix)`, so the entry would be dead weight. The test asserts `raw.gitlab.com` resolves anyway, so the behaviour the issue asked for is covered.

Tests also pin the near-misses so the suffix match can't decay into a substring match: `gitlab.com.evil.net` and `notgitlab.com` are rejected, and `http://` is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)