### PR TITLE
fix(deps): cap mcp below 2.0 — main is red because Server.list_tools is gone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,13 @@ dependencies = [
     # ------------------------------------------------------------------
     "kuzu; python_version < '3.14' or sys_platform == 'linux'",
     "ladybug; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
-    "mcp>=1.0.0",
+    # Cap below 2.0: the low-level `mcp.server.Server` dropped its `list_tools`
+    # and `call_tool` decorators in 2.0.0, which api/mcp_sse.py registers its
+    # handlers with. With an unbounded pin, CI resolved 2.0.0 on release day and
+    # every job failed at import with
+    # "AttributeError: 'Server' object has no attribute 'list_tools'".
+    # Lift this once mcp_sse.py is ported to the 2.x server API.
+    "mcp>=1.0.0,<2",
     "fastapi>=0.100.0",
     "uvicorn>=0.22.0"
 ]

--- a/tests/unit/api/test_mcp_server_api_contract.py
+++ b/tests/unit/api/test_mcp_server_api_contract.py
@@ -1,0 +1,51 @@
+"""
+Guards the `mcp` low-level server API that `api/mcp_sse.py` is built on.
+
+`mcp_sse` registers its handlers with the `@mcp_server.list_tools()` and
+`@mcp_server.call_tool()` decorators. Both were removed from the low-level
+`Server` in mcp 2.0.0. Because the dependency was pinned `mcp>=1.0.0` with no
+upper bound, CI resolved 2.0.0 the day it was published and every job died
+during collection with:
+
+    AttributeError: 'Server' object has no attribute 'list_tools'
+
+An import-time AttributeError inside an unrelated test module is a poor signal
+for "your MCP dependency is too new", so this test states the contract directly.
+"""
+import importlib.metadata as importlib_metadata
+
+import pytest
+from packaging.version import Version
+
+from mcp.server import Server
+
+
+REQUIRED_DECORATORS = ("list_tools", "call_tool")
+
+
+@pytest.mark.parametrize("decorator", REQUIRED_DECORATORS)
+def test_lowlevel_server_exposes_decorator(decorator):
+    """api/mcp_sse.py cannot register its handlers without these."""
+    assert hasattr(Server, decorator), (
+        f"mcp.server.Server has no {decorator!r}. The installed mcp "
+        f"({importlib_metadata.version('mcp')}) is incompatible with "
+        f"api/mcp_sse.py, which registers handlers via @mcp_server.{decorator}(). "
+        f"Either keep mcp<2 or port mcp_sse.py to the 2.x server API."
+    )
+
+
+def test_installed_mcp_is_within_the_supported_range():
+    """Fail loudly on a major bump rather than deep inside an unrelated module."""
+    installed = Version(importlib_metadata.version("mcp"))
+    assert installed < Version("2"), (
+        f"mcp {installed} is installed but api/mcp_sse.py targets the 1.x "
+        f"low-level server API. Port mcp_sse.py before relaxing the cap in "
+        f"pyproject.toml."
+    )
+
+
+def test_mcp_sse_module_imports():
+    """The regression itself: this module failed to import under mcp 2.0.0."""
+    import codegraphcontext.api.mcp_sse as mcp_sse
+
+    assert mcp_sse.mcp_server is not None


### PR DESCRIPTION

`main` is currently failing Build Test on 3.12, 3.13 and 3.14. Every job dies
during collection, not in a test:

    ERROR collecting tests/unit/api/test_api_auth.py
    ERROR collecting tests/unit/api/test_health.py
    E   AttributeError: 'Server' object has no attribute 'list_tools'
    !!!! Interrupted: 2 errors during collection !!!!

Cause: `mcp` 2.0.0 was published, and the dependency was pinned `mcp>=1.0.0`
with no upper bound, so CI resolves 2.0.0. The low-level server dropped both
decorators that `api/mcp_sse.py` registers its handlers with. Verified against a
clean install of each:

    mcp 1.27.2 -> hasattr(mcp.server.Server, 'list_tools') is True
    mcp 2.0.0  -> hasattr(mcp.server.Server, 'list_tools') is False
                  hasattr(mcp.server.Server, 'call_tool')  is False

This is invisible locally: anyone with a pre-2.0 mcp already in their venv sees
a green suite, which is why it reached main unnoticed.

Capping at `<2` is the minimal unblock. Porting `mcp_sse.py` to the 2.x server
API is the real follow-up and is deliberately not attempted here — this PR is
meant to be safe enough to land immediately so the other open PRs stop
inheriting a red build.

Tests: `tests/unit/api/test_mcp_server_api_contract.py` asserts the two
decorators exist and that the installed mcp is <2, so a future unbounded bump
fails with an actionable message instead of an AttributeError inside an
unrelated module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)