### PR TITLE
chore: ignore a single local/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ scripts/.agents/
 # file points at scripts/sync_viz_dist.sh as the build step for viz/dist. The
 # rule made that script impossible to add without -f. Only .agents/ is ignored.
 .agents
+# Local-only scratch: audit output, ad-hoc reports, throwaway DBs and logs.
+# Everything in here is developer-machine state, never part of a release.
+/local/
 *.py[cod]
 .tox/
 .mypy_cache/


### PR DESCRIPTION

Local audit output, ad-hoc reports, throwaway DBs and logs had accumulated
loose in the repo root, each needing its own .gitignore line as it appeared
(CGC_EXPECTED_GRAPH_SPEC.md, GOLDEN_PERFECTION_REPORT.md, audit_output/,
test_env_e2e/, scratch/, cgc_api.log, *.db …).

Adds a single ignored `local/` directory to collect them, so developer-machine
state has one obvious home and new artifacts do not each need a new rule. The
existing per-artifact entries are intentionally left in place — contributors
with those paths already on disk should keep them ignored.

No tracked file moves, so nothing in the package, the wheel or the build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)