### PR TITLE
test(viz): resolve repo root from the test file, not the installed module

### DIFF
--- a/tests/unit/cli/test_offline_visualization.py
+++ b/tests/unit/cli/test_offline_visualization.py
@@ -123,7 +123,11 @@ def test_visualize_falls_back_instead_of_exiting():
 def test_sync_viz_dist_script_exists_and_is_executable():
     """The CLI error message told users to run ./scripts/sync_viz_dist.sh,
     which did not exist."""
-    repo_root = Path(cli_helpers.__file__).resolve().parents[3]
+    # Derive the root from this test file, not from the imported module: CI
+    # installs the package (`pip install .[dev,parsing]`), so
+    # `cli_helpers.__file__` resolves into site-packages and `parents[3]` is
+    # `<venv>/lib/python3.x` rather than the checkout.
+    repo_root = Path(__file__).resolve().parents[3]
     script = repo_root / "scripts" / "sync_viz_dist.sh"
 
     assert script.is_file(), f"{script} is referenced by the CLI but missing"


### PR DESCRIPTION
Found while fixing the `tests/unit/api` collection error in #1460 — this is a **second, currently-masked CI failure**.

`test_sync_viz_dist_script_exists_and_is_executable` derived the repo root from `cli_helpers.__file__`. CI runs `pip install .[dev,parsing]` (not editable), so that path lands in site-packages and `parents[3]` resolves to `<venv>/lib/python3.x` — the assertion then looks for `<venv>/lib/python3.x/scripts/sync_viz_dist.sh` and fails:

```
E  +  where is_file = PosixPath('.../venv/lib/python3.12/scripts/sync_viz_dist.sh').is_file
```

Right now it's hidden behind the `tests/unit/api` collection error, which aborts the run before this test executes. **It will start failing the moment #1460 lands**, so this should go in alongside it.

Derives the root from `__file__` instead, which is stable under both editable and non-editable installs. **6 passed** (was 5 passed / 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)