### PR TITLE
fix(parsers): extract C/C++ functions returning a pointer or reference

### DIFF
--- a/src/codegraphcontext/tools/languages/c.py
+++ b/src/codegraphcontext/tools/languages/c.py
@@ -6,17 +6,34 @@ from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logge
 from codegraphcontext.utils.tree_sitter_manager import execute_query
 
 C_QUERIES = {
+    # A pointer return type wraps the function declarator from the OUTSIDE:
+    # `char* f()` is
+    #     function_definition > pointer_declarator > function_declarator > identifier
+    # The second alternative below used to nest these the other way round, which
+    # matches nothing, so no function returning `T*` or `T**` was extracted —
+    # and because pre_scan_c shares this query they were invisible as call
+    # targets too.
     "functions": """
         (function_definition
             declarator: (function_declarator
                 declarator: (identifier) @name
             )
         ) @function_node
-        
+
         (function_definition
-            declarator: (function_declarator
-                declarator: (pointer_declarator
+            declarator: (pointer_declarator
+                declarator: (function_declarator
                     declarator: (identifier) @name
+                )
+            )
+        ) @function_node
+
+        (function_definition
+            declarator: (pointer_declarator
+                declarator: (pointer_declarator
+                    declarator: (function_declarator
+                        declarator: (identifier) @name
+                    )
                 )
             )
         ) @function_node
@@ -762,15 +779,25 @@ def pre_scan_c(files: list[Path], parser_wrapper) -> dict:
                 declarator: (identifier) @name
             )
         )
-        
+
         (function_definition
-            declarator: (function_declarator
-                declarator: (pointer_declarator
+            declarator: (pointer_declarator
+                declarator: (function_declarator
                     declarator: (identifier) @name
                 )
             )
         )
-        
+
+        (function_definition
+            declarator: (pointer_declarator
+                declarator: (pointer_declarator
+                    declarator: (function_declarator
+                        declarator: (identifier) @name
+                    )
+                )
+            )
+        )
+
         (struct_specifier
             name: (type_identifier) @name
         )

--- a/src/codegraphcontext/tools/languages/cpp.py
+++ b/src/codegraphcontext/tools/languages/cpp.py
@@ -6,6 +6,13 @@ from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logge
 from codegraphcontext.utils.tree_sitter_manager import execute_query
 
 CPP_QUERIES = {
+    # A pointer or reference return type wraps the function declarator from the
+    # OUTSIDE: `char* f()` is
+    #     function_definition > pointer_declarator > function_declarator > identifier
+    # not function_declarator > pointer_declarator. Matching only the unwrapped
+    # shape meant no function returning `T*`, `T&` or `T**` was ever extracted —
+    # accessors, factories and `operator[]` are pervasive in C++, and because
+    # pre_scan_cpp shares this query they were invisible as call targets too.
     "functions": """
         (function_definition
             declarator: (function_declarator
@@ -14,6 +21,44 @@ CPP_QUERIES = {
                     (field_identifier) @name
                     (qualified_identifier) @qualified_name
                 ]
+            )
+        ) @function_node
+
+        (function_definition
+            declarator: (pointer_declarator
+                declarator: (function_declarator
+                    declarator: [
+                        (identifier) @name
+                        (field_identifier) @name
+                        (qualified_identifier) @qualified_name
+                    ]
+                )
+            )
+        ) @function_node
+
+        (function_definition
+            declarator: (pointer_declarator
+                declarator: (pointer_declarator
+                    declarator: (function_declarator
+                        declarator: [
+                            (identifier) @name
+                            (field_identifier) @name
+                            (qualified_identifier) @qualified_name
+                        ]
+                    )
+                )
+            )
+        ) @function_node
+
+        (function_definition
+            declarator: (reference_declarator
+                (function_declarator
+                    declarator: [
+                        (identifier) @name
+                        (field_identifier) @name
+                        (qualified_identifier) @qualified_name
+                    ]
+                )
             )
         ) @function_node
     """,
@@ -651,6 +696,23 @@ def pre_scan_cpp(files: list[Path], parser_wrapper) -> dict:
         (type_definition declarator: (type_identifier) @name)
         (function_definition declarator: (function_declarator declarator: (identifier) @name))
         (function_definition declarator: (function_declarator declarator: (qualified_identifier) @qualified_name))
+
+        ; A pointer/reference return type wraps the function declarator from the
+        ; outside, so these forms need their own alternatives — without them a
+        ; `T* f()` was not registered here either, and so was unresolvable as a
+        ; call target even once it became a node.
+        (function_definition declarator: (pointer_declarator
+            declarator: (function_declarator declarator: (identifier) @name)))
+        (function_definition declarator: (pointer_declarator
+            declarator: (function_declarator declarator: (qualified_identifier) @qualified_name)))
+        (function_definition declarator: (pointer_declarator declarator: (pointer_declarator
+            declarator: (function_declarator declarator: (identifier) @name))))
+        (function_definition declarator: (pointer_declarator declarator: (pointer_declarator
+            declarator: (function_declarator declarator: (qualified_identifier) @qualified_name))))
+        (function_definition declarator: (reference_declarator
+            (function_declarator declarator: (identifier) @name)))
+        (function_definition declarator: (reference_declarator
+            (function_declarator declarator: (qualified_identifier) @qualified_name)))
     """
 
 

--- a/tests/unit/parsers/test_c_cpp_pointer_returns.py
+++ b/tests/unit/parsers/test_c_cpp_pointer_returns.py
@@ -1,0 +1,92 @@
+"""C/C++ functions returning a pointer or reference (#1524).
+
+The queries nested `pointer_declarator` *inside* `function_declarator`. The
+real AST is the reverse — a pointer return type wraps the function declarator
+from the outside:
+
+    char* f() { }
+    function_definition > pointer_declarator > function_declarator > identifier
+
+So no function returning `T*`, `T**` or `T&` matched. Because `pre_scan_c` and
+`pre_scan_cpp` carried their own copies of the same inverted shape, those
+functions were missing as *call targets* too, not just as nodes.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from codegraphcontext.tools.languages.c import CTreeSitterParser, pre_scan_c
+from codegraphcontext.tools.languages.cpp import CppTreeSitterParser, pre_scan_cpp
+from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+
+def _wrapper(lang):
+    manager = get_tree_sitter_manager()
+    w = MagicMock()
+    w.language_name = lang
+    w.language = manager.get_language_safe(lang)
+    w.parser = manager.create_parser(lang)
+    return w
+
+
+C_SOURCE = """char* dup_str(const char* s) { return 0; }
+int plain(void) { return 0; }
+char** grid(void) { return 0; }
+"""
+
+CPP_SOURCE = """#include <string>
+class Buf { public: char* data(); int size(); };
+char* Buf::data() { return nullptr; }
+int Buf::size() { return 0; }
+std::string* make() { return nullptr; }
+int plain() { return 0; }
+int& ref() { static int x; return x; }
+char** dd() { return nullptr; }
+"""
+
+
+class TestCPointerReturns:
+    def _parse(self, tmp_path):
+        f = tmp_path / "a.c"
+        f.write_text(C_SOURCE, encoding="utf-8")
+        return f, CTreeSitterParser(_wrapper("c")).parse(str(f))
+
+    def test_pointer_returning_functions_are_extracted(self, tmp_path):
+        _, result = self._parse(tmp_path)
+        names = {fn["name"] for fn in result["functions"]}
+        assert {"dup_str", "plain", "grid"} <= names
+
+    def test_double_pointer_return(self, tmp_path):
+        _, result = self._parse(tmp_path)
+        assert "grid" in {fn["name"] for fn in result["functions"]}
+
+    def test_pre_scan_registers_them_as_call_targets(self, tmp_path):
+        """pre_scan builds the cross-file name map. Missing here means the
+        function is unresolvable as a callee even once it becomes a node."""
+        f, _ = self._parse(tmp_path)
+        assert {"dup_str", "grid", "plain"} <= set(pre_scan_c([f], _wrapper("c")))
+
+
+class TestCppPointerAndReferenceReturns:
+    def _parse(self, tmp_path):
+        f = tmp_path / "b.cpp"
+        f.write_text(CPP_SOURCE, encoding="utf-8")
+        return f, CppTreeSitterParser(_wrapper("cpp")).parse(str(f))
+
+    @pytest.mark.parametrize("name", ["data", "size", "make", "plain", "ref", "dd"])
+    def test_every_return_shape_is_extracted(self, tmp_path, name):
+        _, result = self._parse(tmp_path)
+        assert name in {fn["name"] for fn in result["functions"]}
+
+    def test_out_of_line_pointer_method_keeps_its_class(self, tmp_path):
+        """`char* Buf::data()` is pointer_declarator > function_declarator >
+        qualified_identifier — the class context must survive the extra wrap."""
+        _, result = self._parse(tmp_path)
+        data = next(fn for fn in result["functions"] if fn["name"] == "data")
+        assert data.get("class_context") == "Buf"
+
+    def test_pre_scan_registers_them_as_call_targets(self, tmp_path):
+        f, _ = self._parse(tmp_path)
+        found = set(pre_scan_cpp([f], _wrapper("cpp")))
+        assert {"data", "make", "ref", "plain"} <= found
+        assert "Buf::data" in found, "qualified form must survive the pointer wrap"


### PR DESCRIPTION
Fixes #1524. Full suite: **1139 passed, 7 skipped**, no failures.

## The bug

Both queries nested `pointer_declarator` **inside** `function_declarator`. The real AST is the reverse — a pointer return type wraps the function declarator from the outside:

```
char* f() { }
function_definition > pointer_declarator > function_declarator > identifier
```

Verified against the grammar:

```
'char* data() { ... }'      -> pointer_declarator > function_declarator > identifier
'int size() { ... }'        -> function_declarator > identifier
'char** dd() { ... }'       -> pointer_declarator > pointer_declarator > function_declarator > identifier
'int& ref() { ... }'        -> reference_declarator > function_declarator
'char* Buf::at() { ... }'   -> pointer_declarator > function_declarator > qualified_identifier
```

So `c.py`'s second alternative matched nothing, and `cpp.py` had no alternative at all.

## The half that mattered more

`pre_scan_c` and `pre_scan_cpp` carry **their own copies** of the same inverted shape. That is the cross-file name map, so these functions weren't just missing as nodes — they were missing as **call targets**, and every call to them stayed unresolved. Both copies are fixed here.

```
C   pre_scan : ['dup_str', 'grid', 'plain']            # was ['plain']
C++ pre_scan : ['Buf', 'Buf::data', 'Buf::size', 'data',
                'make', 'plain', 'ref', 'size']
```

Accessors returning `T*`/`T&`, factory functions and `operator[]` are pervasive in C and C++, so this was a large silent gap.

## Covered forms

`T*`, `T**`, `T&` (C++ only), and the qualified out-of-line method `char* Buf::data()` — whose `class_context` survives the extra wrap, which is asserted separately since that is the case most likely to break.

## Tests

`tests/unit/parsers/test_c_cpp_pointer_returns.py` — 11 tests. Reverting the source changes fails **9 of 11**; the 2 that still pass are the plain-`int` control cases, which is the correct behaviour.

## Why no golden moved

Worth stating, since an unchanged golden usually means a change didn't apply. The only pointer-returning function in the C/C++ fixtures is `const char* get_color_name` in `tough_macros.c`, and it sits inside an X-macro region tree-sitter cannot parse:

```
ERROR/missing nodes: [('ERROR', 13), ('ERROR', 66), ('ERROR', 73), ('ERROR', 75), ('ERROR', 79)]
```

Line 79 is that function. It is unreachable for reasons unrelated to this fix, so the goldens are correctly unchanged. A fixture exercising a plain `T*` return would be a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
