### PR TITLE
chore(a11y): give landing-page form fields ids, names and labels (#1305)

### DIFF
--- a/website/src/components/BundleRegistrySection.tsx
+++ b/website/src/components/BundleRegistrySection.tsx
@@ -327,7 +327,13 @@ const BundleRegistrySection = () => {
                 <div className="mb-8 space-y-4">
                     <div className="relative">
                         <Search className="absolute left-4 top-3.5 h-5 w-5 text-gray-500" />
+                        <label htmlFor="bundle-search" className="sr-only">
+                            Search bundles
+                        </label>
                         <Input
+                            id="bundle-search"
+                            name="bundleSearch"
+                            type="search"
                             placeholder="SEARCH BUNDLES..."
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -271,7 +271,13 @@ const Footer = () => {
 
               <form onSubmit={handleNewsletterSubmit} className="space-y-4">
                 <div className="flex flex-col sm:flex-row gap-3">
+                  <label htmlFor="newsletter-email" className="sr-only">
+                    Email address for the newsletter
+                  </label>
                   <input
+                    id="newsletter-email"
+                    name="email"
+                    autoComplete="email"
                     type="email"
                     placeholder="YOUR EMAIL"
                     value={email}

--- a/website/src/components/HeroSection.tsx
+++ b/website/src/components/HeroSection.tsx
@@ -203,7 +203,12 @@ const HeroSection = () => {
         return (
           <div className="space-y-4 w-full relative z-10">
             <div className="flex flex-col gap-3">
+              <label htmlFor="hero-repo-url" className="sr-only">
+                Repository URL to index
+              </label>
               <Input
+                id="hero-repo-url"
+                name="repoUrl"
                 type="url"
                 placeholder="https://github.com/owner/repo"
                 value={repoUrl}


### PR DESCRIPTION

Three form controls reachable from the landing page had no `id`, no `name` and
no associated label, so assistive tech announced them as unlabelled and
Lighthouse flagged them:

  Footer.tsx                newsletter email input
  HeroSection.tsx           repository URL input
  BundleRegistrySection.tsx bundle search input

Each now has an `id`, a `name`, and a visually hidden `<label htmlFor=...>`.
Labels use `sr-only`, which is stock Tailwind and already used elsewhere in the
codebase (ThemeToggle, ui/breadcrumb, ui/pagination), so no config change is
needed and nothing moves visually.

A placeholder is not a substitute for a label: it is not exposed as an
accessible name by every screen reader and it disappears once the user types.

Also added while touching these:
  - `autoComplete="email"` on the newsletter field, so browsers can fill it
  - `type="search"` on the bundle search field, matching its role

`npx tsc --noEmit` is clean.

Closes #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)