### PR TITLE
test: strengthen MCP tool definition contract validation

### DIFF
--- a/tests/unit/tools/test_mcp_contracts.py
+++ b/tests/unit/tools/test_mcp_contracts.py
@@ -56,3 +56,44 @@ def test_cypher_fallback_instruction_is_not_self_contradictory():
     assert "`path` vs `path`" not in prompts.LLM_SYSTEM_PROMPT
     # ...and it still tells the model to consult the schema.
     assert "Graph Schema Reference" in prompts.LLM_SYSTEM_PROMPT
+
+
+def test_every_tool_definition_has_a_matching_wrapper():
+    """Every public tool definition should have a corresponding wrapper
+    method on MCPServer."""
+    for tool_name in TOOLS:
+        assert hasattr(
+            MCPServer, f"{tool_name}_tool"
+        ), f"Missing wrapper method: {tool_name}_tool"
+
+
+def test_every_wrapper_has_a_tool_definition():
+    """Every public *_tool wrapper should correspond to a declared MCP tool."""
+    excluded = {
+        "_init_tools",
+        "_load_disabled_tools",
+        "_normalize_tool_name",
+        "_get_version",
+        "handle_tool_call",
+    }
+
+    wrapper_methods = {
+        name[:-5]
+        for name, member in inspect.getmembers(MCPServer, inspect.isfunction)
+        if name.endswith("_tool") and name not in excluded
+    }
+
+    missing = wrapper_methods - set(TOOLS.keys())
+    assert not missing, (
+        "Wrapper methods without matching tool definitions: "
+        f"{sorted(missing)}"
+    )
+
+
+def test_tool_definition_keys_match_declared_names():
+    """The dictionary key should always match the tool's declared name."""
+    for key, definition in TOOLS.items():
+        assert definition["name"] == key
+
+
+


### PR DESCRIPTION
## Summary

This PR strengthens the MCP contract test suite by adding regression tests that verify the consistency between MCP tool definitions and their corresponding server wrapper methods.

## Changes

- Added a regression test to verify that every tool definition has a matching `*_tool` wrapper in `MCPServer`.
- Added a regression test to verify that every public `*_tool` wrapper has a corresponding tool definition.
- Added a regression test to verify that each tool definition's `name` field matches its registry key.

## Why

These tests help prevent regressions when introducing new MCP tools by ensuring that tool definitions and server wrapper methods remain synchronized.

## Testing

```bash
python -m pytest tests/unit/tools/test_mcp_contracts.py -v
python -m pytest tests/unit/test_tool_definitions.py tests/unit/tools/test_mcp_contracts.py -v
```

All tests pass successfully.

Closes #1579