### PR TITLE
feat(security): audit-log rejected read-only Cypher queries (#1233)

### DIFF
--- a/src/codegraphcontext/utils/cypher_readonly.py
+++ b/src/codegraphcontext/utils/cypher_readonly.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import re
 
+from .debug_log import warning_logger
+
 _FORBIDDEN_KEYWORDS = (
     "CREATE",
     "MERGE",
@@ -48,17 +50,33 @@ def _strip_comments(query: str) -> str:
 
 
 def is_read_only_cypher(query: str) -> bool:
-    """Return True when *query* has no write keywords outside string literals."""
+    """Return True when *query* has no write keywords outside string literals.
+
+    Every rejection is logged at warning level so blocked queries leave an
+    audit trail. The reason is logged, never the query text: a rejected query
+    can carry caller-supplied literals, and this validator guards the CLI, MCP
+    and viz endpoints alike.
+    """
     if not query or not query.strip():
+        warning_logger("Cypher query rejected: query is empty.")
         return False
     stripped = _strip_comments(strip_string_literals(query))
     if ";" in stripped:
+        warning_logger(
+            "Cypher query rejected: multiple statements are not allowed (';' found)."
+        )
         return False
     for keyword in _FORBIDDEN_KEYWORDS:
         if re.search(r"\b" + keyword + r"\b", stripped, re.IGNORECASE):
+            warning_logger(
+                f"Cypher query rejected: forbidden keyword '{keyword}' detected."
+            )
             return False
     for pattern in _FORBIDDEN_PATTERNS:
         if pattern.search(stripped):
+            warning_logger(
+                f"Cypher query rejected: forbidden pattern '{pattern.pattern}' matched."
+            )
             return False
     return True
 

--- a/tests/unit/utils/test_cypher_readonly.py
+++ b/tests/unit/utils/test_cypher_readonly.py
@@ -1,3 +1,4 @@
+from codegraphcontext.utils import cypher_readonly
 from codegraphcontext.utils.cypher_readonly import is_read_only_cypher
 
 
@@ -49,3 +50,58 @@ def test_keyword_as_substring_not_false_positive():
     assert is_read_only_cypher("MATCH (n:Asset) RETURN n")
     # Read-only APOC helpers (path/coll/text) are still permitted inline.
     assert is_read_only_cypher("RETURN apoc.coll.max([1, 2, 3]) AS m")
+
+
+def test_rejection_is_logged_with_the_offending_keyword(monkeypatch):
+    """Rejections must leave an audit trail naming the reason."""
+    logged = []
+    monkeypatch.setattr(cypher_readonly, "warning_logger", logged.append)
+
+    assert not cypher_readonly.is_read_only_cypher("MATCH (n) DELETE n")
+
+    assert len(logged) == 1
+    assert "DELETE" in logged[0]
+
+
+def test_every_rejection_path_logs_exactly_once(monkeypatch):
+    logged = []
+    monkeypatch.setattr(cypher_readonly, "warning_logger", logged.append)
+
+    cases = {
+        "": "empty",
+        "   ": "empty",
+        "MATCH (n) RETURN n; MATCH (m) RETURN m": "multiple statements",
+        "CREATE (n:Foo)": "CREATE",
+        # Hits a forbidden *pattern* rather than a keyword. (apoc.create would
+        # not do: the keyword loop runs first and catches its "create".)
+        "CALL dbms.components()": "dbms",
+    }
+    for query, expected_fragment in cases.items():
+        logged.clear()
+        assert not cypher_readonly.is_read_only_cypher(query)
+        assert len(logged) == 1, f"expected one log line for {query!r}, got {logged}"
+        assert expected_fragment.lower() in logged[0].lower(), (
+            f"{logged[0]!r} does not mention {expected_fragment!r}"
+        )
+
+
+def test_accepted_queries_log_nothing(monkeypatch):
+    logged = []
+    monkeypatch.setattr(cypher_readonly, "warning_logger", logged.append)
+
+    assert cypher_readonly.is_read_only_cypher("MATCH (n) RETURN n LIMIT 1")
+
+    assert logged == []
+
+
+def test_rejection_log_does_not_leak_query_text(monkeypatch):
+    """A rejected query may carry caller-supplied literals; keep them out."""
+    logged = []
+    monkeypatch.setattr(cypher_readonly, "warning_logger", logged.append)
+
+    assert not cypher_readonly.is_read_only_cypher(
+        "CREATE (n:Secret {token: 'hunter2-super-secret'})"
+    )
+
+    assert logged
+    assert "hunter2-super-secret" not in logged[0]


### PR DESCRIPTION
Closes #1233

`is_read_only_cypher()` returned `False` silently, so a blocked query left no trace — impossible to monitor or debug rejections.

**Broader than the issue sketch:** the issue only covered the forbidden-keyword loop, but there are four rejection paths. All four now log their own reason — empty query, multi-statement (`;`), forbidden keyword, forbidden pattern — because an audit trail with holes in it is not an audit trail.

**The reason is logged, never the query text.** This validator guards the CLI, MCP *and* viz endpoints, and a rejected query can carry caller-supplied literals — echoing it into the log would turn the audit trail into a way to leak secrets (cf. #1313). A regression test pins that a query containing `hunter2-super-secret` does not put it in the log.

4 new tests: keyword named in the log line, every path logs exactly once, accepted queries log nothing, and no query text leaks. **16 passed** across this file plus `test_cypher_readonly_enforcement.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)