### PR TITLE
fix(graph): always sanitize bundle filename, even if it already ends in .cgc

### DIFF
--- a/src/codegraphcontext/utils/path_sandbox.py
+++ b/src/codegraphcontext/utils/path_sandbox.py
@@ -61,11 +61,12 @@ def sanitize_bundle_filename(filename: str, default: str = "bundle.cgc") -> str:
     name = Path(filename).name
     if not name or name in (".", ".."):
         return default
-    if not re.fullmatch(r"[\w.\-]+\.cgc", name, flags=re.IGNORECASE):
-        if not name.endswith(".cgc"):
-            sanitized = re.sub(r'[^\w.\-]+', '_', name)
-            name = f"{sanitized}.cgc"
-    return name
+    # Always sanitize the stem so that unsafe characters cannot bypass the
+    # check by simply appending a .cgc extension.
+    stem = name[:-4] if name.lower().endswith(".cgc") else name
+    sanitized_stem = re.sub(r"[^\w.\-]+", "_", stem)
+    # Re-attach the extension whether it was present or not.
+    return f"{sanitized_stem}.cgc"
 
 
 def is_safe_download_url(url: str) -> bool:

--- a/tests/unit/utils/test_path_sandbox_security.py
+++ b/tests/unit/utils/test_path_sandbox_security.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import pytest
 
 from codegraphcontext.utils.path_sandbox import (
     clamp_discovery_depth,
@@ -8,12 +8,40 @@ from codegraphcontext.utils.path_sandbox import (
 
 
 def test_sanitize_bundle_filename_rejects_traversal():
+    # Path traversal sequences must always fall back to the default name.
     assert sanitize_bundle_filename("../../etc/passwd.cgc") == "bundle.cgc"
     assert sanitize_bundle_filename("numpy.cgc") == "numpy.cgc"
 
 
+# Parametrized cases from the original issue report.
+# Previously the second case was a bug: a .cgc-suffixed name with unsafe
+# characters would skip sanitization entirely and be returned unchanged.
+@pytest.mark.parametrize(
+    "input_name, expected",
+    [
+        # Clean name - must pass through unchanged.
+        ("ok.cgc", "ok.cgc"),
+        # Unsafe chars present, already ends with .cgc - must be sanitized (was the bug).
+        ("we ird$.cgc", "we_ird_.cgc"),
+        # Unsafe chars present, non-.cgc extension - must be sanitized and .cgc appended.
+        ("we ird$.txt", "we_ird_.txt.cgc"),
+        # Injection payload containing a forward slash - the early guard rejects it
+        # before sanitization and returns the safe default name.
+        ("<script>alert(1)</script>.cgc", "bundle.cgc"),
+        # Injection payload without slashes - unsafe chars are removed by the regex.
+        # Parentheses are not in [\w.\-] so they must be replaced with underscores.
+        ("alert(1).cgc", "alert_1_.cgc"),
+    ],
+)
+def test_sanitize_bundle_filename_unconditional(input_name, expected):
+    # Sanitization must run regardless of whether the filename ends with .cgc.
+    assert sanitize_bundle_filename(input_name) == expected
+
+
 def test_is_safe_download_url_allows_registry_hosts():
-    assert is_safe_download_url("https://huggingface.co/datasets/codegraphcontext/registry/resolve/main/foo.cgc")
+    assert is_safe_download_url(
+        "https://huggingface.co/datasets/codegraphcontext/registry/resolve/main/foo.cgc"
+    )
     assert not is_safe_download_url("http://evil.com/bundle.cgc")
     assert not is_safe_download_url("https://169.254.169.254/latest/meta-data")
 


### PR DESCRIPTION
Closes #1517

`sanitize_bundle_filename` in `utils/path_sandbox.py` only ran the sanitization regex when the name did NOT already end in `.cgc`. This meant a name that was already unsafe but happened to end in `.cgc` (e.g. containing spaces, `$`, or control characters) skipped sanitization entirely and was returned raw.

This PR makes sanitization run unconditionally on the stem, then appends `.cgc` only if it's missing — so the function always returns a sanitized name regardless of the input's extension.

Added a test covering an unsafe name that already ends in `.cgc` (e.g. `we ird$.cgc` → `we_ird_.cgc`).