### PR TITLE
fix(website): pass an explicit radix to parseInt in LocalUploader

### DIFF
--- a/website/src/components/LocalUploader.tsx
+++ b/website/src/components/LocalUploader.tsx
@@ -696,7 +696,7 @@ export default function LocalUploader({ onComplete, plain }: { onComplete: (data
                       max={500000}
                       step={10000}
                       value={config.maxNodes}
-                      onChange={e => updateConfig({ maxNodes: parseInt(e.target.value) })}
+                      onChange={e => updateConfig({ maxNodes: parseInt(e.target.value, 10) })}
                       className="w-full h-1 bg-zinc-800 rounded-lg appearance-none cursor-pointer accent-purple-500"
                     />
                   </div>
@@ -720,7 +720,7 @@ export default function LocalUploader({ onComplete, plain }: { onComplete: (data
                       max={200000}
                       step={5000}
                       value={config.maxEdges}
-                      onChange={e => updateConfig({ maxEdges: parseInt(e.target.value) })}
+                      onChange={e => updateConfig({ maxEdges: parseInt(e.target.value, 10) })}
                       className="w-full h-1 bg-zinc-800 rounded-lg appearance-none cursor-pointer accent-purple-500"
                     />
                   </div>


### PR DESCRIPTION
Supersedes the legitimate half of #1454 / #1455 / #1459.

Those three PRs claimed to add a missing radix but their central change was **wrong**: they rewrote

```js
Number.parseInt(String(rawValue ?? ""), 10)   // correct already
Number.parseInt(String(rawValue ?? "", 10), 10) // radix moved INTO String()
```

in `website/api/lib/security.js`. `String()` takes one argument and silently ignores the second, so that edit is a no-op on a line that already had the radix in the right place. (#1459 additionally truncated `website/public/wasm/web-tree-sitter.js` from 4007 lines to ~2418, cutting a vendored WASM bundle mid-function.)

This PR keeps only the part that was actually a fix: the two `parseInt(e.target.value)` calls in `LocalUploader.tsx` that genuinely had no radix.

Deliberately **not** changed — the other radix-less `parseInt` calls are correct as-is: `PRReviewer.tsx`, `CodeGraphViewer.tsx` and `html-exporter.ts` all pass `16` for hex colour parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)