### PR TITLE
fix(bundle): map every Kùzu node label's primary key, incl. composite keys (#1322)

### DIFF
--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -113,9 +113,10 @@ class CGCBundle:
         if isinstance(labels, str):
             labels = [labels]
         primary_label = labels[0]
-        pk_field = self._PK_MAP.get(primary_label)
-        if pk_field and pk_field in properties:
-            return (primary_label, pk_field, properties[pk_field])
+        pk_fields = self._pk_fields(primary_label)
+        if pk_fields and all(f in properties for f in pk_fields):
+            # ((field, value), ...) so composite keys survive to edge matching.
+            return (primary_label, tuple((f, properties[f]) for f in pk_fields))
         return None
 
     
@@ -1009,14 +1010,26 @@ cgc import <bundle-file>.cgc
         
         return count
     
+    # Primary key per node label, mirroring the PRIMARY KEY declarations in
+    # core/database_embedded_kuzu.py. Kùzu/Ladybug reject a bare
+    # `CREATE (n:Label)` with "expects primary key <field> as input", so every
+    # node table declared there must appear here or its import fails outright.
+    # Values are tuples because two tables have composite keys.
     _PK_MAP = {
-        'Repository': 'path', 'File': 'path', 'Directory': 'path',
-        'Module': 'name',
-        'Function': 'uid', 'Class': 'uid', 'Variable': 'uid',
-        'Trait': 'uid', 'Interface': 'uid', 'Macro': 'uid',
-        'Struct': 'uid', 'Enum': 'uid', 'Union': 'uid',
-        'Annotation': 'uid', 'Record': 'uid', 'Property': 'uid',
-        'Parameter': 'uid',
+        'Repository': ('path',), 'File': ('path',), 'Directory': ('path',),
+        'Module': ('name',),
+        'Function': ('uid',), 'Class': ('uid',), 'Variable': ('uid',),
+        'Trait': ('uid',), 'Interface': ('uid',), 'Macro': ('uid',),
+        'Struct': ('uid',), 'Enum': ('uid',), 'EnumMember': ('uid',),
+        'Union': ('uid',), 'Annotation': ('uid',), 'Record': ('uid',),
+        'Property': ('uid',), 'Parameter': ('uid',),
+        'Mixin': ('uid',), 'Extension': ('uid',), 'Object': ('uid',),
+        # Datasource-ingestion labels. DbTable and ExternalClass are the two
+        # reported in issue #1322; the rest were missing for the same reason.
+        'DbTable': ('name',), 'Datasource': ('name',),
+        'ExternalClass': ('name',),
+        'DbColumn': ('name', 'table_fqn'),
+        'RedisKeyPattern': ('pattern', 'datasource_name'),
     }
     _UID_PARTS = {
         'Function': ['name', 'path', 'line_number'],
@@ -1027,12 +1040,21 @@ cgc import <bundle-file>.cgc
         'Macro': ['name', 'path', 'line_number'],
         'Struct': ['name', 'path', 'line_number'],
         'Enum': ['name', 'path', 'line_number'],
+        'EnumMember': ['name', 'path', 'line_number'],
         'Union': ['name', 'path', 'line_number'],
         'Annotation': ['name', 'path', 'line_number'],
         'Record': ['name', 'path', 'line_number'],
         'Property': ['name', 'path', 'line_number'],
         'Parameter': ['name', 'path', 'function_line_number'],
+        'Mixin': ['name', 'path', 'line_number'],
+        'Extension': ['name', 'path', 'line_number'],
+        'Object': ['name', 'path', 'line_number'],
     }
+
+    @classmethod
+    def _pk_fields(cls, label: str) -> tuple:
+        """Primary key field names for *label*, empty when it has none."""
+        return cls._PK_MAP.get(label, ())
 
     def _import_node_batch(self, session, batch: List[Tuple], id_mapping: Dict) -> int:
         """Import a batch of nodes."""
@@ -1048,19 +1070,20 @@ cgc import <bundle-file>.cgc
             label_str = ':'.join(labels)
             primary_label = labels[0]
 
-            pk_field = self._PK_MAP.get(primary_label)
-            if pk_field == 'uid' and 'uid' not in properties:
+            pk_fields = self._pk_fields(primary_label)
+            if pk_fields == ('uid',) and 'uid' not in properties:
                 parts = self._UID_PARTS.get(primary_label, [])
                 properties['uid'] = ''.join(str(properties.get(p, '')) for p in parts)
 
-            if pk_field and pk_field in properties:
-                pk_val = properties[pk_field]
-                remaining = {k: v for k, v in properties.items() if k != pk_field}
+            if pk_fields and all(f in properties for f in pk_fields):
+                pk_params = {f"pk_{i}": properties[f] for i, f in enumerate(pk_fields)}
+                pattern = ", ".join(f"{f}: $pk_{i}" for i, f in enumerate(pk_fields))
+                remaining = {k: v for k, v in properties.items() if k not in pk_fields}
                 query = (
-                    f"MERGE (n:{label_str} {{{pk_field}: $pk_val}}) "
+                    f"MERGE (n:{label_str} {{{pattern}}}) "
                     f"SET n += $props RETURN {id_function}(n) as new_id"
                 )
-                result = session.run(query, pk_val=pk_val, props=remaining)
+                result = session.run(query, props=remaining, **pk_params)
             else:
                 query = f"CREATE (n:{label_str}) SET n = $props RETURN {id_function}(n) as new_id"
                 result = session.run(query, props=properties)
@@ -1124,19 +1147,22 @@ cgc import <bundle-file>.cgc
                 continue
             
             if self._uses_pk_edge_matching():
-                from_label, from_pk, from_val = new_from
-                to_label, to_pk, to_val = new_to
+                from_label, from_key = new_from
+                to_label, to_key = new_to
+                from_pattern = ", ".join(
+                    f"{f}: $from_{i}" for i, (f, _) in enumerate(from_key)
+                )
+                to_pattern = ", ".join(
+                    f"{f}: $to_{i}" for i, (f, _) in enumerate(to_key)
+                )
+                key_params = {f"from_{i}": v for i, (_, v) in enumerate(from_key)}
+                key_params.update({f"to_{i}": v for i, (_, v) in enumerate(to_key)})
                 query = f"""
-                    MATCH (a:{from_label} {{{from_pk}: $from_val}}), (b:{to_label} {{{to_pk}: $to_val}})
+                    MATCH (a:{from_label} {{{from_pattern}}}), (b:{to_label} {{{to_pattern}}})
                     CREATE (a)-[r:{rel_type}]->(b)
                     SET r = $props
                 """
-                session.run(
-                    query,
-                    from_val=from_val,
-                    to_val=to_val,
-                    props=properties,
-                )
+                session.run(query, props=properties, **key_params)
             else:
                 query = f"""
                     MATCH (a), (b)

--- a/tests/unit/core/test_bundle_pk_map.py
+++ b/tests/unit/core/test_bundle_pk_map.py
@@ -1,0 +1,105 @@
+"""_PK_MAP must cover every node table Kùzu declares (see issue #1322).
+
+Kùzu/Ladybug reject a bare `CREATE (n:Label)` with
+"Create node n expects primary key <field> as input", so a label missing from
+_PK_MAP does not degrade — its import fails outright.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.cgc_bundle import CGCBundle
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "codegraphcontext"
+    / "core"
+    / "database_embedded_kuzu.py"
+)
+
+
+def _declared_node_tables() -> dict:
+    """Parse (label -> pk field tuple) out of the Kùzu node_tables block."""
+    source = SCHEMA_PATH.read_text(encoding="utf-8")
+    block = source.split("node_tables = [", 1)[1].split("\n        ]", 1)[0]
+
+    tables = {}
+    for label, body in re.findall(r'\("(\w+)",\s*"([^"]+)"\)', block):
+        match = re.search(r"PRIMARY KEY \(([^)]+)\)", body)
+        if match:
+            tables[label] = tuple(f.strip() for f in match.group(1).split(","))
+    return tables
+
+
+def test_schema_parse_found_the_tables():
+    """Guard the parser itself — a silent empty parse would pass everything."""
+    tables = _declared_node_tables()
+    assert len(tables) > 20, f"only parsed {len(tables)} node tables"
+    assert tables["Repository"] == ("path",)
+    assert tables["DbColumn"] == ("name", "table_fqn")
+
+
+def test_every_kuzu_node_table_has_a_pk_map_entry():
+    tables = _declared_node_tables()
+    missing = sorted(set(tables) - set(CGCBundle._PK_MAP))
+    assert not missing, (
+        "node labels declared in the Kùzu schema but absent from _PK_MAP "
+        f"(their bundle import will fail): {missing}"
+    )
+
+
+def test_pk_map_fields_match_the_declared_primary_keys():
+    tables = _declared_node_tables()
+    mismatched = {
+        label: {"schema": pk, "pk_map": CGCBundle._PK_MAP[label]}
+        for label, pk in tables.items()
+        if label in CGCBundle._PK_MAP and CGCBundle._PK_MAP[label] != pk
+    }
+    assert not mismatched, f"_PK_MAP disagrees with the schema: {mismatched}"
+
+
+def test_pk_map_has_no_labels_the_schema_does_not_declare():
+    tables = _declared_node_tables()
+    extra = sorted(set(CGCBundle._PK_MAP) - set(tables))
+    assert not extra, f"_PK_MAP entries with no matching node table: {extra}"
+
+
+@pytest.mark.parametrize(
+    "label,expected",
+    [
+        ("DbTable", ("name",)),
+        ("ExternalClass", ("name",)),
+        ("DbColumn", ("name", "table_fqn")),
+        ("RedisKeyPattern", ("pattern", "datasource_name")),
+        ("EnumMember", ("uid",)),
+        ("Mixin", ("uid",)),
+        ("Extension", ("uid",)),
+        ("Object", ("uid",)),
+        ("Datasource", ("name",)),
+    ],
+)
+def test_labels_reported_in_1322_are_now_mapped(label, expected):
+    assert CGCBundle._pk_fields(label) == expected
+
+
+def test_unknown_label_reports_no_pk_fields():
+    assert CGCBundle._pk_fields("NotARealLabel") == ()
+
+
+def test_composite_key_lookup_carries_every_field():
+    """Edge matching must keep both halves of a composite key."""
+    bundle = object.__new__(CGCBundle)
+    key = bundle._node_lookup_key(
+        ["DbColumn"], {"name": "id", "table_fqn": "db.users", "type": "INT"}
+    )
+
+    assert key == ("DbColumn", (("name", "id"), ("table_fqn", "db.users")))
+
+
+def test_lookup_is_none_when_a_composite_field_is_absent():
+    bundle = object.__new__(CGCBundle)
+
+    assert bundle._node_lookup_key(["DbColumn"], {"name": "id"}) is None


### PR DESCRIPTION
Closes #1322

Bundle import failed with `Create node n expects primary key name as input` because `_PK_MAP` was missing labels. Without an entry, `_import_node_batch` falls through to a bare `CREATE (n:Label)`, which Kùzu/Ladybug reject outright — so a missing label does not degrade, it fails the import.

**Scope is wider than the issue.** It names `DbTable` and `ExternalClass`. Diffing `_PK_MAP` against the `PRIMARY KEY` declarations in `database_embedded_kuzu.py` turned up **nine** missing labels:

`DbTable`, `ExternalClass`, `Datasource`, `DbColumn`, `RedisKeyPattern`, `EnumMember`, `Mixin`, `Extension`, `Object`

**Two of them have composite primary keys the old single-field design could not express at all** — `DbColumn (name, table_fqn)` and `RedisKeyPattern (pattern, datasource_name)`. So `_PK_MAP` values are now tuples throughout and all three consumers build their patterns from every key field:

- the `_import_node_batch` `MERGE`
- `_node_lookup_key`, whose tuple becomes `(label, ((field, value), ...))` so a composite key survives into edge matching
- the Kùzu/Ladybug edge `MATCH`, which previously bound exactly one field per side

`EnumMember`/`Mixin`/`Extension`/`Object` also needed `_UID_PARTS` entries so their `uid` is synthesised like their siblings.

**The tests parse the `PRIMARY KEY` declarations straight out of the schema module** and assert `_PK_MAP` matches in *both* directions — so a node table added later without a `_PK_MAP` entry fails here rather than at a user's import. The parser itself is guarded, since a silent empty parse would vacuously pass everything.

**Verified: 940 passed, 7 skipped, 0 failed** across `tests/unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)