### PR TITLE
fix(query): five defects that returned wrong answers without erroring

### DIFF
--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -1211,16 +1211,31 @@ class CodeFinder:
         try:
             if query_type == "find_callers":
                 results = self.who_calls_function(target, context, repo_path=repo_path)
-                # Hoist target_file_path (constant across rows) to the envelope once,
-                # instead of repeating the absolute path in every row (payload slimming).
-                target_file_path = next((r.pop("target_file_path", None) for r in results), None) if results else None
-                for r in results:
-                    r.pop("target_file_path", None)
-                return {
+                # target_file_path is only constant when `context` pinned a single
+                # definition. Without it, who_calls_function matches
+                # Function {name: $function_name} across every file, so rows
+                # legitimately carry different targets — hoisting the first row's
+                # value and stripping the rest reported every caller as calling
+                # whichever definition happened to sort first.
+                #
+                # Hoist only when the rows agree; otherwise leave the field on each
+                # row so the ambiguity is visible to the caller.
+                target_paths = {r.get("target_file_path") for r in results}
+                target_file_path = target_paths.pop() if len(target_paths) == 1 else None
+                if target_file_path is not None:
+                    for r in results:
+                        r.pop("target_file_path", None)
+                envelope = {
                     "query_type": "find_callers", "target": target, "context": context,
                     "target_file_path": target_file_path, "results": results,
                     "summary": f"Found {len(results)} functions that call '{target}'"
                 }
+                if target_file_path is None and len(target_paths) > 1:
+                    envelope["note"] = (
+                        f"'{target}' is defined in {len(target_paths)} files; each result "
+                        "carries its own target_file_path. Pass `context` to disambiguate."
+                    )
+                return envelope
             
             elif query_type == "find_callees":
                 results = self.what_does_function_call(target, context, repo_path=repo_path)
@@ -1272,7 +1287,10 @@ class CodeFinder:
                 }
             
             elif query_type in ["dead_code", "unused", "unreachable"]:
-                results = self.find_dead_code(repo_path=repo_path)
+                # graph_name must be forwarded: find_dead_code defaults it to None and
+                # re-assigns the shared self._active_graph, so omitting it here
+                # silently redirected the query to the default graph.
+                results = self.find_dead_code(repo_path=repo_path, graph_name=graph_name)
                 return {
                     "query_type": "dead_code", "results": results,
                     "summary": f"Found {len(results['potentially_unused_functions'])} potentially unused functions"
@@ -1281,7 +1299,7 @@ class CodeFinder:
             elif query_type == "find_complexity":
                 limit_val = context if context else target
                 limit = int(limit_val) if limit_val and str(limit_val).isdigit() else 10
-                results = self.find_most_complex_functions(limit, repo_path=repo_path)
+                results = self.find_most_complex_functions(limit, repo_path=repo_path, graph_name=graph_name)
                 return {
                     "query_type": "find_complexity", "limit": limit, "results": results,
                     "summary": f"Found the top {len(results)} most complex functions"

--- a/src/codegraphcontext/tools/handlers/analysis_handlers.py
+++ b/src/codegraphcontext/tools/handlers/analysis_handlers.py
@@ -236,8 +236,8 @@ def find_java_spring_beans(code_finder: CodeFinder, **args) -> Dict[str, Any]:
     query = f"""
         MATCH (c:Class)
         WHERE {where_clause}
-        OPTIONAL MATCH ()-[:INJECTS]->(c)
-        WITH c, count(*) AS injection_count
+        OPTIONAL MATCH ()-[inj:INJECTS]->(c)
+        WITH c, count(inj) AS injection_count
         RETURN c.name AS name, c.spring_stereotype AS stereotype,
                c.path AS file, c.line_number AS line_number, injection_count
         ORDER BY stereotype, name
@@ -296,7 +296,8 @@ def find_datasource_nodes(code_finder: CodeFinder, **args) -> Dict[str, Any]:
         {kp_where}
         OPTIONAL MATCH (kp:RedisKeyPattern)-[:STORED_IN]->(d)
         RETURN d.name AS datasource,
-               collect({{pattern: kp.pattern, key_type: kp.key_type, count: kp.count}}) AS key_patterns
+               [x IN collect(kp) | {{pattern: x.pattern, key_type: x.key_type,
+                                     count: x.count}}] AS key_patterns
     """
 
     try:

--- a/src/codegraphcontext/tools/handlers/indexing_handlers.py
+++ b/src/codegraphcontext/tools/handlers/indexing_handlers.py
@@ -19,6 +19,25 @@ def add_code_to_graph(graph_builder, job_manager, loop, list_repos_func, **args)
 
     if not path:
         return {"error": "Path is a required argument (repo_path)."}
+
+    # `graph_name` is advertised in this tool's schema but indexing cannot yet
+    # honour it: GraphBuilder binds its GraphWriter to the default driver at
+    # construction, so a named graph would need a per-job writer threaded
+    # through the whole pipeline. Refuse explicitly rather than write to the
+    # default graph and report success — an agent that believed the repository
+    # landed in a named graph would find nothing there later, with no error to
+    # explain it.
+    graph_name = args.get("graph_name")
+    if graph_name:
+        return {
+            "error": (
+                f"Indexing into a named graph is not supported yet, so "
+                f"graph_name={graph_name!r} cannot be honoured. Omit it to index "
+                "into the default graph, or select the graph via the CLI context "
+                "(`cgc context create` / `cgc index --context`)."
+            ),
+            "unsupported_argument": "graph_name",
+        }
     
     try:
         path_obj = Path(path).resolve()

--- a/src/codegraphcontext/tools/handlers/management_handlers.py
+++ b/src/codegraphcontext/tools/handlers/management_handlers.py
@@ -354,15 +354,15 @@ def get_repository_stats(code_finder: CodeFinder, **args) -> Dict[str, Any]:
                     }
                 
                 # 1. Files
-                file_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(f:File) RETURN count(f) as c"
+                file_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(f:File) RETURN count(DISTINCT f) as c"
                 file_count = session.run(file_query, path=repo_path_obj).single()["c"]
                 
                 # 2. Functions
-                func_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(func:Function) RETURN count(func) as c"
+                func_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(func:Function) RETURN count(DISTINCT func) as c"
                 func_count = session.run(func_query, path=repo_path_obj).single()["c"]
                 
                 # 3. Classes
-                class_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(cls:Class) RETURN count(cls) as c"
+                class_query = "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(cls:Class) RETURN count(DISTINCT cls) as c"
                 class_count = session.run(class_query, path=repo_path_obj).single()["c"]
                 
                 # 4. Modules (imported)

--- a/src/codegraphcontext/tools/query_tool_languages/java_toolkit.py
+++ b/src/codegraphcontext/tools/query_tool_languages/java_toolkit.py
@@ -114,8 +114,8 @@ class JavaToolkit:
             f"""
             MATCH (c:Class)
             WHERE {where}
-            OPTIONAL MATCH ()-[:INJECTS]->(c)
-            WITH c, count(*) AS injection_count
+            OPTIONAL MATCH ()-[inj:INJECTS]->(c)
+            WITH c, count(inj) AS injection_count
             RETURN c.name AS name, c.spring_stereotype AS stereotype,
                    c.path AS file, c.line_number AS line_number,
                    injection_count

--- a/tests/unit/tools/test_query_correctness_batch.py
+++ b/tests/unit/tools/test_query_correctness_batch.py
@@ -1,0 +1,160 @@
+"""Query-shape and argument-plumbing defects found in the 0.5.x audit.
+
+Each test pins one defect that produced a plausible-looking but wrong answer
+rather than an error, which is the class of bug an agent cannot detect.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.tools.code_finder import CodeFinder
+
+
+# --------------------------------------------------------------- #1529
+def test_repository_stats_count_distinct_nodes_not_contains_paths():
+    """A method is reachable via File->CONTAINS and Class->CONTAINS both.
+
+    Counting rows instead of distinct nodes inflated every per-repo figure
+    (2202 reported against 1551 real Function nodes on a live database).
+    """
+    import inspect
+
+    from codegraphcontext.tools.handlers import management_handlers
+
+    src = inspect.getsource(management_handlers)
+    for var, label in (("f", "File"), ("func", "Function"), ("cls", "Class")):
+        assert (
+            f"-[:CONTAINS*]->({var}:{label}) RETURN count(DISTINCT {var})" in src
+        ), f"{label} counter must use count(DISTINCT {var})"
+        # Only the traversal form can double-count. The global branch
+        # (`MATCH (f:File) RETURN count(f)`) has no CONTAINS path and is
+        # correct as-is, so assert specifically against the traversal shape.
+        assert (
+            f"-[:CONTAINS*]->({var}:{label}) RETURN count({var})" not in src
+        ), f"{label} counter still counts CONTAINS paths"
+
+
+# --------------------------------------------------------------- #1533
+def test_injection_count_counts_relationships_not_rows():
+    """`count(*)` after an unmatched OPTIONAL MATCH still counts one null row,
+    so every Spring bean reported at least one injector."""
+    import inspect
+
+    from codegraphcontext.tools.handlers import analysis_handlers
+    from codegraphcontext.tools.query_tool_languages import java_toolkit
+
+    for mod in (analysis_handlers, java_toolkit):
+        src = inspect.getsource(mod)
+        assert "count(inj) AS injection_count" in src, f"{mod.__name__} must bind the relationship"
+        assert "count(*) AS injection_count" not in src, f"{mod.__name__} still counts rows"
+
+
+def test_key_patterns_collect_drops_empty_rows():
+    """A map literal is non-null even when every field is null, so collecting
+    maps kept a phantom all-null entry for a datasource with no patterns."""
+    import inspect
+
+    from codegraphcontext.tools.handlers import analysis_handlers
+
+    src = inspect.getsource(analysis_handlers)
+    assert "[x IN collect(kp) |" in src, "must collect the node, then project"
+    assert "collect({pattern: kp.pattern" not in src, "still collects a map literal"
+
+
+# --------------------------------------------------------------- #1530
+class _Recorder:
+    def __init__(self, rows):
+        self._rows = rows
+        self.last_query = None
+
+    def session(self, *a, **k):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def run(self, query, **params):
+        self.last_query = query
+        res = MagicMock()
+        res.data.return_value = self._rows
+        return res
+
+
+def _finder_with(rows):
+    dbm = MagicMock()
+    rec = _Recorder(rows)
+    dbm.get_driver.return_value = rec
+    dbm.get_backend_type.return_value = "neo4j"
+    return CodeFinder(dbm)
+
+
+def test_find_callers_keeps_per_row_target_when_definitions_differ():
+    """Without `context`, callers of a common name legitimately point at
+    different definitions; hoisting the first row's path reported every caller
+    as calling whichever file sorted first."""
+    rows = [
+        {"caller": "a", "target_file_path": "/repo/models/user.py"},
+        {"caller": "b", "target_file_path": "/repo/models/order.py"},
+    ]
+    finder = _finder_with(rows)
+    out = finder.analyze_code_relationships("find_callers", "save")
+
+    assert out["target_file_path"] is None, "must not claim a single target"
+    paths = {r.get("target_file_path") for r in out["results"]}
+    assert paths == {"/repo/models/user.py", "/repo/models/order.py"}
+    assert "note" in out and "2 files" in out["note"]
+
+
+def test_find_callers_still_hoists_when_all_rows_agree():
+    """The payload-slimming behaviour is kept for the unambiguous case."""
+    rows = [
+        {"caller": "a", "target_file_path": "/repo/models/user.py"},
+        {"caller": "b", "target_file_path": "/repo/models/user.py"},
+    ]
+    finder = _finder_with(rows)
+    out = finder.analyze_code_relationships("find_callers", "save")
+
+    assert out["target_file_path"] == "/repo/models/user.py"
+    assert all("target_file_path" not in r for r in out["results"])
+    assert "note" not in out
+
+
+# --------------------------------------------------------------- #1531
+@pytest.mark.parametrize(
+    "query_type,method",
+    [("dead_code", "find_dead_code"), ("find_complexity", "find_most_complex_functions")],
+)
+def test_graph_name_is_forwarded_to_inner_queries(query_type, method):
+    """Both inner methods default graph_name to None and re-assign the shared
+    `_active_graph`, so omitting it silently queried the default graph."""
+    finder = _finder_with([])
+    captured = {}
+
+    def spy(*args, **kwargs):
+        captured["graph_name"] = kwargs.get("graph_name")
+        return {"potentially_unused_functions": []} if query_type == "dead_code" else []
+
+    setattr(finder, method, spy)
+    finder.analyze_code_relationships(query_type, "x", graph_name="myrepo")
+    assert captured["graph_name"] == "myrepo"
+
+
+# --------------------------------------------------------------- #1558
+def test_add_code_to_graph_refuses_an_unsupported_graph_name():
+    """The schema advertises graph_name but indexing cannot honour it, so it
+    must refuse rather than write to the default graph and report success."""
+    from codegraphcontext.tools.handlers.indexing_handlers import add_code_to_graph
+
+    out = add_code_to_graph(
+        MagicMock(), MagicMock(), MagicMock(), MagicMock(),
+        repo_path=".", graph_name="service-a",
+    )
+    assert "error" in out
+    assert out.get("unsupported_argument") == "graph_name"
+    assert "service-a" in out["error"]


### PR DESCRIPTION
Fixes #1529, #1530, #1531, #1558, and items 1–2 of #1533.

Full suite: **1101 passed, 19 skipped**, no failures.

These are grouped because they share a failure mode: each returned a **plausible-looking wrong answer instead of an error**, which is the class an agent cannot detect and will act on.

| # | Defect | Effect |
|---|---|---|
| #1529 | per-repo counters counted `CONTAINS` paths, not nodes | **2202** functions reported where **1551** exist — and the same tool's global branch said 1551 |
| #1530 | `find_callers` hoisted row 0's `target_file_path` and stripped the rest | every caller attributed to whichever definition sorted first |
| #1531 | `graph_name` not forwarded to `find_dead_code` / `find_most_complex_functions` | results returned from the **wrong repository** on FalkorDB |
| #1533 ①② | `count(*)` after `OPTIONAL MATCH`; `collect()` of a map literal | `injection_count` never 0; a phantom all-null `key_patterns` entry |
| #1558 | `add_code_to_graph` advertised `graph_name` and ignored it | agent told indexing succeeded into a graph that stayed empty |

## Notes on two of them

**#1530** keeps the payload-slimming that motivated the original code. The path is still hoisted when every row agrees — the common case, when `context` pinned one definition. It only stays per-row when the rows genuinely disagree, and then the envelope carries a note:

```
"'save' is defined in 2 files; each result carries its own target_file_path.
 Pass `context` to disambiguate."
```

**#1558** is *not* fully fixed and the issue stays open. Honouring `graph_name` for indexing needs a per-job `GraphWriter` threaded through the pipeline — `GraphBuilder` binds its writer to the default driver at construction (`graph_builder.py:57`). That is a real change with real risk to the core path, so this PR makes the tool **refuse explicitly** rather than write to the default graph and report success. Failing loudly beats misleading silently; the proper fix remains tracked.

## Tests

`tests/unit/tools/test_query_correctness_batch.py` — 8 tests. Verified they catch the bugs by reverting the source changes: **7 of 8 fail**, the 8th being the hoist-when-rows-agree case, which is correct both before and after.

One thing the tests caught while I wrote them: my first assertion for #1529 was too broad and flagged the *global* branch (`MATCH (f:File) RETURN count(f)`), which has no `CONTAINS` traversal and is correct as-is. The assertion now targets the traversal shape specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
