### PR TITLE
fix: fall back when GCF encoding fails

### DIFF
--- a/src/codegraphcontext/utils/gcf_encoder.py
+++ b/src/codegraphcontext/utils/gcf_encoder.py
@@ -15,8 +15,11 @@ See https://gcformat.com for the full specification.
 """
 
 import json
+import logging
 import os
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 _gcf_encode = None
 _gcf_checked = False
@@ -53,6 +56,9 @@ def encode_response(result: Any) -> str:
     if is_gcf_enabled():
         encoder = _load_gcf()
         if encoder is not None:
-            return encoder(result)
+            try:
+                return encoder(result)
+            except Exception:
+                logger.debug("GCF encoding failed; falling back to JSON", exc_info=True)
 
     return json.dumps(result, indent=2)

--- a/tests/unit/tools/test_gcf_encoder.py
+++ b/tests/unit/tools/test_gcf_encoder.py
@@ -84,3 +84,20 @@ class TestEncodeResponse:
         result = {"success": True, "data": "test"}
         encoded = encode_response(result)
         assert json.loads(encoded) == result
+
+    def test_falls_back_to_json_when_gcf_encoding_fails(self, monkeypatch, caplog):
+        monkeypatch.setenv("CGC_OUTPUT_FORMAT", "gcf")
+        import codegraphcontext.utils.gcf_encoder as mod
+
+        def failing_encoder(_result):
+            raise ValueError("unsupported result shape")
+
+        mod._gcf_checked = True
+        mod._gcf_encode = failing_encoder
+        result = {"success": True, "data": "test"}
+
+        with caplog.at_level("DEBUG", logger="codegraphcontext.utils.gcf_encoder"):
+            encoded = encode_response(result)
+
+        assert json.loads(encoded) == result
+        assert "GCF encoding failed; falling back to JSON" in caplog.text


### PR DESCRIPTION
## Summary

- catch failures from the optional GCF encoder and preserve the documented JSON fallback
- log the failure at debug level with the traceback for diagnosis
- add a regression test covering an encoder that raises

This follows the scoped behavior described in #1518. Successful GCF output and the missing-package fallback remain unchanged.

## Validation

- `PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/unit/tools/test_gcf_encoder.py -q` (8 passed, 2 skipped because `gcf-python` is not installed)
- `python -m compileall -q src tests/unit/tools/test_gcf_encoder.py`
- `git diff --check`

The default local pytest plugin set has an unrelated `pytest-recording` / `pytest-vcr` conflict, so the focused test was rerun with third-party plugin autoload disabled.

Closes #1518