### PR TITLE
fix: read import aliases from relationships

### DIFF
--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -654,7 +654,7 @@ class CodeFinder:
                 OPTIONAL MATCH (repo:Repository)-[:CONTAINS]->(file)
                 WITH file, repo, COLLECT({{
                     imported_module: module.name,
-                    import_alias: module.alias,
+                    import_alias: imp.alias,
                     full_import_name: module.full_import_name
                 }}) AS imports
                 RETURN

--- a/src/codegraphcontext/tools/query_tool_languages/cpp_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/cpp_toolkit.py
@@ -43,7 +43,7 @@ class CppToolkit:
             return """
                 MATCH (f:File)-[i:IMPORTS]->(m:Module)
                 RETURN f.name AS file_name, m.name AS module_name, 
-                    m.full_import_name AS full_import_name, m.alias AS alias
+                    m.full_import_name AS full_import_name, i.alias AS alias
                 ORDER BY f.name
             """
 

--- a/tests/unit/tools/test_kuzu_relationship_queries.py
+++ b/tests/unit/tools/test_kuzu_relationship_queries.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional
 from codegraphcontext.tools.code_finder import CodeFinder
+from codegraphcontext.tools.query_tool_languages.cpp_toolkit import CppToolkit
 
 class _FakeResult:
     def data(self):
@@ -69,3 +70,16 @@ def test_call_chain_avoids_list_extract():
     assert "list_extract" not in q
     assert "MATCH path = (start)-[:CALLS|HEURISTIC_CALLS*1..5]->()" in q
     assert "size(call_rels) as chain_length" in q
+
+
+def test_import_alias_queries_use_imports_relationship():
+    finder, recorder = _make_finder()
+    finder.who_imports_module("numpy")
+
+    query = recorder["last_query"]
+    assert "import_alias: imp.alias" in query
+    assert "module.alias" not in query
+
+    cpp_query = CppToolkit().get_cypher_query("Module")
+    assert "i.alias AS alias" in cpp_query
+    assert "m.alias AS alias" not in cpp_query


### PR DESCRIPTION
## Summary

- read import aliases from the IMPORTS relationship in who_imports_module
- fix the same relationship-property bug in the C++ Module query
- add one regression test covering both query paths

Fixes #1515.
Also addresses item 3 of #1533.

## Testing

- PYTHONPATH=src uv run --no-project --with pytest --with pathspec --with pyyaml pytest -q tests/unit/tools/test_kuzu_relationship_queries.py
- uvx ruff check --ignore F541 on the three changed files
- git diff --check
