### PR TITLE
fix(bundle): map primary keys for 7 unimportable node labels (#1322)

### DIFF
--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -1009,6 +1009,16 @@ cgc import <bundle-file>.cgc
         
         return count
     
+    # Must stay in step with the node tables declared in
+    # database_embedded_kuzu.py. A label missing here falls through to the
+    # `CREATE (n:Label) SET n = $props` branch, which Kùzu rejects with
+    # "Create node n expects primary key <field> as input" — so an omission is
+    # not a slow path, it is a hard import failure for any bundle containing
+    # that label (#1322).
+    #
+    # Not yet covered: DbColumn PK(name, table_fqn) and RedisKeyPattern
+    # PK(pattern, datasource_name). Composite keys need a multi-key MERGE and a
+    # wider `_node_lookup_key` tuple; tracked separately.
     _PK_MAP = {
         'Repository': 'path', 'File': 'path', 'Directory': 'path',
         'Module': 'name',
@@ -1016,7 +1026,9 @@ cgc import <bundle-file>.cgc
         'Trait': 'uid', 'Interface': 'uid', 'Macro': 'uid',
         'Struct': 'uid', 'Enum': 'uid', 'Union': 'uid',
         'Annotation': 'uid', 'Record': 'uid', 'Property': 'uid',
-        'Parameter': 'uid',
+        'Parameter': 'uid', 'EnumMember': 'uid', 'Mixin': 'uid',
+        'Extension': 'uid', 'Object': 'uid',
+        'DbTable': 'name', 'Datasource': 'name', 'ExternalClass': 'name',
     }
     _UID_PARTS = {
         'Function': ['name', 'path', 'line_number'],
@@ -1032,6 +1044,10 @@ cgc import <bundle-file>.cgc
         'Record': ['name', 'path', 'line_number'],
         'Property': ['name', 'path', 'line_number'],
         'Parameter': ['name', 'path', 'function_line_number'],
+        'EnumMember': ['name', 'path', 'line_number'],
+        'Mixin': ['name', 'path', 'line_number'],
+        'Extension': ['name', 'path', 'line_number'],
+        'Object': ['name', 'path', 'line_number'],
     }
 
     def _import_node_batch(self, session, batch: List[Tuple], id_mapping: Dict) -> int:

--- a/tests/unit/core/test_bundle_pk_map_coverage.py
+++ b/tests/unit/core/test_bundle_pk_map_coverage.py
@@ -1,0 +1,73 @@
+"""
+Regression tests for #1322 — `_PK_MAP` must cover the declared node tables.
+
+A label absent from `_PK_MAP` does not degrade gracefully. `_import_node_batch`
+falls through to `CREATE (n:Label) SET n = $props`, and Kùzu rejects that with
+"Create node n expects primary key <field> as input", so importing any bundle
+containing that label fails outright.
+
+The coverage test derives its expectations from the schema itself, so adding a
+node table without teaching the importer about it fails here rather than in a
+user's bundle import.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.cgc_bundle import CGCBundle
+
+SCHEMA_FILE = (
+    Path(__file__).resolve().parents[3]
+    / "src" / "codegraphcontext" / "core" / "database_embedded_kuzu.py"
+)
+
+# Composite primary keys need a multi-key MERGE and a wider `_node_lookup_key`
+# tuple than the current (label, field, value) shape. Tracked separately; listed
+# here so this test states the gap instead of hiding it.
+KNOWN_COMPOSITE_PK_LABELS = {"DbColumn", "RedisKeyPattern"}
+
+
+def declared_node_tables():
+    """(label, primary-key-fields) for every node table in the Kùzu schema."""
+    text = SCHEMA_FILE.read_text()
+    found = re.findall(r'\("(\w+)",\s*"[^"]*PRIMARY KEY \(([^)]+)\)"', text)
+    assert found, "could not parse any node tables out of the Kùzu schema"
+    return [(label, [f.strip() for f in keys.split(",")]) for label, keys in found]
+
+
+@pytest.mark.parametrize(
+    "label,pk_fields",
+    [(l, k) for l, k in declared_node_tables() if l not in KNOWN_COMPOSITE_PK_LABELS],
+)
+def test_single_key_label_is_mapped(label, pk_fields):
+    """Every single-PK node table must be importable."""
+    assert len(pk_fields) == 1, (
+        f"{label} has a composite PK; add it to KNOWN_COMPOSITE_PK_LABELS "
+        f"or teach _PK_MAP about composite keys"
+    )
+    assert label in CGCBundle._PK_MAP, (
+        f"{label} is a declared node table but missing from _PK_MAP; "
+        f"importing a bundle containing it would fail"
+    )
+    assert CGCBundle._PK_MAP[label] == pk_fields[0], (
+        f"{label} PK mismatch: schema says {pk_fields[0]!r}, "
+        f"_PK_MAP says {CGCBundle._PK_MAP[label]!r}"
+    )
+
+
+def test_labels_reported_in_1322_are_mapped():
+    """The two labels named in the issue report, pinned explicitly."""
+    assert CGCBundle._PK_MAP.get("DbTable") == "name"
+    assert CGCBundle._PK_MAP.get("ExternalClass") == "name"
+
+
+def test_uid_labels_can_derive_a_uid():
+    """A 'uid' PK is synthesised from _UID_PARTS, so those parts must exist."""
+    for label, field in CGCBundle._PK_MAP.items():
+        if field == "uid":
+            assert CGCBundle._UID_PARTS.get(label), (
+                f"{label} uses a uid primary key but has no _UID_PARTS entry, "
+                f"so its uid would be the empty string and all such nodes "
+                f"would collapse onto one"
+            )


### PR DESCRIPTION

`CGCBundle._PK_MAP` had drifted behind the node tables declared in
`database_embedded_kuzu.py`. A label missing from the map falls through to the
`CREATE (n:Label) SET n = $props` branch of `_import_node_batch`, which Kùzu
rejects with "Create node n expects primary key name as input" — so an omission
is not a slow path, it is a hard failure for any bundle containing that label.

#1322 reports DbTable and ExternalClass. Diffing the map against the schema
found seven affected labels, not two:

  EnumMember, Mixin, Extension, Object   PK(uid)
  DbTable, Datasource, ExternalClass     PK(name)

The four uid-keyed labels also needed `_UID_PARTS` entries. Without them the
synthesised uid is the empty string, which would silently MERGE every node of
that label onto a single row — a data-loss bug rather than an error.

Still unfixed, deliberately: DbColumn PK(name, table_fqn) and RedisKeyPattern
PK(pattern, datasource_name). Composite keys need a multi-key MERGE and a wider
`_node_lookup_key` return shape than the current (label, field, value) tuple, so
they are out of scope here. `KNOWN_COMPOSITE_PK_LABELS` in the new test records
the gap explicitly instead of leaving it implicit.

Tests: `tests/unit/core/test_bundle_pk_map_coverage.py` derives expectations
from the schema file itself, so adding a node table without teaching the
importer about it now fails in CI instead of in a user's import. 8 of its cases
fail against the pre-fix code; all 26 pass after.

Closes #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)