### PR TITLE
fix: correct 13 bugs across query validation, MCP gateway, indexing and CLI (v0.5.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.5.3"
+version = "0.5.4"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"

--- a/src/codegraphcontext/api/app.py
+++ b/src/codegraphcontext/api/app.py
@@ -1,10 +1,10 @@
 # src/codegraphcontext/api/app.py
 import os
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from .router import router
-from .auth import log_auth_status
+from .auth import log_auth_status, require_api_key
 from .mcp_sse import handle_sse, handle_messages
 
 def create_app() -> FastAPI:
@@ -37,9 +37,23 @@ def create_app() -> FastAPI:
         """Liveness probe for load balancers and k8s."""
         return {"status": "ok"}
 
-    # MCP-over-SSE Endpoints
-    app.add_api_route("/api/v1/mcp/sse", handle_sse, methods=["GET"])
-    app.add_api_route("/api/v1/mcp/messages", handle_messages, methods=["POST"])
+    # MCP-over-SSE Endpoints. These dispatch to the same tools as the REST
+    # router (execute_cypher_query, add_code_to_graph, delete_repository), so
+    # they need the same API-key dependency the router applies — without it,
+    # setting CGC_API_KEY left the SSE transport as an unauthenticated path to
+    # every tool.
+    app.add_api_route(
+        "/api/v1/mcp/sse",
+        handle_sse,
+        methods=["GET"],
+        dependencies=[Depends(require_api_key)],
+    )
+    app.add_api_route(
+        "/api/v1/mcp/messages",
+        handle_messages,
+        methods=["POST"],
+        dependencies=[Depends(require_api_key)],
+    )
 
     @app.get("/", response_class=HTMLResponse)
     async def root():

--- a/src/codegraphcontext/api/mcp_sse.py
+++ b/src/codegraphcontext/api/mcp_sse.py
@@ -48,11 +48,41 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[TextConten
 # Create the SSE transport.
 sse = SseServerTransport("/api/v1/mcp/messages")
 
+
+class _AlreadySentResponse(Response):
+    """Placeholder for a response the MCP transport wrote itself.
+
+    Both handlers below hand the raw ASGI ``send`` to the SDK, which emits the
+    complete response. FastAPI still does ``await endpoint(request)`` followed
+    by ``await response(...)``, so returning ``None`` raises ``TypeError:
+    'NoneType' object is not callable`` and returning a real ``Response`` starts
+    a second response on a finished ASGI cycle. This satisfies FastAPI while
+    putting nothing on the wire.
+    """
+
+    async def __call__(self, scope, receive, send) -> None:
+        return
+
+
+class _SendTracker:
+    """ASGI ``send`` wrapper that records whether a response was started."""
+
+    def __init__(self, send):
+        self._send = send
+        self.response_started = False
+
+    async def __call__(self, message) -> None:
+        if message.get("type") == "http.response.start":
+            self.response_started = True
+        await self._send(message)
+
+
 async def handle_sse(request: Request):
     """Entry point for the SSE connection."""
     logger.info("SSE client connected")
+    sender = _SendTracker(request._send)
     try:
-        async with sse.connect_sse(request.scope, request.receive, request._send) as (read_stream, write_stream):
+        async with sse.connect_sse(request.scope, request.receive, sender) as (read_stream, write_stream):
             await mcp_server.run(
                 read_stream,
                 write_stream,
@@ -70,6 +100,10 @@ async def handle_sse(request: Request):
         logger.debug("SSE connection closed: %s", type(exc).__name__)
     finally:
         logger.info("SSE client disconnected — handler exited, resources freed")
+    if sender.response_started:
+        return _AlreadySentResponse()
+    # connect_sse bailed out before writing anything (e.g. rejected origin).
+    return Response(status_code=500, content="SSE connection could not be established")
 
 
 async def handle_messages(request: Request):
@@ -99,7 +133,20 @@ async def handle_messages(request: Request):
             media_type="application/json"
         )
 
+    # `handle_post_message` builds its own Request and awaits `.body()` again.
+    # Starlette caches a body on the Request instance, not in the scope, so
+    # handing it the raw `receive` would make it wait for a body that has
+    # already been drained above — the POST hangs until the client gives up and
+    # the message never reaches the session. Replay the buffered bytes instead.
+    async def replay_receive() -> dict:
+        return {"type": "http.request", "body": raw_body, "more_body": False}
+
+    sender = _SendTracker(request._send)
     try:
-        await sse.handle_post_message(request.scope, request.receive, request._send)
+        await sse.handle_post_message(request.scope, replay_receive, sender)
     except Exception as exc:
         logger.debug("Message handler closed: %s", type(exc).__name__)
+
+    if sender.response_started:
+        return _AlreadySentResponse()
+    return Response(status_code=202, content="Accepted")

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -3086,7 +3086,10 @@ def visualize_abbrev(
 ):
     """Shortcut for 'cgc visualize'"""
     _load_credentials()
-    visualize_helper(repo, port, context=context)
+    # `port` must be passed by keyword: visualize_helper's second positional
+    # parameter is `host`, so the int landed there and the server tried to bind
+    # to host=8000 while ignoring --port entirely.
+    visualize_helper(repo, port=port, context=context)
 
 @app.command("w", rich_help_panel="Shortcuts")
 def watch_abbrev(

--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -184,6 +184,11 @@ def find_jetbrains_mcp_config():
                     configs.append(mcp_file)
                     print(mcp_file)
                     return configs
+    # Always return a list: callers store this directly in the config_paths
+    # mapping and iterate it, so returning None (no JetBrains install, or no
+    # mcpServer.xml yet) raised a TypeError instead of falling through to the
+    # "configure manually" path.
+    return configs
 
 
 def convert_mcp_json_to_yaml():

--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -265,9 +265,13 @@ class CGCBundle:
                 # Step 1: Extract ZIP (with Zip Slip protection)
                 info_logger("Extracting bundle...")
                 with zipfile.ZipFile(bundle_path, 'r') as zip_ref:
+                    extract_root = temp_path.resolve()
                     for entry in zip_ref.namelist():
                         resolved = (temp_path / entry).resolve()
-                        if not str(resolved).startswith(str(temp_path.resolve())):
+                        # Compare path components, not string prefixes: a bare
+                        # startswith also accepts a sibling directory whose name
+                        # merely extends the target's (/tmp/tmpabc vs /tmp/tmpabc2).
+                        if resolved != extract_root and extract_root not in resolved.parents:
                             return False, f"Zip Slip detected: entry '{entry}' escapes target directory"
                     zip_ref.extractall(temp_path)
                 

--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -729,7 +729,18 @@ class EmbeddedSessionWrapper:
         try:
             # Force loop fallback for relationship writes inside UNWIND to avoid Kuzu query planner bugs
             # which can incorrectly bind/corrupt relationship endpoints across rows in the batch.
-            if "UNWIND" in query and ("-[" in query or "]->" in query) and not getattr(self, "_skip_unwind_fallback", False):
+            # Only force it for `UNWIND $param AS row`, the single shape the
+            # recovery path below can rewrite into a per-row loop. Read queries
+            # that unwind a bound list (`WITH relationships(p) AS rels UNWIND
+            # rels AS r`, used by find_all_callers/find_all_callees and the
+            # visualizer) matched this guard too, but no `$`-UNWIND for the
+            # fallback to latch onto — so the fabricated exception fell through
+            # every handler and surfaced to the caller as a hard failure.
+            if (
+                re.search(r"UNWIND\s+\$\w+\s+AS\s+\w+", query)
+                and ("-[" in query or "]->" in query)
+                and not getattr(self, "_skip_unwind_fallback", False)
+            ):
                 raise Exception("unordered_map::at (forced fallback to avoid relationship UNWIND planner bugs)")
 
             # 2. Execute under the lock. _write_lock (name kept for backward

--- a/src/codegraphcontext/core/database_falkordb.py
+++ b/src/codegraphcontext/core/database_falkordb.py
@@ -129,7 +129,11 @@ class FalkorDBManager:
                 FalkorDBManager._failed_configurations.discard(previous_configuration)
             self.shutdown()
             self._driver = None
-            self._graph = None
+            # `_graphs` (plural) is the per-graph cache; clearing the singular
+            # `_graph` left every cached wrapper bound to the worker that
+            # shutdown() just killed, so a later get_driver(graph_name=...) for
+            # any non-default graph returned a dead client.
+            self._graphs = {}
 
         self._initialized = False
         self.db_path = new_db_path

--- a/src/codegraphcontext/core/watcher.py
+++ b/src/codegraphcontext/core/watcher.py
@@ -56,6 +56,7 @@ class RepositoryEventHandler(FileSystemEventHandler):
 
         self.ignore_root = self.repo_path
         self.ignore_spec = ignore_spec
+        self.cgcignore_path = cgcignore_path
         self._load_ignore_spec(cgcignore_path)
 
         self.all_file_data = []
@@ -118,11 +119,17 @@ class RepositoryEventHandler(FileSystemEventHandler):
         from ..tools.indexing.discovery import discover_files_to_index
 
         supported = self.graph_builder.parsers.keys()
+        # Forward the explicit ignore file and re-apply this handler's own spec.
+        # Without them, discovery fell back to the repo-local .cgcignore, so the
+        # initial scan and disk sync indexed files that later change events
+        # would skip — the graph kept entries the user asked to exclude, and
+        # they went stale on edit.
         files, _ = discover_files_to_index(
             self.repo_path,
+            cgcignore_path=getattr(self, "cgcignore_path", None),
             supported_extensions=set(supported),
         )
-        return files
+        return [f for f in files if not self._should_ignore(f)]
 
     def _initial_scan(self):
         info_logger(f"Initial scan: {self.repo_path}")

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -751,10 +751,6 @@ class GraphBuilder:
                         path=caller_file_path,
                         parent_name=base_name)
 
-    def _create_all_inheritance_links(self, all_file_data: list[Dict], imports_map: dict):
-        """Create INHERITS relationships for all classes using batched UNWIND queries."""
-        return self.pre_scan_imports(files)
-
     def add_repository_to_graph(self, repo_path: Path, is_dependency: bool = False) -> None:
         """Add a repository node to the graph.
 

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -194,9 +194,13 @@ async def run_tree_sitter_index_async(
                     is_dependency,
                 )
         except Exception as exc:  # noqa: BLE001 - keep indexing the other files
-            path = file_data.get("path")
-            write_failures.append({"path": path, "error": str(exc)})
-            error_logger(f"Failed to write {path} to the graph: {exc}")
+            # Must not be named `path`: that is the function's repo-root Path
+            # parameter, still needed further down (`path.is_dir()`). Rebinding
+            # it to this file's path string turned a single recoverable write
+            # failure into an AttributeError that aborted the whole job.
+            failed_path = file_data.get("path")
+            write_failures.append({"path": failed_path, "error": str(exc)})
+            error_logger(f"Failed to write {failed_path} to the graph: {exc}")
             file_data["error"] = str(exc)
             file_data["parse_failed"] = True
 

--- a/src/codegraphcontext/tools/indexing/resolution/calls.py
+++ b/src/codegraphcontext/tools/indexing/resolution/calls.py
@@ -1143,7 +1143,9 @@ def resolve_function_call(
         and base_obj in ("$this", "this")
     ):
         enclosing_class = call.get("enclosing_class")
-        trait_hit = (local_class_trait_methods.get(enclosing_class or {}) or {}).get(
+        # `or {}` belongs outside the lookup: using {} as the *key* raises
+        # TypeError: unhashable type: 'dict' whenever enclosing_class is None.
+        trait_hit = (local_class_trait_methods.get(enclosing_class) or {}).get(
             called_name
         )
         if trait_hit:

--- a/src/codegraphcontext/tools/indexing/resolution/inheritance.py
+++ b/src/codegraphcontext/tools/indexing/resolution/inheritance.py
@@ -352,8 +352,15 @@ def build_decorated_by_links(
             for item in file_data.get(key, [])
             if item.get("name")
         }
+        # Parsed imports carry `name` / `full_import_name`; there is no `source`
+        # key, so this mapped every imported symbol to None and made
+        # _resolve_decorator_path bail out to the caller's own file before it
+        # could consult imports_map. Mirrors the working construction in
+        # build_inheritance_links above.
         local_imports = {
-            imp.get("alias") or imp.get("name"): imp.get("source")
+            imp.get("alias") or (imp.get("name") or "").split(".")[-1]: (
+                imp.get("full_import_name") or imp.get("name")
+            )
             for imp in file_data.get("imports", [])
             if imp.get("name") or imp.get("alias")
         }
@@ -408,8 +415,15 @@ def build_metaclass_links(
             continue
         caller_file_path = str(Path(file_data["path"]).resolve().as_posix())
         local_class_names = {c["name"] for c in file_data.get("classes", [])}
+        # Parsed imports carry `name` / `full_import_name`; there is no `source`
+        # key, so this mapped every imported symbol to None and made
+        # _resolve_decorator_path bail out to the caller's own file before it
+        # could consult imports_map. Mirrors the working construction in
+        # build_inheritance_links above.
         local_imports = {
-            imp.get("alias") or imp.get("name"): imp.get("source")
+            imp.get("alias") or (imp.get("name") or "").split(".")[-1]: (
+                imp.get("full_import_name") or imp.get("name")
+            )
             for imp in file_data.get("imports", [])
             if imp.get("name") or imp.get("alias")
         }

--- a/src/codegraphcontext/tools/indexing/resolution/post_resolution.py
+++ b/src/codegraphcontext/tools/indexing/resolution/post_resolution.py
@@ -192,12 +192,21 @@ def run_inheritance_reresolve(
     backend = get_backend_type(driver)
 
     def _make_write_query(caller_has_line: bool, called_has_line: bool) -> str:
+        # Every literal Cypher map here needs doubled braces — this is an
+        # f-string, so a single `{name: ...}` is parsed as a replacement field
+        # and raised NameError before the query ever reached the driver, which
+        # the caller logged as "Post-resolution failed (skipping)".
+        #
+        # The line predicates are baked in per bucket rather than tested at
+        # runtime against a possibly-null row value, which is what the
+        # caller_has_line / called_has_line bucketing exists to enable.
+        caller_line = ", line_number: row.caller_line" if caller_has_line else ""
+        called_line = ", line_number: row.new_called_line" if called_has_line else ""
         return f"""
                 UNWIND $batch AS row
-                MATCH (caller {name: row.caller_name, path: row.caller_path})
-                WHERE row.caller_line IS NULL OR caller.line_number = row.caller_line
-                MATCH (new_called:Function {name: row.called_name, path: row.new_called_path})
-                OPTIONAL MATCH (caller)-[old_edge:CALLS|HEURISTIC_CALLS]->(old_called {name: row.called_name})
+                MATCH (caller {{name: row.caller_name, path: row.caller_path{caller_line}}})
+                MATCH (new_called:Function {{name: row.called_name, path: row.new_called_path{called_line}}})
+                OPTIONAL MATCH (caller)-[old_edge:CALLS|HEURISTIC_CALLS]->(old_called {{name: row.called_name}})
                   WHERE old_edge.resolution_tier IN [8, 9]
                 DELETE old_edge
                 WITH caller, new_called, row

--- a/src/codegraphcontext/utils/cypher_readonly.py
+++ b/src/codegraphcontext/utils/cypher_readonly.py
@@ -34,24 +34,45 @@ _FORBIDDEN_PATTERNS = (
     re.compile(r"\bapoc\.(?:create|merge|refactor|periodic)\b", re.IGNORECASE),
 )
 _STRING_LITERAL_RE = re.compile(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
-_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
-_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+# Quoted spans and comments must be recognised in a single left-to-right pass.
+# Stripping literals first would treat a quote *inside* a comment as the start
+# of a literal, pairing it with a later real quote and deleting the write
+# keywords in between:
+#
+#     MATCH (n) // note with '
+#     DELETE n WHERE n.x = 'y' RETURN n
+#
+# The `'` in the comment paired with the `'` of 'y', the DELETE vanished with
+# it, and the query was accepted as read-only. Backtick-quoted identifiers are
+# consumed here too, so `` [r:`DELETE`] `` is not mistaken for a write clause.
+_LITERAL_OR_COMMENT_RE = re.compile(
+    r"""
+      '(?:\\.|[^'\\])*'      # '...'
+    | "(?:\\.|[^"\\])*"      # "..."
+    | `(?:\\.|[^`\\])*`      # `...`
+    | //[^\n]*               # // line comment
+    | /\*.*?\*/              # /* block comment */
+    """,
+    re.VERBOSE | re.DOTALL,
+)
 
 
 def strip_string_literals(query: str) -> str:
     return _STRING_LITERAL_RE.sub("", query)
 
 
-def _strip_comments(query: str) -> str:
-    without_block = _BLOCK_COMMENT_RE.sub("", query)
-    return _LINE_COMMENT_RE.sub("", without_block)
+def _strip_literals_and_comments(query: str) -> str:
+    # Replace with a space rather than "" so neighbouring tokens cannot fuse
+    # into a new identifier once the quoted span between them is removed.
+    return _LITERAL_OR_COMMENT_RE.sub(" ", query)
 
 
 def is_read_only_cypher(query: str) -> bool:
     """Return True when *query* has no write keywords outside string literals."""
     if not query or not query.strip():
         return False
-    stripped = _strip_comments(strip_string_literals(query))
+    stripped = _strip_literals_and_comments(query)
     if ";" in stripped:
         return False
     for keyword in _FORBIDDEN_KEYWORDS:

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -653,6 +653,11 @@ Suggest 2-3 specific follow-up questions or related areas the user might want to
             "links": edges
         }
         
+    except HTTPException:
+        # Preserve intentional HTTP errors (e.g. the 400 raised above when the
+        # generated Cypher is not read-only); re-wrapping them as 500 made a
+        # safety rejection look like a server failure to the frontend.
+        raise
     except Exception as e:
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/unit/api/test_api_auth.py
+++ b/tests/unit/api/test_api_auth.py
@@ -100,6 +100,41 @@ def test_root_stays_open_when_key_configured(client_factory):
     assert response.status_code == 200
 
 
+# --- MCP-over-SSE transport is behind the same key --------------------------
+
+# These routes dispatch to the same tools as the REST router (execute_cypher_query,
+# add_code_to_graph, delete_repository), so leaving them off the authenticated
+# router made CGC_API_KEY trivially bypassable.
+
+def test_mcp_messages_requires_key(client_factory):
+    client = client_factory(API_KEY)
+    response = client.post("/api/v1/mcp/messages", json={"jsonrpc": "2.0", "id": 1})
+    assert response.status_code == 401
+
+
+def test_mcp_sse_requires_key(client_factory):
+    client = client_factory(API_KEY)
+    response = client.get("/api/v1/mcp/sse")
+    assert response.status_code == 401
+
+
+def test_mcp_messages_rejects_wrong_key(client_factory):
+    client = client_factory(API_KEY)
+    response = client.post(
+        "/api/v1/mcp/messages",
+        json={"jsonrpc": "2.0", "id": 1},
+        headers={"X-API-Key": "nope"},
+    )
+    assert response.status_code == 401
+
+
+def test_mcp_messages_open_when_no_key_configured(client_factory):
+    # Backward compatible: without a configured key the transport stays open.
+    client = client_factory(None)
+    response = client.post("/api/v1/mcp/messages", json={"jsonrpc": "2.0", "id": 1})
+    assert response.status_code != 401
+
+
 # --- No key configured: backward compatible + warning -----------------------
 
 def test_no_key_endpoint_works_without_header(client_factory):

--- a/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
+++ b/tests/unit/tools/test_cross_lang_call_resolution_patterns.py
@@ -696,10 +696,9 @@ class TestCrossLangCallResolutionPatterns:
         )
         assert edge["line_number"] == 363
 
-    def test_python_decorator_resolution_handles_missing_import_source(self):
-        caller_path = "/tmp/repo/app/service.py"
-        decorator_path = "/tmp/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py"
-        file_data = {
+    @staticmethod
+    def _decorated_file_data(caller_path, imports):
+        return {
             "path": caller_path,
             "lang": "python",
             "functions": [
@@ -710,7 +709,20 @@ class TestCrossLangCallResolutionPatterns:
                 }
             ],
             "classes": [],
-            "imports": [
+            "imports": imports,
+        }
+
+    def test_python_decorator_resolves_to_the_imported_module(self):
+        # An imported decorator must point at the file it was imported from.
+        # The parser emits `name` / `full_import_name` on imports (there is no
+        # `source` key), so reading the wrong key made every imported decorator
+        # resolve to the caller's own file — where no such function exists, so
+        # the writer's MATCH found nothing and the edge was silently dropped.
+        caller_path = "/tmp/repo/app/service.py"
+        decorator_path = "/tmp/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py"
+        file_data = self._decorated_file_data(
+            caller_path,
+            [
                 {
                     "name": "retry",
                     "full_import_name": "tenacity.retry",
@@ -718,12 +730,27 @@ class TestCrossLangCallResolutionPatterns:
                     "alias": None,
                 }
             ],
-        }
-
-        edges = build_decorated_by_links(
-            [file_data],
-            {"retry": [decorator_path]},
         )
+
+        edges = build_decorated_by_links([file_data], {"retry": [decorator_path]})
+
+        assert len(edges) == 1
+        edge = edges[0]
+        assert edge["decorated_name"] == "fetch_data"
+        assert edge["decorator_name"] == "retry"
+        assert edge["decorator_path"] == str(Path(decorator_path).resolve().as_posix())
+
+    def test_python_decorator_resolution_handles_missing_import_source(self):
+        # When the import carries no usable name at all, fall back to the
+        # caller's own path rather than raising.
+        caller_path = "/tmp/repo/app/service.py"
+        decorator_path = "/tmp/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py"
+        file_data = self._decorated_file_data(
+            caller_path,
+            [{"alias": "retry", "line_number": 1}],
+        )
+
+        edges = build_decorated_by_links([file_data], {"retry": [decorator_path]})
 
         assert len(edges) == 1
         edge = edges[0]

--- a/tests/unit/utils/test_cypher_readonly.py
+++ b/tests/unit/utils/test_cypher_readonly.py
@@ -29,6 +29,24 @@ def test_ignores_write_keywords_in_comments():
     assert is_read_only_cypher("// CREATE (n)\nMATCH (n) RETURN n")
 
 
+def test_quote_inside_comment_does_not_hide_write_keywords():
+    # A quote inside a comment must not open a string literal. Stripping
+    # literals before comments let that stray quote pair with a later real
+    # quote, deleting the write clause between them and passing the query.
+    assert not is_read_only_cypher(
+        "MATCH (n) // comment with '\nDELETE n WHERE n.x = 'y' RETURN n"
+    )
+    assert not is_read_only_cypher(
+        'MATCH (n) /* note: " */ DETACH DELETE n WHERE n.name = "x" RETURN n'
+    )
+
+
+def test_backtick_quoted_identifiers_are_not_write_keywords():
+    # Cypher escapes keyword-colliding labels/rel-types with backticks.
+    assert is_read_only_cypher("MATCH (n)-[r:`DELETE`]->(m) RETURN r")
+    assert is_read_only_cypher("MATCH (n) RETURN n.`create` AS c")
+
+
 def test_blocks_write_apoc_procedures():
     # Write-side APOC namespaces must be rejected, whether called or inline.
     assert not is_read_only_cypher("CALL apoc.create.node(['L'], {}) YIELD node RETURN node")


### PR DESCRIPTION
Fixes 13 bugs found by auditing `core/`, `utils/`, `tools/`, `cli/`, `api/` and `viz/`. Every fix was reproduced or traced to a concrete call site before being changed. Bumps the version to **0.5.4**.

Full suite: **1053 passed, 19 skipped** (baseline on `main` was 1044 passed + 1 failing test in `tests/test_mcp_sse.py`, fixed here).

## Security / correctness

**Read-only Cypher guard could be bypassed** — `cypher_readonly.py` stripped string literals *before* comments, so a quote inside a comment opened a "literal" that ran to the next real quote and deleted the write clause in between:

```
MATCH (n) // comment with '
DELETE n WHERE n.x = 'y' RETURN n     -> accepted as read-only
```

On Kùzu/Ladybug/Nornic this check is the *only* gate (there is no DB-level READ mode fallback), so the mutation actually ran. Now literals and comments are matched in a single pass, the way `cypher_ddl.py` already does it. The same change stops backtick-quoted identifiers (`` [r:`DELETE`] ``) being misread as write clauses.

**MCP SSE endpoints bypassed API-key auth** — `/api/v1/mcp/sse` and `/api/v1/mcp/messages` were registered with `app.add_api_route` instead of on the authenticated router, while dispatching to the same tools as REST (`execute_cypher_query`, `add_code_to_graph`, `delete_repository`). Setting `CGC_API_KEY` left the entire tool surface reachable without a key.

## MCP-over-SSE gateway (was non-functional)

- `handle_messages` called `await request.body()` and then handed the *drained* `receive` to the SDK, which builds its own `Request` and reads the body again. Under uvicorn the POST blocked until client disconnect, so no client message was ever delivered. The buffered bytes are now replayed.
- Both handlers returned `None` after the transport had already written its response; FastAPI then does `await response(...)` → `TypeError: 'NoneType' object is not callable`. Returning a real `Response` instead double-sends (verified — `assert not response_started` fires), so a send-tracking wrapper decides between a no-op placeholder and a real response.

## Indexing

- **`pipeline.py`** — the per-file write-failure handler did `path = file_data.get("path")`, rebinding the function's repo-root `Path` parameter to a string. One unwritable file then crashed the run at `path.is_dir()` and skipped the Maven/Gradle, ORM, MyBatis and embedding phases — precisely what the `except` block exists to prevent.
- **`post_resolution.py`** — the Cypher template is an f-string but its map literals used single braces, so building the query raised `NameError` before it reached the driver. Inheritance re-resolution could never write an edge; the failure was logged as "Post-resolution failed (skipping)". The `caller_has_line`/`called_has_line` bucketing is now actually applied.
- **`calls.py`** — PHP trait lookup used `{}` as the dict *key* (`.get(enclosing_class or {})`), raising `TypeError: unhashable type: 'dict'` and aborting the whole CALLS phase.
- **`inheritance.py`** — decorator/metaclass resolution read `imp.get("source")`, a key the parsers never emit, so every imported decorator mapped to `None`, resolved to the caller's own file, and had its `DECORATED_BY`/`METACLASS` edge silently dropped at write time.
- **`graph_builder.py`** — removed a dead duplicate `_create_all_inheritance_links` whose body referenced an undefined `files`.

## Backends

- **`database_embedded_kuzu.py`** — the forced-fallback guard fired on *any* query containing `UNWIND` plus a relationship pattern, but the recovery path only rewrites `UNWIND $param AS row`. Read queries that unwind a bound list (`WITH relationships(p) AS rels UNWIND rels AS r`) had nothing to fall back to, so the fabricated `unordered_map::at` exception surfaced to the caller — breaking `find_all_callers`/`find_all_callees` and the visualizer on the embedded backends. The guard is now scoped to the shape the fallback handles.
- **`database_falkordb.py`** — reconfiguring `db_path` cleared `_graph` (a typo; the cache is `_graphs`), so every cached graph wrapper stayed bound to the worker `shutdown()` had just killed.
- **`cgc_bundle.py`** — the Zip Slip check used `startswith`, which also accepts a sibling directory whose name merely extends the target's (`/tmp/tmpabc` vs `/tmp/tmpabc2`). Now compares path components.
- **`watcher.py`** — the initial scan and disk sync did not forward the handler's explicit `.cgcignore`, so they indexed files that subsequent change events would skip; the graph kept excluded files and they went stale on edit.

## CLI / viz

- **`cgc v`** passed `port` positionally into `visualize_helper`'s `host` parameter, so the shortcut tried to bind `host=8000` and ignored `--port` entirely.
- **`setup_wizard.py`** — `find_jetbrains_mcp_config()` returned `None` when no `mcpServer.xml` exists (the common case); callers iterate the result, so choosing "JetBrainsAI" crashed with a `TypeError` instead of falling through to manual setup.
- **`viz/server.py`** — the `400` raised for a rejected AI-generated query was caught by its own `except Exception` and re-raised as a `500`, so a safety rejection looked like a server failure.

## A note on one changed test

`test_python_decorator_resolution_handles_missing_import_source` asserted that an imported decorator resolves to the **caller's** file. That codified the bug: PR #1350 fixed the resulting `AttributeError` by type-guarding the `None`, without addressing the wrong key it came from. Its own fixture supplies `full_import_name: "tenacity.retry"` and an `imports_map` pointing at tenacity, then asserted the edge points at `service.py` — where no `retry` function exists, so the writer's `MATCH` found nothing. The test now covers correct resolution, and a second case keeps the caller-path fallback for imports with genuinely no usable name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
