### PR TITLE
fix: stop node names and titles breaking out of the visualizer page

### DIFF
--- a/src/codegraphcontext/utils/visualize_graph.py
+++ b/src/codegraphcontext/utils/visualize_graph.py
@@ -12,6 +12,7 @@ import json
 import os
 import tempfile
 import webbrowser
+from html import escape as html_escape
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -53,6 +54,24 @@ def node_color(label: str) -> str:
 def edge_color(rel_type: str) -> str:
     """Return the hex colour string for a given relationship type."""
     return _EDGE_COLORS.get(rel_type, _EDGE_COLORS["default"])
+
+
+def _json_for_script(data: Any) -> str:
+    """Serialise ``data`` for inlining inside a ``<script>`` element.
+
+    ``json.dumps`` escapes quotes and backslashes but leaves ``<``, ``>`` and
+    ``&`` alone, so a node name or file path containing ``</script>`` closes
+    the element early and the rest of the document is parsed as markup. Those
+    three characters only ever appear inside string literals, so replacing
+    them with their ``\\uXXXX`` form keeps the payload valid JSON and valid
+    JavaScript while making it inert as markup.
+    """
+    return (
+        json.dumps(data, indent=2)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
 
 
 def build_graph_data(
@@ -125,14 +144,15 @@ def render_html(
     str
         Complete HTML document as a string.
     """
-    graph_json = json.dumps(graph_data, indent=2)
+    graph_json = _json_for_script(graph_data)
+    safe_title = html_escape(title)
 
     html = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{title}</title>
+  <title>{safe_title}</title>
   <style>
     * {{ box-sizing: border-box; margin: 0; padding: 0; }}
     body {{
@@ -198,7 +218,7 @@ def render_html(
 </head>
 <body>
   <div id="header">
-    <h1>🏗 {title}</h1>
+    <h1>🏗 {safe_title}</h1>
     <span id="stats"></span>
   </div>
   <div id="canvas-container">

--- a/tests/unit/utils/test_visualize_graph.py
+++ b/tests/unit/utils/test_visualize_graph.py
@@ -114,6 +114,43 @@ class TestRenderHtml:
         assert "CGC Code Graph" in html
 
 
+class TestRenderHtmlEscaping:
+    """A name or title carrying markup must not escape into the document."""
+
+    BREAKOUT = "x</script><script>alert(1)</script>"
+
+    def test_node_name_cannot_close_the_script_block(self):
+        nodes = [{"id": "1", "label": "Function", "name": self.BREAKOUT, "file_path": "/a.py"}]
+        html = render_html(build_graph_data(nodes, []))
+        assert self.BREAKOUT not in html
+        # the only closing tag left is the one that ends the real script block
+        assert html.count("</script>") == 1
+
+    def test_payload_still_parses_back_to_the_original_name(self):
+        nodes = [{"id": "1", "label": "Function", "name": self.BREAKOUT, "file_path": "/a.py"}]
+        html = render_html(build_graph_data(nodes, []))
+        start = html.index("const GRAPH = ") + len("const GRAPH = ")
+        data, _ = json.JSONDecoder().raw_decode(html[start:])
+        assert data["nodes"][0]["name"] == self.BREAKOUT
+
+    def test_file_path_cannot_close_the_script_block(self):
+        nodes = [{"id": "1", "label": "File", "name": "a", "file_path": "/x</script>/a.py"}]
+        html = render_html(build_graph_data(nodes, []))
+        assert "/x</script>/a.py" not in html
+        assert html.count("</script>") == 1
+
+    def test_title_is_html_escaped(self):
+        graph_data = build_graph_data(SAMPLE_NODES, SAMPLE_EDGES)
+        html = render_html(graph_data, title="t</title><script>alert(2)</script>")
+        assert "<script>alert(2)</script>" not in html
+        assert "&lt;/title&gt;" in html
+
+    def test_ordinary_title_is_untouched(self):
+        graph_data = build_graph_data(SAMPLE_NODES, SAMPLE_EDGES)
+        html = render_html(graph_data, title="My Graph")
+        assert "My Graph" in html
+
+
 class TestOpenInBrowser:
     def test_creates_html_file(self, tmp_path):
         graph_data = build_graph_data(SAMPLE_NODES, SAMPLE_EDGES)


### PR DESCRIPTION
Fixes #1514

`json.dumps` escapes quotes and backslashes but not `<`, `>` or `&`, and the graph gets inlined straight into a `<script>` block. So a node name or file path containing `</script>` closes the element early and everything after it is read as markup. `title` was interpolated raw at both of its sites too.

```
script breakout in payload : True
title breakout             : True
```

`_json_for_script` now escapes those three characters to their `\uXXXX` form after serialising. They only ever appear inside string literals in JSON, so the result is still valid JSON and still valid JavaScript, and the browser gets the same object it did before:

```
payload round-trips to the original name: True
title tag: t&lt;/title&gt;&lt;script&gt;alert(2)&lt;/script&gt;
```

That last part mattered more to me than the escaping itself. A fix that mangles the names would break the graph for anyone indexing minified JS, which is the exact case that triggers the bug. After the change the document contains one `</script>`, the real one.

The title goes through `html.escape`. Note the import is `from html import escape as html_escape`, since `render_html` already has a local called `html`.

Five tests: the node name, the file path, the title, and two guards checking the payload still parses back to the original string and that an ordinary title is left alone. Three fail on main.

Ran `./tests/run_tests.sh fast` as CONTRIBUTING asks. Unit goes from 1005 to 1010 passing, which is the five new tests. Four unit tests and 21 integration tests fail both before and after on my machine (Windows), in the falkordb wrapper, watcher startup sync, the elisp parser and the parser goldens, so I checked them against main's code rather than assuming they were mine. Upstream CI is green, so they look local to my setup.