### PR TITLE
fix(a11y): give landing-page form fields id, name and accessible labels (#1305)

### DIFF
--- a/website/src/components/BundleRegistrySection.tsx
+++ b/website/src/components/BundleRegistrySection.tsx
@@ -328,6 +328,10 @@ const BundleRegistrySection = () => {
                     <div className="relative">
                         <Search className="absolute left-4 top-3.5 h-5 w-5 text-gray-500" />
                         <Input
+                            type="search"
+                            id="bundle-search"
+                            name="bundleSearch"
+                            aria-label="Search bundles"
                             placeholder="SEARCH BUNDLES..."
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -273,6 +273,10 @@ const Footer = () => {
                 <div className="flex flex-col sm:flex-row gap-3">
                   <input
                     type="email"
+                    id="newsletter-email"
+                    name="email"
+                    autoComplete="email"
+                    aria-label="Email address for newsletter"
                     placeholder="YOUR EMAIL"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}

--- a/website/src/components/HeroSection.tsx
+++ b/website/src/components/HeroSection.tsx
@@ -205,6 +205,10 @@ const HeroSection = () => {
             <div className="flex flex-col gap-3">
               <Input
                 type="url"
+                id="hero-repo-url"
+                name="repoUrl"
+                autoComplete="url"
+                aria-label="Repository URL to index"
                 placeholder="https://github.com/owner/repo"
                 value={repoUrl}
                 onChange={(e) => setRepoUrl(e.target.value)}


### PR DESCRIPTION
Closes #1305

Three landing-page form fields had neither `id` nor `name`:

| Component | Field | Now |
|---|---|---|
| `HeroSection.tsx:206` | repo URL | `id="hero-repo-url"` `name="repoUrl"` `autoComplete="url"` |
| `Footer.tsx:274` | newsletter email | `id="newsletter-email"` `name="email"` `autoComplete="email"` |
| `BundleRegistrySection.tsx:330` | bundle search | `id="bundle-search"` `name="bundleSearch"` `type="search"` |

**Went past the literal ask on one point:** none of the three had a visible `<label>` either — the `placeholder` was doing all the labelling, and screen readers do not treat a placeholder as an accessible name. So each field also gets an `aria-label`. That addresses the *accessibility* half of the DevTools warning rather than only the autofill half, which is what the issue was actually about.

**On the "4 resources" count:** a sweep of the landing tree — `Index.tsx` plus all eleven sections it renders, plus `Navbar` — finds only these three form fields (no `textarea`, `select`, `contentEditable`, or `role="textbox"` elsewhere). The fourth is most likely the same component counted twice across a re-render. If the DevTools panel still shows a fourth after this lands, the affected-resource detail would let us chase it.

**Not built locally** — the checkout has no `node_modules`. The changes are additive standard `input` attributes and `ui/input.tsx` forwards `...props` to `<input>`, so they are all valid `React.ComponentProps<"input">`; the website build job will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)