### PR TITLE
chore(release): bump version to 0.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.5.4"
+version = "0.5.5"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
Bug-fix release. Seven PRs have landed on `main` since 0.5.4 was published to PyPI.

| Fix | Issue | PR |
|---|---|---|
| SCIP path never recorded non-code files, so `cgc index` reported "only N of M files indexed" on every run | #1565 | #1566 |
| PHP imports query captured trait uses instead of imports — PHP files produced no imports at all | #1522 | #1563 |
| Python annotated params without defaults dropped (**40.3%** of all parameters); Go grouped imports yielded zero | #1520, #1521 | #1561 |
| 13 fixes across read-only Cypher validation, MCP SSE auth + transport, and indexing crashes | — | #1508 |
| Bundle filenames not sanitized when already ending in `.cgc` | #1517 | #1541 |
| Import aliases read from the `Module` node instead of the `IMPORTS` relationship | #1515 | #1540 |
| GCF encode failures propagated instead of falling back to JSON | #1518 | #1539 |

Version-only change; each fix was verified with the full suite and CI before merge.

Note: the newest git tag is `v0.5.2` while PyPI is at 0.5.4 — the drift reported in #1262. I'll tag `v0.5.5` on merge to start closing that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)