### PR TITLE
fix(viz): match backend internal keys case-insensitively (#1458)

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -608,6 +608,20 @@ def _render_offline_visualization(
     def _ident(value) -> Optional[str]:
         return None if value is None else str(value)
 
+    # Kùzu spells its internal dict fields lowercase (_label/_src/_dst/_id);
+    # LadybugDB spells the same fields uppercase (_LABEL/_SRC/_DST/_ID). Match
+    # either casing — keying on one only means every row is discarded on the
+    # other backend and the renderer reports an empty graph (see issue #1458).
+    def _meta(value, name: str):
+        """Read a backend-internal dict field regardless of its casing."""
+        for key in (f"_{name.lower()}", f"_{name.upper()}"):
+            if key in value:
+                return value[key]
+        return None
+
+    def _has_meta(value, name: str) -> bool:
+        return f"_{name.lower()}" in value or f"_{name.upper()}" in value
+
     # Neo4j/Falkor return driver objects carrying .labels / .type; Kùzu and
     # Ladybug return plain dicts carrying _label plus _src/_dst. Check the
     # driver attributes first — a driver object may also be dict-like.
@@ -616,7 +630,11 @@ def _render_offline_visualization(
             return False
         if hasattr(value, "type"):
             return True
-        return isinstance(value, dict) and "_src" in value and "_dst" in value
+        return (
+            isinstance(value, dict)
+            and _has_meta(value, "src")
+            and _has_meta(value, "dst")
+        )
 
     def _is_node(value) -> bool:
         if hasattr(value, "labels"):
@@ -625,7 +643,11 @@ def _render_offline_visualization(
             return False
         # Kùzu relationships also carry _label, so _src/_dst is what
         # distinguishes them from nodes.
-        return isinstance(value, dict) and "_label" in value and "_src" not in value
+        return (
+            isinstance(value, dict)
+            and _has_meta(value, "label")
+            and not _has_meta(value, "src")
+        )
 
     def _node_payload(value) -> Dict[str, Any]:
         if hasattr(value, "labels"):
@@ -634,8 +656,9 @@ def _render_offline_visualization(
             label = labels[0] if labels else "Node"
             node_id = getattr(value, "element_id", None) or getattr(value, "id", None)
         else:
-            props, label = dict(value), value.get("_label", "Node")
-            node_id = value.get("_id")
+            props = dict(value)
+            label = _meta(value, "label") or "Node"
+            node_id = _meta(value, "id")
         if node_id is None:
             node_id = props.get("path") or props.get("name")
         return {
@@ -657,9 +680,9 @@ def _render_offline_visualization(
             }
         if isinstance(value, dict):
             return {
-                "source": _ident(value.get("_src")),
-                "target": _ident(value.get("_dst")),
-                "type": value.get("_label", "RELATED"),
+                "source": _ident(_meta(value, "src")),
+                "target": _ident(_meta(value, "dst")),
+                "type": _meta(value, "label") or "RELATED",
             }
         return None
 

--- a/tests/unit/cli/test_offline_visualization.py
+++ b/tests/unit/cli/test_offline_visualization.py
@@ -66,9 +66,27 @@ _N2 = _Node("4:2", ["Function"], name="alpha", path="/repo/a.py", line_number=3)
 NEO4J_RECORDS = [_Record([_N1, _Rel("CONTAINS", _N1, _N2), _N2])]
 
 
+# --- LadybugDB shape: same plain dicts, but the internal fields are UPPERCASE.
+# Keying only on the lowercase spelling discarded every row and made the
+# renderer report an empty graph (issue #1458). ------------------------------
+
+LADYBUG_RECORDS = [
+    _Record([
+        {"_ID": "0:1", "_LABEL": "File", "path": "/repo/a.py", "name": "a.py"},
+        {"_SRC": "0:1", "_DST": "0:2", "_LABEL": "CONTAINS"},
+        {"_ID": "0:2", "_LABEL": "Function", "name": "alpha", "path": "/repo/a.py",
+         "line_number": 3},
+    ])
+]
+
+
 @pytest.mark.parametrize(
     "records,label",
-    [(KUZU_RECORDS, "kuzu-style dicts"), (NEO4J_RECORDS, "neo4j-style objects")],
+    [
+        (KUZU_RECORDS, "kuzu-style dicts"),
+        (NEO4J_RECORDS, "neo4j-style objects"),
+        (LADYBUG_RECORDS, "ladybug-style uppercase dicts"),
+    ],
 )
 def test_offline_renderer_handles_both_driver_shapes(records, label, tmp_path, monkeypatch):
     """Kùzu/Ladybug return plain dicts carrying `_label`/`_src`/`_dst`, while
@@ -129,3 +147,54 @@ def test_sync_viz_dist_script_exists_and_is_executable():
     assert script.is_file(), f"{script} is referenced by the CLI but missing"
     assert os.access(script, os.X_OK), f"{script} is not executable"
     assert "viz/dist" in script.read_text(encoding="utf-8")
+
+
+def test_ladybug_uppercase_records_do_not_produce_an_empty_graph(tmp_path, monkeypatch):
+    """Regression for #1458: uppercase internal keys used to be discarded
+    wholesale, so the renderer exited with 'No graph data returned'."""
+    monkeypatch.setattr("webbrowser.open", lambda *_a, **_k: True)
+    out = tmp_path / "graph.html"
+
+    cli_helpers._render_offline_visualization(
+        _db_manager(LADYBUG_RECORDS), repo_path="/repo", output_path=str(out)
+    )
+
+    html = out.read_text(encoding="utf-8")
+    assert "alpha" in html
+    assert "CONTAINS" in html
+
+
+def test_mixed_casing_in_one_record_is_handled(tmp_path, monkeypatch):
+    """Nothing guarantees a backend is internally consistent about casing."""
+    monkeypatch.setattr("webbrowser.open", lambda *_a, **_k: True)
+    out = tmp_path / "graph.html"
+    records = [
+        _Record([
+            {"_id": "0:1", "_label": "File", "path": "/repo/a.py", "name": "a.py"},
+            {"_SRC": "0:1", "_DST": "0:2", "_LABEL": "CALLS"},
+            {"_ID": "0:2", "_LABEL": "Function", "name": "beta", "path": "/repo/a.py"},
+        ])
+    ]
+
+    cli_helpers._render_offline_visualization(
+        _db_manager(records), repo_path="/repo", output_path=str(out)
+    )
+
+    html = out.read_text(encoding="utf-8")
+    assert "beta" in html
+    assert "CALLS" in html
+
+
+def test_uppercase_relationship_is_not_mistaken_for_a_node(tmp_path, monkeypatch):
+    """_LABEL alone must not classify a row as a node — _SRC/_DST decide."""
+    monkeypatch.setattr("webbrowser.open", lambda *_a, **_k: True)
+    out = tmp_path / "graph.html"
+
+    cli_helpers._render_offline_visualization(
+        _db_manager(LADYBUG_RECORDS), repo_path="/repo", output_path=str(out)
+    )
+
+    html = out.read_text(encoding="utf-8")
+    # The CONTAINS row carries _LABEL too; if it were treated as a node the
+    # renderer would emit a node whose name is empty and whose id is 'None'.
+    assert '"id": "None"' not in html


### PR DESCRIPTION
Closes #1458

The offline renderer's four parsing helpers keyed only on the lowercase internal fields Kùzu returns (`_label`/`_src`/`_dst`/`_id`). LadybugDB returns the same fields **uppercase** (`_LABEL`/`_SRC`/`_DST`/`_ID`), so no dict branch matched, every value was discarded, and the renderer bailed out with `No graph data returned — index a repository first` against a database that demonstrably held data.

Adds `_meta()` / `_has_meta()` helpers accepting either casing, and routes all four helpers through them.

**Deliberately additive and low-risk:** both helpers try the **lowercase spelling first** and only then uppercase, so the Kùzu, Neo4j and Falkor code paths are byte-for-byte unchanged. Mixed casing inside a single record also works, since each field resolves independently.

**One intentional behaviour change, called out explicitly:** an empty-or-missing `_label` now falls back to `Node`/`RELATED`, whereas previously only a *missing* key hit the default and a present-but-empty one propagated `""`.

Tests add the Ladybug uppercase shape to the existing backend-shape parametrisation, plus three cases: uppercase records render, mixed casing renders, and an uppercase relationship is still **not** misclassified as a node (`_LABEL` alone must not decide — `_SRC`/`_DST` does).

**Verified: 944 passed, 7 skipped, 0 failed** across `tests/unit`.

> ⚠️ Touches the same four helpers as #1453 (real FalkorDB Node/Edge shape). They are complementary — different backends, different failure — but will conflict textually. Merge #1453 first, then rebase this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)