### PR TITLE
chore(release): bump version to 0.5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.5.5"
+version = "0.5.6"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
Bug-fix release. Four PRs landed on `main` since 0.5.5.

| Fix | Issue | PR |
|---|---|---|
| LadybugDB's uppercase internal keys (`_ID`/`_LABEL`/`_SRC`/`_DST`) in the **live viz server** — the API returned an empty graph on Ladybug. `7da51f5` had fixed only the offline renderer; this covers the second call site. | #1458 | #1506 |
| A node name containing `</script>` broke out of the inlined JSON and corrupted the offline visualizer page | #1514 | #1562 |
| `advanced_language_query(language="java")` raised an uncaught `TypeError` — `JavaToolkit` was the only toolkit with a non-zero-arg constructor | #1534 | #1560 |
| Unit coverage for `git_utils` failure modes | #1571 | #1572 |

Version-only change. Each fix was verified with the full suite (1093 passed, 19 skipped) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)