### PR TITLE
fix(indexer): record non-code files on the SCIP path so `cgc index` stops reporting a partial index

### DIFF
--- a/src/codegraphcontext/tools/indexing/scip_pipeline.py
+++ b/src/codegraphcontext/tools/indexing/scip_pipeline.py
@@ -191,12 +191,39 @@ async def run_scip_index_async(
             cgcignore_path=cgcignore_path,
             supported_extensions=set(parsers_keys),
         )
+        minimal_nodes = 0
         for repo_file in supplementary_files:
             abs_str = str(repo_file.resolve())
             if abs_str in scip_abs_paths:
                 continue
             ts_parser = get_parser(repo_file.suffix)
             if not ts_parser:
+                # No parser: still record the file. `discover_files_to_index`
+                # returns supported extensions *plus* generic ones (.md, .json,
+                # .yaml, Dockerfile, .gitignore …), and the Tree-sitter pipeline
+                # gives those a minimal File node (pipeline.py, via
+                # `add_minimal_file_node`) precisely so the graph accounts for
+                # every discovered file.
+                #
+                # Skipping them here left the SCIP path short by exactly the
+                # number of non-code files, so `cgc index` compared a graph
+                # count against the discovery count and reported "only N of M
+                # files indexed. Continuing." on every run, forever.
+                try:
+                    await asyncio.to_thread(
+                        writer.add_minimal_file_node,
+                        repo_file,
+                        index_root,
+                        is_dependency,
+                    )
+                    minimal_nodes += 1
+                    processed += 1
+                    if job_id:
+                        job_manager.update_job(
+                            job_id, processed_files=processed, current_file=abs_str
+                        )
+                except Exception as e:
+                    debug_log(f"Minimal file node failed for {abs_str}: {e}")
                 continue
             try:
                 ts_data = ts_parser.parse(repo_file, is_dependency, index_source=True)
@@ -222,6 +249,10 @@ async def run_scip_index_async(
             imports_map = pre_scan_for_imports(all_paths, parsers_keys, get_parser)
             info_logger(
                 f"[SCIP+TS] Supplemented {supplemented} files not covered by SCIP indexer"
+            )
+        if minimal_nodes:
+            info_logger(
+                f"[SCIP+TS] Recorded {minimal_nodes} non-code file(s) as minimal File nodes"
             )
 
         info_logger(

--- a/tests/unit/tools/test_scip_pipeline_minimal_nodes.py
+++ b/tests/unit/tools/test_scip_pipeline_minimal_nodes.py
@@ -1,0 +1,135 @@
+"""Non-code files must reach the graph on the SCIP path too.
+
+`discover_files_to_index` returns supported extensions *plus* a generic set
+(`.md`, `.json`, `.yaml`, `Dockerfile`, `.gitignore`, …). The Tree-sitter
+pipeline gives those a minimal `File` node so the graph accounts for every
+discovered file; the SCIP pipeline used to skip them outright.
+
+`cgc index` compares the graph's File count against the discovery count, so
+the shortfall made it report "Repository '.' has only N of M files indexed.
+Continuing." on every run — a state no amount of re-indexing could clear.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codegraphcontext.tools.indexing.scip_pipeline import run_scip_index_async
+
+
+class _FakeScipIndexer:
+    def run(self, _project_path: Path, _lang: str, output_dir: Path) -> Path:
+        scip_file = output_dir / "index.scip"
+        scip_file.write_bytes(b"fake")
+        return scip_file
+
+
+class _FakeScipIndexParser:
+    files_data: dict[str, dict] = {}
+
+    def parse(self, _index_scip_path: Path, _project_path: Path) -> dict:
+        return {"files": self.files_data}
+
+
+class _FakeParser:
+    def parse(self, path: Path, _is_dependency: bool, index_source: bool = False) -> dict:
+        return {
+            "path": str(path),
+            "functions": [],
+            "classes": [],
+            "imports": [],
+            "variables": [],
+            "function_calls_scip": [],
+            "module_level_calls_scip": [],
+        }
+
+
+async def _run(repo: Path, writer: MagicMock, supported: set[str]) -> None:
+    fake_mod = SimpleNamespace(
+        ScipIndexer=_FakeScipIndexer,
+        ScipIndexParser=_FakeScipIndexParser,
+    )
+    _FakeScipIndexParser.files_data = {}
+
+    with patch(
+        "codegraphcontext.tools.indexing.scip_pipeline.pre_scan_for_imports",
+        return_value={},
+    ):
+        await run_scip_index_async(
+            repo,
+            is_dependency=False,
+            job_id=None,
+            lang="c_sharp",
+            writer=writer,
+            job_manager=MagicMock(),
+            parsers_keys=supported,
+            get_parser=lambda suffix: _FakeParser() if suffix in supported else None,
+            scip_indexer_mod=fake_mod,
+        )
+
+
+@pytest.mark.asyncio
+async def test_generic_files_get_minimal_nodes(tmp_path: Path):
+    """A C#-plus-config project must account for every discovered file."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    (repo / "Program.cs").write_text("public class P {}\n", encoding="utf-8")
+    generic = ["README.md", "appsettings.json", "Dockerfile", ".gitignore", "build.sh"]
+    for name in generic:
+        (repo / name).write_text("x\n", encoding="utf-8")
+
+    writer = MagicMock()
+    await _run(repo, writer, supported={".cs"})
+
+    parsed = {
+        Path(call.args[0]["path"]).name
+        for call in writer.add_file_to_graph.call_args_list
+    }
+    minimal = {
+        Path(call.args[0]).name
+        for call in writer.add_minimal_file_node.call_args_list
+    }
+
+    assert "Program.cs" in parsed
+    # Every non-code file is still represented, so the graph File count can
+    # reach the number of files discovered on disk.
+    assert set(generic) <= minimal, f"missing minimal nodes for {set(generic) - minimal}"
+
+
+@pytest.mark.asyncio
+async def test_graph_file_count_matches_discovery(tmp_path: Path):
+    """The count `cgc index` checks against must be reachable.
+
+    Reproduces the reported shape: 32 source files, 14 non-code files, and a
+    'only 32 of 46' warning that never cleared.
+    """
+    from codegraphcontext.tools.indexing.discovery import discover_files_to_index
+
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    for i in range(32):
+        (repo / f"Class{i}.cs").write_text("public class A {}\n", encoding="utf-8")
+    for name in [
+        "README.md", "LICENSE.txt", "appsettings.json", "Dockerfile", ".gitignore",
+        "build.sh", "config.yaml", "pyproject.toml", "setup.cfg", "notes.txt",
+        "deploy.ps1", "run.bat", "docker-compose.yml", "values.yaml",
+    ]:
+        (repo / name).write_text("x\n", encoding="utf-8")
+
+    discovered, _ = discover_files_to_index(repo, supported_extensions={".cs"})
+    assert len(discovered) == 46
+
+    writer = MagicMock()
+    await _run(repo, writer, supported={".cs"})
+
+    written = (
+        writer.add_file_to_graph.call_count + writer.add_minimal_file_node.call_count
+    )
+    assert written == len(discovered), (
+        f"graph would hold {written} File nodes but discovery expects "
+        f"{len(discovered)} — `cgc index` will warn on every run"
+    )


### PR DESCRIPTION
Fixes #1565 — reported by a user indexing a 46-file C# project with `scip-dotnet`, where `cgc index .` said *"Repository '.' has only 32 of 46 files indexed. Continuing."* on every run and never converged.

Full suite: **1080 passed, 7 skipped**, no failures.

## Cause

Two rules counted files, and one could never be satisfied.

The **expected** count comes from `estimate_processing_time` → `discover_files_to_index`, which returns supported extensions **plus** a generic set (`discovery.py:14-22`): `.md .txt .json .yaml .yml .toml .ini .cfg .sh .bat .ps1`, plus `Dockerfile`, `Makefile`, `.gitignore`, `.dockerignore`, `.env`.

The **actual** count is `File` nodes in the graph.

The gap was `scip_pipeline.py`, in the supplementary Tree-sitter pass:

```python
ts_parser = get_parser(repo_file.suffix)
if not ts_parser:
    continue          # no File node, no record, nothing
```

The Tree-sitter pipeline has no such hole — `pipeline.py:189` falls back to `add_minimal_file_node`, and `parse_file` separates the two cases deliberately so it can: generic types return `"unsupported": False` (`graph_builder.py:1048`) while genuinely unparseable ones return `True` (`:1053`).

So the two pipelines disagreed about what counts as a file, and the SCIP path was short by exactly the number of non-code files in the repo.

## Reproduction

```
files on disk:                      46
discover_files_to_index (expected): 46
  with a .cs parser:                32
  with NO parser:                   14   (.gitignore, Dockerfile, LICENSE.txt,
                                          README.md, appsettings.json, build.sh, …)
SCIP path writes File nodes for:    32
```

The 32/46 split is the natural one for a project of that shape, not a coincidence.

## Fix

Give the SCIP path the same fallback. Non-code files now get a minimal `File` node, count toward job progress, and are surfaced in the summary log:

```
[SCIP+TS] Recorded 14 non-code file(s) as minimal File nodes
```

## Test

`tests/unit/tools/test_scip_pipeline_minimal_nodes.py` pins the two pipelines to the same contract: for a 32-source + 14-non-code repo, File nodes written must equal files discovered.

Reverting the fix fails it with the reported symptom:

```
AssertionError: graph would hold 32 File nodes but discovery expects 46
                — `cgc index` will warn on every run
```

## Notes for review

- Impact was cosmetic in graph terms — the C# code was always fully indexed, and the missing entries are inert placeholder nodes. The real cost was that a false partial-index warning is indistinguishable from a genuine one, so an actual failure would have been invisible.
- Only the SCIP path was affected, so behaviour differed by language for the same repository.
- Related but separate: #1535 (SCIP job progress can exceed 100% because `total_files` is snapshotted before this supplementary pass). This PR makes `processed` include minimal nodes, which is consistent with that count once #1535 is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
