### PR TITLE
fix(core): name the backend a fallback actually landed on (#1331)

### DIFF
--- a/src/codegraphcontext/core/__init__.py
+++ b/src/codegraphcontext/core/__init__.py
@@ -48,6 +48,49 @@ def _fallback_db_path_for(db_path: Optional[str], target_backend: str) -> Option
     return db_path
 
 
+def _try_fallback_backends(db_path: Optional[str], candidates, *, reason: str):
+    """
+    Return the first available backend from ``candidates``, naming it in the log.
+
+    Every fallback path funnels through here so the backend a user actually ends
+    up on is always recorded. A silent switch is effectively undebuggable: the
+    only trace left is that the *requested* backend was requested, so an
+    interpreter where FalkorDB Lite cannot load looks identical to one where it
+    loaded fine, and queries run against a different (often empty) database.
+
+    Returns ``None`` when no candidate is available, so callers keep control of
+    the error they raise.
+    """
+    from codegraphcontext.utils.debug_log import warning_logger
+
+    for name in candidates:
+        if name == 'kuzudb' and _is_kuzudb_available():
+            from .database_kuzu import KuzuDBManager
+            path = _fallback_db_path_for(db_path, 'kuzudb')
+            warning_logger(
+                f"Database backend fallback: {reason} "
+                f"Now using KùzuDB at {path or 'default path'}."
+            )
+            return KuzuDBManager(db_path=path)
+        if name == 'ladybugdb' and _is_ladybugdb_available():
+            from .database_ladybug import LadybugDBManager
+            path = _fallback_db_path_for(db_path, 'ladybugdb')
+            warning_logger(
+                f"Database backend fallback: {reason} "
+                f"Now using LadybugDB at {path or 'default path'}."
+            )
+            return LadybugDBManager(db_path=path)
+        if name == 'neo4j' and _is_neo4j_configured():
+            from .database import DatabaseManager
+            warning_logger(f"Database backend fallback: {reason} Now using Neo4j Server.")
+            return DatabaseManager()
+        if name == 'nornic' and _is_nornic_configured():
+            from .database_nornic import NornicDBManager
+            warning_logger(f"Database backend fallback: {reason} Now using Nornic DB.")
+            return NornicDBManager()
+    return None
+
+
 def mark_falkordb_unavailable() -> None:
     """Remember that FalkorDB Lite cannot run in this process."""
     global _FALKORDB_DISABLED
@@ -124,17 +167,13 @@ def get_database_manager(db_path: Optional[str] = None) -> Union['DatabaseManage
         db_type = db_type.lower()
         if db_type == 'kuzudb':
             if not _is_kuzudb_available():
-                info_logger("Kùzu is not installed. Falling back to an available configured backend.")
-                if _is_ladybugdb_available():
-                    from .database_ladybug import LadybugDBManager
-                    return LadybugDBManager(db_path=db_path)
-                if _is_neo4j_configured():
-                    from .database import DatabaseManager
-                    info_logger("Using Neo4j Server (fallback)")
-                    return DatabaseManager()
-                if _is_nornic_configured():
-                    from .database_nornic import NornicDBManager
-                    return NornicDBManager()
+                mgr = _try_fallback_backends(
+                    db_path,
+                    ('ladybugdb', 'neo4j', 'nornic'),
+                    reason="database was set to 'kuzudb' but Kùzu is not installed.",
+                )
+                if mgr is not None:
+                    return mgr
                 raise ValueError("Database set to 'kuzudb' but Kùzu is not installed.\nRun 'pip install kuzu'")
             from .database_kuzu import KuzuDBManager
             info_logger(f"Using KùzuDB (explicit) at {db_path or 'default path'}")
@@ -143,22 +182,16 @@ def get_database_manager(db_path: Optional[str] = None) -> Union['DatabaseManage
         elif db_type == 'falkordb':
             if not is_falkordb_usable():
                 if _FALKORDB_DISABLED:
-                    info_logger("FalkorDB Lite disabled for this process after earlier failure. Falling back to an available backend.")
+                    reason = "FalkorDB Lite was disabled for this process after an earlier failure."
                 else:
-                    info_logger("FalkorDB Lite is not supported or not installed. Falling back to an available backend.")
-                if _is_kuzudb_available():
-                    from .database_kuzu import KuzuDBManager
-                    return KuzuDBManager(db_path=_fallback_db_path_for(db_path, 'kuzudb'))
-                if _is_ladybugdb_available():
-                    from .database_ladybug import LadybugDBManager
-                    return LadybugDBManager(db_path=_fallback_db_path_for(db_path, 'ladybugdb'))
-                if _is_neo4j_configured():
-                    from .database import DatabaseManager
-                    info_logger("Using Neo4j Server (fallback)")
-                    return DatabaseManager()
-                if _is_nornic_configured():
-                    from .database_nornic import NornicDBManager
-                    return NornicDBManager()
+                    reason = "FalkorDB Lite is not supported or not installed here."
+                mgr = _try_fallback_backends(
+                    db_path,
+                    ('kuzudb', 'ladybugdb', 'neo4j', 'nornic'),
+                    reason=reason,
+                )
+                if mgr is not None:
+                    return mgr
                 raise ValueError(
                     "Database set to 'falkordb' but FalkorDB Lite is not installed or not supported on this OS.\n"
                     "Install 'falkordblite' or configure a supported alternative such as KùzuDB or Neo4j."
@@ -172,20 +205,13 @@ def get_database_manager(db_path: Optional[str] = None) -> Union['DatabaseManage
                 return mgr
             except FalkorDBUnavailableError as falkor_err:
                 mark_falkordb_unavailable()
-                info_logger(f"FalkorDB Lite not functional ({falkor_err}). Falling back to available backend.")
-                if _is_kuzudb_available():
-                    from .database_kuzu import KuzuDBManager
-                    return KuzuDBManager(db_path=_fallback_db_path_for(db_path, 'kuzudb'))
-                if _is_ladybugdb_available():
-                    from .database_ladybug import LadybugDBManager
-                    return LadybugDBManager(db_path=_fallback_db_path_for(db_path, 'ladybugdb'))
-                if _is_neo4j_configured():
-                    from .database import DatabaseManager
-                    info_logger("Using Neo4j Server (fallback)")
-                    return DatabaseManager()
-                if _is_nornic_configured():
-                    from .database_nornic import NornicDBManager
-                    return NornicDBManager()
+                mgr = _try_fallback_backends(
+                    db_path,
+                    ('kuzudb', 'ladybugdb', 'neo4j', 'nornic'),
+                    reason=f"FalkorDB Lite was requested but is not functional ({falkor_err}).",
+                )
+                if mgr is not None:
+                    return mgr
                 raise
 
         elif db_type == 'falkordb-remote':

--- a/tests/unit/core/test_backend_fallback_logging.py
+++ b/tests/unit/core/test_backend_fallback_logging.py
@@ -1,0 +1,78 @@
+"""
+Regression tests for #1331 — a backend fallback must name the backend it landed on.
+
+The bug these pin down: when an explicitly requested backend was unavailable,
+`get_database_manager` returned a *different* backend without logging which one.
+The user's only signal was the banner naming the backend they *asked* for, so an
+interpreter where FalkorDB Lite cannot load was indistinguishable from one where
+it loaded fine — while queries silently ran against a different, often empty, DB.
+"""
+import sys
+
+import pytest
+
+import codegraphcontext.core as core
+
+
+@pytest.fixture
+def fallback_log(monkeypatch):
+    """Capture warning_logger output emitted during backend selection."""
+    messages = []
+
+    import codegraphcontext.utils.debug_log as debug_log
+
+    monkeypatch.setattr(debug_log, "warning_logger", messages.append)
+    monkeypatch.setattr(debug_log, "info_logger", lambda *_a, **_k: None)
+    return messages
+
+
+def _only_backend(monkeypatch, available):
+    """Make exactly one backend look available, and none of the others."""
+    for name, flag in (
+        ("_is_kuzudb_available", "kuzudb"),
+        ("_is_ladybugdb_available", "ladybugdb"),
+    ):
+        monkeypatch.setattr(core, name, lambda f=flag: f == available)
+    monkeypatch.setattr(core, "_is_neo4j_configured", lambda: available == "neo4j")
+    monkeypatch.setattr(core, "_is_nornic_configured", lambda: available == "nornic")
+
+
+def test_falkordb_to_kuzu_fallback_names_kuzu(monkeypatch, fallback_log):
+    """The Failure Mode 1 from #1331: FalkorDB unusable, Kùzu takes over silently."""
+    monkeypatch.setenv("CGC_RUNTIME_DB_TYPE", "falkordb")
+    monkeypatch.setattr(core, "is_falkordb_usable", lambda: False)
+    _only_backend(monkeypatch, "kuzudb")
+
+    sentinel = object()
+    fake = type(sys)("codegraphcontext.core.database_kuzu")
+    fake.KuzuDBManager = lambda db_path=None: sentinel
+    monkeypatch.setitem(sys.modules, "codegraphcontext.core.database_kuzu", fake)
+
+    assert core.get_database_manager() is sentinel
+
+    joined = " ".join(fallback_log)
+    assert "fallback" in joined.lower(), f"no fallback logged: {fallback_log!r}"
+    assert "Kùzu" in joined, f"fallback did not name the backend it landed on: {fallback_log!r}"
+
+
+def test_kuzu_missing_fallback_names_the_replacement(monkeypatch, fallback_log):
+    """Explicit kuzudb with Kùzu absent must still say what it fell back to."""
+    monkeypatch.setenv("CGC_RUNTIME_DB_TYPE", "kuzudb")
+    _only_backend(monkeypatch, "ladybugdb")
+
+    sentinel = object()
+    fake = type(sys)("codegraphcontext.core.database_ladybug")
+    fake.LadybugDBManager = lambda db_path=None: sentinel
+    monkeypatch.setitem(sys.modules, "codegraphcontext.core.database_ladybug", fake)
+
+    assert core.get_database_manager() is sentinel
+    assert any("LadybugDB" in m for m in fallback_log), fallback_log
+
+
+def test_no_backend_available_still_raises(monkeypatch, fallback_log):
+    """Funnelling through the helper must not swallow the 'nothing installed' error."""
+    monkeypatch.setenv("CGC_RUNTIME_DB_TYPE", "kuzudb")
+    _only_backend(monkeypatch, "none-of-them")
+
+    with pytest.raises(ValueError, match="Kùzu is not installed"):
+        core.get_database_manager()


### PR DESCRIPTION

`get_database_manager` had eight fallback branches that returned a manager
without logging which backend won. When an explicitly requested backend was
unavailable, the only signal a user got was the CLI banner naming the backend
they *asked* for — so an interpreter where FalkorDB Lite cannot load looked
identical to one where it loaded fine, while queries ran against a different,
often empty, database.

This is the "Failure Mode 1" from #1331: on Python 3.13 `falkordblite` is not
installed, selection quietly falls through to Kùzu, and nothing says so.

The three duplicated four-branch fallback chains now funnel through a single
`_try_fallback_backends` helper that logs the backend it landed on and the
reason it fell back. It returns `None` when nothing is available so callers
keep control of the error they raise, preserving the existing messages.

Also fixes a latent inconsistency: the `kuzudb` → LadybugDB path did not run
`_fallback_db_path_for`, so a `…/db/falkordb` path could be handed to Ladybug.

Tests: `tests/unit/core/test_backend_fallback_logging.py` — 2 of the 3 fail
against the pre-fix code and all pass after.

Note: the CLI banner itself is still derived from the *configured* value at
cli/main.py:474-476 rather than from the factory, so it can still print a
backend that lost the fallback. That needs an eager `get_database_manager()`
call on the explicit path, which changes DB-startup timing, so it is left for
a separate PR.

Closes #1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)