### PR TITLE
fix(bundle): stop dropping every edge on the node whose id is 0

### DIFF
--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -1119,7 +1119,12 @@ cgc import <bundle-file>.cgc
             new_from = id_mapping.get(old_from)
             new_to = id_mapping.get(old_to)
             
-            if not new_from or not new_to:
+            # `is None`, not falsy: FalkorDB's id() is 0-based, so the first
+            # node imported (the Repository) maps to 0. A truthiness test drops
+            # every edge touching it -- silently, while the caller still reports
+            # the full edge count. Neo4j elementIds (str) and Kuzu/Ladybug PK
+            # tuples are never falsy, so this only ever bit FalkorDB.
+            if new_from is None or new_to is None:
                 warning_logger(f"Skipping edge: node IDs not found in mapping")
                 continue
             

--- a/tests/unit/core/test_bundle_edge_zero_id.py
+++ b/tests/unit/core/test_bundle_edge_zero_id.py
@@ -1,0 +1,87 @@
+"""
+Regression tests for edges dropped when a node's new ID is `0`.
+
+`_import_edge_batch` maps each edge endpoint through `_id_mapping` and skips the
+edge when an endpoint is absent. The absence test was a truthiness test, so an
+endpoint that mapped to a falsy-but-valid id was treated as missing.
+
+FalkorDB's `id()` is 0-based and the Repository node is written first, so it
+maps to `0` on every import: every `Repository -> *` edge was dropped. Nothing
+surfaced it — `import_from_bundle` reports the edge count it *intended*, the
+node counts match exactly, and a `cgc find name` style check never traverses
+from Repository, so the graph looks whole until someone follows an edge out of
+the repository root.
+
+Neo4j (`elementId()` strings) and Kùzu/Ladybug (PK tuples) never produce a falsy
+endpoint, which is why this only ever affected FalkorDB.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.core.cgc_bundle import CGCBundle
+
+
+def _bundle(backend: str) -> CGCBundle:
+    """A CGCBundle whose only real behaviour is its backend type."""
+    db_manager = MagicMock()
+    db_manager.get_backend_type.return_value = backend
+    return CGCBundle(db_manager)
+
+
+def _edge(from_id: str, to_id: str) -> dict:
+    return {"from": from_id, "to": to_id, "type": "CONTAINS", "properties": {}}
+
+
+def test_edge_from_node_mapped_to_zero_is_imported():
+    """id 0 is a valid FalkorDB node id, not a missing mapping."""
+    bundle = _bundle("falkordb")
+    bundle._id_mapping = {"0": 0, "1": 1}
+    session = MagicMock()
+
+    bundle._import_edge_batch(session, [_edge("0", "1")])
+
+    assert session.run.call_count == 1, (
+        "edge out of the node mapped to id 0 was skipped; every Repository -> * "
+        "edge is lost this way, silently"
+    )
+
+
+def test_edge_into_node_mapped_to_zero_is_imported():
+    """The same endpoint check guards `to`, so cover both directions."""
+    bundle = _bundle("falkordb")
+    bundle._id_mapping = {"0": 0, "1": 1}
+    session = MagicMock()
+
+    bundle._import_edge_batch(session, [_edge("1", "0")])
+
+    assert session.run.call_count == 1
+
+
+def test_edge_with_unmapped_endpoint_is_still_skipped():
+    """The guard must keep doing its job: a genuinely absent id is not an edge."""
+    bundle = _bundle("falkordb")
+    bundle._id_mapping = {"0": 0}
+    session = MagicMock()
+
+    bundle._import_edge_batch(session, [_edge("0", "does-not-exist")])
+
+    assert session.run.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "backend,mapping",
+    [
+        ("neo4j", {"0": "4:9f:0", "1": "4:9f:1"}),
+        ("kuzudb", {"0": ("Repository", "path", "/r"), "1": ("File", "path", "/r/a")}),
+    ],
+)
+def test_other_backends_are_unaffected(backend, mapping):
+    """elementId strings and PK tuples were never falsy; keep it that way."""
+    bundle = _bundle(backend)
+    bundle._id_mapping = mapping
+    session = MagicMock()
+
+    bundle._import_edge_batch(session, [_edge("0", "1")])
+
+    assert session.run.call_count == 1


### PR DESCRIPTION
Every `Repository -> *` edge is silently lost on `cgc bundle import` with the FalkorDB backend, and nothing reports it.

## Cause

`_import_edge_batch` decides an endpoint is missing from `_id_mapping` with a truthiness test:

```python
new_from = id_mapping.get(old_from)
new_to   = id_mapping.get(old_to)

if not new_from or not new_to:      # `not 0` is True
    warning_logger("Skipping edge: node IDs not found in mapping")
    continue
```

`dict.get()` already returns `None` for a missing key, so `is None` is the condition this was reaching for. FalkorDB `id()` is 0-based and the Repository node is written first, so it maps to `0` on every import and each of its edges is discarded.

Neo4j endpoints are `elementId()` strings and Kùzu/Ladybug endpoints are `(label, pk, value)` tuples — neither is ever falsy, so only FalkorDB is affected.

## Why it is easy to miss

On a 966-node bundle, 18 of 774 `CONTAINS` edges are dropped:

| | source | after round trip |
| --- | --- | --- |
| nodes (all labels) | 966 | 966 — identical |
| total edges | 1321 | 1303 |
| `Repository->Directory` | 14 | 0 |
| `Repository->File` | 4 | 0 |
| files reachable from `Repository` | 108 | 0 |

The Repository node survives with its correct `name` and `path`; only its edges are gone. `import_from_bundle` prints the edge count it *intended* (`Edges: 1,321`), the node counts match exactly, and a symbol lookup such as `cgc find name <symbol>` still resolves because it never traverses from the repository root. The graph therefore looks whole until something follows an edge out of the root.

The export side is correct — `edges.jsonl` in the bundle contains all 774 `CONTAINS`, including the 18 out of `Repository`.

## Reproduction

Verified on **0.4.7** and **0.5.3** (18 and 19 edges lost respectively — in each case exactly the Repository outdegree):

```bash
cgc index <repo>                       # into an empty FalkorDB
cgc bundle export /tmp/rt.cgc
cgc bundle import /tmp/rt.cgc --clear --yes   # into a second empty FalkorDB
# MATCH (r:Repository)-[:CONTAINS*]->(f:File) RETURN count(DISTINCT f)  -> 0
```

With this change the round trip is exact: 1318 edges in, 1318 out, 129 files reachable from the repository root, identical node fingerprints.

## Tests

`tests/unit/core/test_bundle_edge_zero_id.py` — fails on the unpatched importer with the real `Skipping edge: node IDs not found in mapping` warning, passes with the fix. Covers both endpoint directions, that a genuinely absent id is *still* skipped (the guard keeps doing its job), and the two backends whose endpoint types were never falsy.

`tests/unit/core/test_bundle_pk_map_coverage.py` and `test_bundle_identifier_validation.py` still pass (48 tests).

## Note

Touches the same function as #1473. I first based this on that branch and then rebased onto `main` to keep the PR to a single fix — happy to re-stack if you would rather land them together.