### PR TITLE
test(parsers): cover language dispatch and invalid language names (#1309)

### DIFF
--- a/tests/unit/parsers/test_language_dispatch.py
+++ b/tests/unit/parsers/test_language_dispatch.py
@@ -1,0 +1,51 @@
+"""Language dispatch in TreeSitterParser (see issue #1309).
+
+An unrecognised or misspelled language name must fail loudly with the list of
+supported languages, rather than leaving `language_specific_parser` as None and
+failing later somewhere unrelated.
+"""
+
+import pytest
+
+from codegraphcontext.tools.tree_sitter_parser import TreeSitterParser
+
+
+@pytest.mark.parametrize("bad_name", ["pyhton", "nosuchlang", "cobol", ""])
+def test_invalid_language_name_raises_with_supported_list(bad_name):
+    with pytest.raises(ValueError) as exc_info:
+        TreeSitterParser(bad_name)
+
+    message = str(exc_info.value)
+    assert bad_name in message or "language" in message.lower()
+    # The error must be actionable: it names languages that do work.
+    assert "python" in message.lower()
+
+
+def test_valid_language_builds_a_language_specific_parser():
+    parser = TreeSitterParser("python")
+
+    assert parser.language_specific_parser is not None
+    assert parser.language_name == "python"
+
+
+def test_every_mapped_language_resolves_to_an_importable_parser():
+    """Guards against a map entry whose module or class was renamed: without
+    this, a typo'd mapping only surfaces the first time someone indexes that
+    language."""
+    # Re-read the map from the source of truth rather than duplicating it.
+    import inspect
+    import re
+
+    source = inspect.getsource(TreeSitterParser.__init__)
+    mapped = re.findall(r'"([a-z_]+)":\s*\(".languages\.[a-z_]+",\s*"(\w+)"\)', source)
+    assert mapped, "could not read LANGUAGE_PARSER_MAP out of the constructor"
+
+    failures = []
+    for language_name, class_name in mapped:
+        try:
+            parser = TreeSitterParser(language_name)
+            assert type(parser.language_specific_parser).__name__ == class_name
+        except Exception as exc:  # noqa: BLE001 - collect all, report together
+            failures.append(f"{language_name}: {type(exc).__name__}: {exc}")
+
+    assert not failures, "mapped languages that failed to load:\n" + "\n".join(failures)


### PR DESCRIPTION
Refs #1309

The dict dispatch and actionable error that #1309 asked for are **already implemented** on `main` — `LANGUAGE_PARSER_MAP` replaced the if/elif chain, and an unknown name raises `ValueError` listing the supported languages. But nothing tested either, so both could regress silently.

Verified current behaviour:
```
TreeSitterParser("pyhton") -> ValueError: Unknown language: pyhton. Supported languages: c, c_sharp, cpp, css, ...
```

Adds coverage for:
- misspelled / unknown / empty names raising `ValueError` whose message names languages that do work
- a valid language actually building its `language_specific_parser`
- **all 23 mapped languages** importing and yielding the class the map claims — a renamed module or class in the map otherwise only surfaces the first time someone indexes that language

One detail worth recording on the issue: for a name tree-sitter does not know, the raise comes from `tree_sitter_manager.get_language_safe()` on line 20, *above* the map check on line 49 — not from the map check itself. Both produce a `ValueError` naming the supported set, so behaviour is correct either way. The map check is not dead code: it guards the different case where tree-sitter knows a language but CGC ships no parser class for it.

**6 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)