### PR TITLE
Feature/dual engine ai explorer

### DIFF
--- a/website/src/components/CodeGraphViewer.tsx
+++ b/website/src/components/CodeGraphViewer.tsx
@@ -21,7 +21,7 @@ import { exportSvg } from "../lib/svg-exporter";
 import { packageInteractiveExport } from "../lib/html-exporter";
 import { toast } from "sonner";
 import { getOrCreateSessionId } from "../lib/utils";
-import { generateNodeSummary, type NodeSummary } from "../lib/summary-engine";
+import { generateNodeSummary, type NodeSummary, loadLLMConfig, saveLLMConfig, type LLMConfig, executeClientAIQuery } from "../lib/summary-engine";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -616,6 +616,8 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
   const [highlightLine, setHighlightLine] = useState<number | null>(null);
   const [selectedNode, setSelectedNode] = useState<any | null>(null);
   const [nodeSummary, setNodeSummary] = useState<NodeSummary | null>(null);
+  const [llmConfig, setLlmConfig] = useState<LLMConfig>(loadLLMConfig());
+  const [showLlmSettings, setShowLlmSettings] = useState<boolean>(false);
   const isCodeResizing = useRef(false);
   const codeResizeStartX = useRef(0);
   const codeResizeStartW = useRef(420);
@@ -1469,32 +1471,42 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
     try {
       const searchParams = new URLSearchParams(window.location.search);
       const backend = searchParams.get("backend");
-      const backendUrl = backend || window.location.origin;
-      const url = `${backendUrl.replace(/\/$/, "")}/api/ai_query`;
 
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          query: aiQuery,
-          repo_path: data.metadata?.path || null,
-        }),
-      });
+      if (backend) {
+        const backendUrl = backend || window.location.origin;
+        const url = `${backendUrl.replace(/[\\/]+$/, "")}/api/ai_query`;
+        
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            query: aiQuery,
+            repo_path: data.metadata?.path || null,
+          }),
+        });
 
-      if (!response.ok) {
-        const errData = await response.json().catch(() => ({}));
-        throw new Error(errData.detail || `Server error (${response.status})`);
-      }
+        if (!response.ok) {
+          const errData = await response.json().catch(() => ({}));
+          throw new Error(errData.detail || `Server error (${response.status})`);
+        }
 
-      const resData = await response.json();
-      if (resData.success) {
-        setAiResponse(resData);
-        // Automatically focus and zoom to the query result nodes
-        highlightAIQueryResultNodes(resData);
+        const resData = await response.json();
+        if (resData.success) {
+          setAiResponse(resData);
+          highlightAIQueryResultNodes(resData);
+        } else {
+          setAiError(resData.error || "An error occurred during AI analysis.");
+        }
       } else {
-        setAiError(resData.error || "An error occurred during AI analysis.");
+        const resData = await executeClientAIQuery(aiQuery, data.nodes, data.links, llmConfig);
+        if (resData.success) {
+          setAiResponse(resData);
+          highlightAIQueryResultNodes(resData);
+        } else {
+          setAiError(resData.error || "An error occurred during AI analysis.");
+        }
       }
     } catch (err: any) {
       console.error("AI Query Error:", err);
@@ -1503,7 +1515,7 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
     } finally {
       setAiLoading(false);
     }
-  }, [aiQuery, data, highlightAIQueryResultNodes]);
+  }, [aiQuery, data, highlightAIQueryResultNodes, llmConfig]);
 
   const getLinkColor = useCallback((link: any) => {
     const isFocused = focusSet ? focusSet.links.has(link) : true;
@@ -1662,10 +1674,65 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
               <div className="flex-1 overflow-y-auto px-2 py-1 custom-scrollbar">
                 {isAIMode ? (
                   <motion.div initial={{ opacity: 0, x: -10 }} animate={{ opacity: 1, x: 0 }} className="p-3 space-y-4">
-                    <h3 className="text-[10px] font-bold text-gray-500 uppercase tracking-widest mb-2 flex items-center gap-2">
-                      <MessageSquare className="w-3 h-3 text-purple-400 animate-pulse" /> AI Knowledge Explorer
-                    </h3>
-                    <p className="text-[11px] text-gray-400 leading-relaxed">Ask natural language questions about your repository's code graph.</p>
+                    <div className="flex items-center justify-between mb-2">
+                      <h3 className="text-[10px] font-bold text-gray-500 uppercase tracking-widest flex items-center gap-2 m-0">
+                        <MessageSquare className="w-3 h-3 text-purple-400 animate-pulse" /> AI Knowledge Explorer
+                      </h3>
+                      {!new URLSearchParams(window.location.search).get("backend") && (
+                        <button 
+                          onClick={() => setShowLlmSettings(!showLlmSettings)}
+                          title="BYOK Settings"
+                          className="text-gray-500 hover:text-white"
+                        >
+                          <Settings2 className="w-3 h-3" />
+                        </button>
+                      )}
+                    </div>
+                    
+                    {!new URLSearchParams(window.location.search).get("backend") && (llmConfig.provider === 'none' || showLlmSettings) ? (
+                      <div className="p-3 bg-purple-500/10 border border-purple-500/20 rounded-lg space-y-3">
+                        <div className="text-[11px] text-purple-200 leading-relaxed">
+                          <strong>Client-Side Engine:</strong> Configure your API key to run queries locally in your browser.
+                        </div>
+                        <select
+                          value={llmConfig.provider}
+                          onChange={e => setLlmConfig({...llmConfig, provider: e.target.value as any})}
+                          className={`w-full p-2 text-xs rounded border ${isDark ? 'bg-black/50 border-white/10 text-white' : 'bg-white border-black/10 text-black'}`}
+                        >
+                          <option value="none">Select Provider</option>
+                          <option value="gemini">Google Gemini</option>
+                          <option value="mistral">Mistral AI</option>
+                        </select>
+                        <input
+                          type="password"
+                          placeholder="API Key"
+                          value={llmConfig.apiKey}
+                          onChange={e => setLlmConfig({...llmConfig, apiKey: e.target.value})}
+                          className={`w-full p-2 text-xs rounded border ${isDark ? 'bg-black/50 border-white/10 text-white' : 'bg-white border-black/10 text-black'}`}
+                        />
+                        <Button 
+                          size="sm" 
+                          className="w-full text-xs" 
+                          onClick={() => {
+                            saveLLMConfig(llmConfig);
+                            setShowLlmSettings(false);
+                            toast.success("LLM Config Saved");
+                          }}
+                        >
+                          Save Config
+                        </Button>
+                      </div>
+                    ) : (
+                      <>
+                        <p className="text-[11px] text-gray-400 leading-relaxed flex items-center justify-between">
+                          <span>Ask natural language questions about your repository's code graph.</span>
+                          {!new URLSearchParams(window.location.search).get("backend") && (
+                            <span className="text-[9px] bg-purple-500/20 text-purple-300 px-1.5 py-0.5 rounded ml-2 whitespace-nowrap">Browser BYOK</span>
+                          )}
+                          {new URLSearchParams(window.location.search).get("backend") && (
+                            <span className="text-[9px] bg-blue-500/20 text-blue-300 px-1.5 py-0.5 rounded ml-2 whitespace-nowrap">Neo4j Engine</span>
+                          )}
+                        </p>
 
                     <div className="space-y-2 mt-2">
                       <textarea
@@ -1763,6 +1830,8 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                           </div>
                         )}
                       </motion.div>
+                    )}
+                    </>
                     )}
                   </motion.div>
                 ) : isPathMode ? (

--- a/website/src/components/CodeGraphViewer.tsx
+++ b/website/src/components/CodeGraphViewer.tsx
@@ -21,6 +21,7 @@ import { exportSvg } from "../lib/svg-exporter";
 import { packageInteractiveExport } from "../lib/html-exporter";
 import { toast } from "sonner";
 import { getOrCreateSessionId } from "../lib/utils";
+import { generateNodeSummary, type NodeSummary } from "../lib/summary-engine";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -437,8 +438,8 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
   const [ownerPart, repoPart] = repoName.includes('/') ? repoName.split('/') : [owner || repoName, repo || ''];
   const cleanOwner = String(ownerPart).trim();
   const cleanRepo = String(repoPart).trim();
-  const designedRepoName = cleanOwner && cleanRepo 
-    ? `${cleanOwner}__${cleanRepo}__${branchName}__${cleanCommit}` 
+  const designedRepoName = cleanOwner && cleanRepo
+    ? `${cleanOwner}__${cleanRepo}__${branchName}__${cleanCommit}`
     : repoName;
 
   const userId = getOrCreateSessionId();
@@ -477,7 +478,7 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
       } else {
         filename = `${repoName}.cgc`;
       }
-      
+
       const blob = await packageCgcBundle(repoName, data.nodes, data.links, data.metadata?.version || "1.0.0", data.metadata);
       downloadBlob(blob, filename);
       toast.success("CGC bundle exported successfully!");
@@ -511,14 +512,14 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
     try {
       let filename = "interactive-graph.zip";
       if (data.metadata?.repo) {
-         filename = `${data.metadata.repo.replace(/\//g, '_')}_interactive.zip`;
+        filename = `${data.metadata.repo.replace(/\//g, '_')}_interactive.zip`;
       }
-      
+
       const exportMode = graphMode === 'mermaid' ? 'mermaid' : 'classic';
       const blob = await packageInteractiveExport(
-        filteredData.nodes, 
-        filteredData.links, 
-        data.metadata || {}, 
+        filteredData.nodes,
+        filteredData.links,
+        data.metadata || {},
         nodeColors,
         edgeColors,
         exportMode
@@ -555,7 +556,7 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
       toast.error("Invalid repository name. Expected 'owner/repo' format.");
       return;
     }
-    
+
     // Check if this repository and commit/branch is already pre-indexed in the manifest
     const commitSha = data.metadata?.commit || "";
     if (commitSha) {
@@ -566,20 +567,20 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
         if (manifestRes.ok) {
           const manifestData = await manifestRes.json();
           const bundles = manifestData.bundles || [];
-          
+
           const match = bundles.find((b: any) => {
             const sameRepo = b.repo && b.repo.toLowerCase() === publishRepo.toLowerCase();
-            
+
             // The commit SHA can be stored in either b.commit or b.version (e.g. Hugging Face manifest)
             const targetCommit = (b.commit || b.version || "").toLowerCase();
             const currentCommit = commitSha.toLowerCase();
-            
+
             const sameCommit = targetCommit && (
               currentCommit === targetCommit ||
               currentCommit.startsWith(targetCommit) ||
               targetCommit.startsWith(currentCommit)
             );
-            
+
             return sameRepo && sameCommit;
           });
 
@@ -611,8 +612,10 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
   const [codeContent, setCodeContent] = useState<string | null>(null);
   const [codeError, setCodeError] = useState<string | null>(null);
   const [codePanelWidth, setCodePanelWidth] = useState(420);
-  const [codePanelTab, setCodePanelTab] = useState<'code' | 'entities'>('code');
+  const [codePanelTab, setCodePanelTab] = useState<'code' | 'entities' | 'architecture'>('code');
   const [highlightLine, setHighlightLine] = useState<number | null>(null);
+  const [selectedNode, setSelectedNode] = useState<any | null>(null);
+  const [nodeSummary, setNodeSummary] = useState<NodeSummary | null>(null);
   const isCodeResizing = useRef(false);
   const codeResizeStartX = useRef(0);
   const codeResizeStartW = useRef(420);
@@ -840,16 +843,44 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
       }
 
       default: {
+        const degree = degreeMap.get(node.id) || 0;
+        const baseSize = Math.max(3, Math.min(2 + Math.sqrt(degree) * 1.5, 15)) * nodeSize * graphAwareNodeScale;
+
+        // Glow for selected/highlighted
         if (isHovered || (selectedFile && node.file === selectedFile && node.type === 'File')) {
+          const glowGradient = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, baseSize * 4);
+          glowGradient.addColorStop(0, getRGBA(baseColor, 0.4));
+          glowGradient.addColorStop(1, 'transparent');
           ctx.beginPath();
-          ctx.arc(node.x, node.y, radius * (isHovered ? 2.5 : 2.0), 0, 2 * Math.PI, false);
-          ctx.fillStyle = getRGBA(baseColor, isHovered ? (isFocused ? 0.3 : 0.1) : 0.1);
+          ctx.arc(node.x, node.y, baseSize * 4, 0, 2 * Math.PI, false);
+          ctx.fillStyle = glowGradient;
+          ctx.fill();
+        } else if (isFocused && !isMassive) {
+          const glowGradient = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, baseSize * 2.5);
+          glowGradient.addColorStop(0, getRGBA(baseColor, 0.15));
+          glowGradient.addColorStop(1, 'transparent');
+          ctx.beginPath();
+          ctx.arc(node.x, node.y, baseSize * 2.5, 0, 2 * Math.PI, false);
+          ctx.fillStyle = glowGradient;
           ctx.fill();
         }
+
+        // Main circle
         ctx.beginPath();
-        ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI, false);
-        ctx.fillStyle = isFocused ? baseColor : getRGBA(baseColor, opacity);
+        ctx.arc(node.x, node.y, baseSize, 0, 2 * Math.PI, false);
+        ctx.fillStyle = isFocused ? getRGBA(baseColor, 0.8) : getRGBA(baseColor, 0.15);
         ctx.fill();
+
+        // Border
+        if (isHovered || (selectedFile && node.file === selectedFile && node.type === 'File')) {
+          ctx.strokeStyle = '#ffffff';
+          ctx.lineWidth = 2.5 / globalScale;
+          ctx.stroke();
+        } else if (isFocused) {
+          ctx.strokeStyle = baseColor;
+          ctx.lineWidth = 1.5 / globalScale;
+          ctx.stroke();
+        }
         break;
       }
     }
@@ -1198,6 +1229,11 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
 
     setHighlightLine(targetLine || null);
 
+    // Clear selectedNode if we manually clicked a file from tree
+    if (!targetLine) {
+      setSelectedNode(null);
+    }
+
     if (path !== selectedFile) {
       setSelectedFile(path);
       loadFileCode(path);
@@ -1247,11 +1283,27 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
       }
       return;
     }
+
+    setSelectedNode(node);
+    if (node.type !== 'File' && node.type !== 'Directory') {
+      setCodePanelTab('architecture');
+    }
+
     const filePath = node.file || node.properties?.path || node.properties?.file;
     if (!filePath) return;
     const lineNum = node.line_number ?? node.properties?.line_number;
-    onFileClick(filePath, lineNum ? Number(lineNum) : undefined);
+
+    // Pass lineNum to preserve selectedNode
+    onFileClick(filePath, lineNum ? Number(lineNum) : -1);
   };
+
+  useEffect(() => {
+    if (selectedNode) {
+      setNodeSummary(generateNodeSummary(selectedNode, data.nodes, data.links));
+    } else {
+      setNodeSummary(null);
+    }
+  }, [selectedNode, data.links]);
 
   useEffect(() => {
     if (highlightLine && codeContent && codePanelTab === 'code') {
@@ -1364,7 +1416,7 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
 
   const highlightAIQueryResultNodes = useCallback((responseObj = aiResponse) => {
     if (!responseObj || !responseObj.nodes) return;
-    
+
     const returnedNodeIds = new Set(responseObj.nodes.map((n: any) => n.id));
     const pathNodes = new Set<any>();
     const pathLinks = new Set<any>();
@@ -1413,7 +1465,7 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
     setAiLoading(true);
     setAiError(null);
     setAiResponse(null);
-    
+
     try {
       const searchParams = new URLSearchParams(window.location.search);
       const backend = searchParams.get("backend");
@@ -2009,8 +2061,8 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                         key={mode.id}
                         onClick={() => { setGraphMode(mode.id); setShowModeMenu(false); }}
                         className={`w-full flex items-center gap-3 px-4 py-2.5 transition-all cursor-pointer ${graphMode === mode.id
-                            ? (isDark ? 'bg-white/10 text-white' : 'bg-black/10 text-black')
-                            : (isDark ? 'text-gray-400 hover:text-white hover:bg-purple-500/10' : 'text-gray-500 hover:text-black hover:bg-black/5')
+                          ? (isDark ? 'bg-white/10 text-white' : 'bg-black/10 text-black')
+                          : (isDark ? 'text-gray-400 hover:text-white hover:bg-purple-500/10' : 'text-gray-500 hover:text-black hover:bg-black/5')
                           }`}
                       >
                         <div
@@ -2127,8 +2179,8 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                     key={mode.id}
                     onClick={() => { setGraphMode(mode.id); setShowMobileMenu(false); }}
                     className={`flex items-center gap-3 px-3 py-1.5 rounded-lg transition-all text-left cursor-pointer ${graphMode === mode.id
-                        ? (isDark ? 'bg-white/10 text-white' : 'bg-black/10 text-black')
-                        : (isDark ? 'text-gray-400 hover:text-white hover:bg-purple-500/10' : 'text-gray-500 hover:text-black hover:bg-black/5')
+                      ? (isDark ? 'bg-white/10 text-white' : 'bg-black/10 text-black')
+                      : (isDark ? 'text-gray-400 hover:text-white hover:bg-purple-500/10' : 'text-gray-500 hover:text-black hover:bg-black/5')
                       }`}
                   >
                     <div
@@ -2184,10 +2236,8 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
           </AnimatePresence>
         </div>
 
-        <div className="mt-1 mb-4 flex justify-center">
-          <div className="w-full max-w-[1330px]">
-            <RepositorySummary graphData={data} isIndexed={true} />
-          </div>
+        <div className="absolute top-20 left-1/2 -translate-x-1/2 z-[50] w-full flex justify-center px-4">
+          <RepositorySummary graphData={data} isIndexed={true} />
         </div>
 
         {graphMode === 'city3d' ? (
@@ -2296,10 +2346,16 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
             linkDirectionalParticleSpeed={0.005}
             nodeCanvasObject={nodeCanvasObject}
             nodePointerAreaPaint={(node: any, color: string, ctx: any, globalScale: number) => {
-              const radius = (node.val || 1) * 0.8 * nodeSize * graphAwareNodeScale;
-              const hitSize = graphMode === 'icon'
-                ? Math.max(14 / globalScale, (node.val || 1) * 2)
-                : radius * 1.5;
+              let hitSize = 0;
+              if (graphMode === 'icon') {
+                hitSize = Math.max(14 / globalScale, (node.val || 1) * 2);
+              } else if (graphMode === 'classic' || graphMode === 'curvy') {
+                const degree = degreeMap.get(node.id as any) || 0;
+                hitSize = Math.max(3, Math.min(2 + Math.sqrt(degree) * 1.5, 15)) * nodeSize * graphAwareNodeScale * 1.5;
+              } else {
+                hitSize = (node.val || 1) * 0.8 * nodeSize * graphAwareNodeScale * 1.5;
+              }
+
               ctx.fillStyle = color;
               ctx.beginPath();
               ctx.arc(node.x, node.y, hitSize, 0, 2 * Math.PI, false);
@@ -2369,7 +2425,7 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
 
       {/* ── CODE VIEWER PANEL ── */}
       <AnimatePresence>
-        {selectedFile && (
+        {(selectedFile || selectedNode) && (
           <>
             {dimensions.width < 768 && (
               <div
@@ -2402,11 +2458,11 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                   <div className="flex items-center gap-2 min-w-0">
                     <Code2 className="w-4 h-4 text-purple-400 flex-shrink-0" />
                     <span className="text-[13px] font-bold truncate" style={{ color: pal.text }}>
-                      {selectedFile.split('/').pop()}
+                      {selectedNode ? selectedNode.name : (selectedFile ? selectedFile.split('/').pop() : 'Details')}
                     </span>
                   </div>
                   <button
-                    onClick={() => onFileClick(null)}
+                    onClick={() => { onFileClick(null); setSelectedNode(null); }}
                     className={`p-1.5 rounded-lg transition-colors flex-shrink-0 ${isDark ? 'text-gray-500 hover:text-white hover:bg-purple-500/20' : 'text-gray-400 hover:text-black hover:bg-black/10'}`}
                   >
                     <X className="w-4 h-4" />
@@ -2415,7 +2471,7 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
 
                 {/* path breadcrumb + tabs */}
                 <div className="flex items-center gap-0 px-4 py-0 text-[10px] font-mono flex-shrink-0" style={{ borderBottom: `1px solid ${pal.border}` }}>
-                  <span className="text-gray-500 truncate flex-1 py-1.5">{selectedFile}</span>
+                  <span className="text-gray-500 truncate flex-1 py-1.5">{selectedFile || (selectedNode && selectedNode.type)}</span>
                   <div className="flex ml-2 flex-shrink-0">
                     <button
                       onClick={() => setCodePanelTab('code')}
@@ -2428,6 +2484,12 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                       className={`px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest transition-colors ${codePanelTab === 'entities' ? 'text-purple-400 border-b-2 border-purple-400' : (isDark ? 'text-gray-500 hover:text-gray-300' : 'text-gray-400 hover:text-gray-600')}`}
                     >
                       Entities
+                    </button>
+                    <button
+                      onClick={() => setCodePanelTab('architecture')}
+                      className={`px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest transition-colors ${codePanelTab === 'architecture' ? 'text-purple-400 border-b-2 border-purple-400' : (isDark ? 'text-gray-500 hover:text-gray-300' : 'text-gray-400 hover:text-gray-600')}`}
+                    >
+                      Architecture
                     </button>
                   </div>
                 </div>
@@ -2457,6 +2519,39 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                         <p>{codeError || 'No source available'}</p>
                       </div>
                     )
+                  ) : codePanelTab === 'architecture' ? (
+                    <div className="p-4 space-y-4">
+                      {!selectedNode ? (
+                        <div className="flex items-center justify-center h-40 text-gray-500 text-xs">
+                          Select a specific class, function, or module in the graph to view its architecture details.
+                        </div>
+                      ) : nodeSummary ? (
+                        <>
+                          <div className={`p-4 rounded-xl ${isDark ? 'bg-black/20 border border-white/5' : 'bg-gray-50 border border-black/5'}`}>
+                            <h3 className="text-[10px] font-black uppercase tracking-widest mb-2 text-purple-400">Component Role</h3>
+                            <p className={`text-sm leading-relaxed ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>{nodeSummary.description}</p>
+                          </div>
+
+                          <div className={`p-4 rounded-xl ${isDark ? 'bg-black/20 border border-white/5' : 'bg-gray-50 border border-black/5'}`}>
+                            <h3 className="text-[10px] font-black uppercase tracking-widest mb-2 text-blue-400">Architecture Position</h3>
+                            <p className={`text-sm leading-relaxed ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>{nodeSummary.architecturePosition}</p>
+                          </div>
+
+                          <div className={`p-4 rounded-xl ${isDark ? 'bg-black/20 border border-white/5' : 'bg-gray-50 border border-black/5'}`}>
+                            <h3 className="text-[10px] font-black uppercase tracking-widest mb-2 text-amber-400">Dependency Impact</h3>
+                            <p className={`text-sm leading-relaxed ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>{nodeSummary.dependencyImpact}</p>
+                            <div className={`flex gap-6 mt-3 pt-3 border-t ${isDark ? 'border-white/10' : 'border-black/5'}`}>
+                              <div><span className="text-[10px] uppercase font-bold tracking-wider text-gray-500 block mb-1">Incoming</span><span className={`font-mono text-sm ${isDark ? 'text-white' : 'text-black'}`}>{nodeSummary.incomingCount}</span></div>
+                              <div><span className="text-[10px] uppercase font-bold tracking-wider text-gray-500 block mb-1">Outgoing</span><span className={`font-mono text-sm ${isDark ? 'text-white' : 'text-black'}`}>{nodeSummary.outgoingCount}</span></div>
+                            </div>
+                          </div>
+                        </>
+                      ) : (
+                        <div className="flex items-center justify-center h-40 text-gray-500 text-xs">
+                          Loading architecture...
+                        </div>
+                      )}
+                    </div>
                   ) : (
                     <div className="p-4">
                       <div className="space-y-1">
@@ -2534,11 +2629,10 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
               initial={{ opacity: 0, scale: 0.95, y: 10 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95, y: 10 }}
-              className={`relative w-full max-w-md p-6 rounded-3xl shadow-2xl border backdrop-blur-2xl overflow-hidden ${
-                isDark 
-                  ? "bg-zinc-950/80 border-zinc-800 text-white" 
+              className={`relative w-full max-w-md p-6 rounded-3xl shadow-2xl border backdrop-blur-2xl overflow-hidden ${isDark
+                  ? "bg-zinc-950/80 border-zinc-800 text-white"
                   : "bg-white/90 border-zinc-200 text-zinc-900"
-              }`}
+                }`}
             >
               {/* Subtle top glow bar */}
               <div className="absolute top-0 left-0 right-0 h-1 bg-white" />
@@ -2553,9 +2647,8 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                 <button
                   disabled={isPublishing}
                   onClick={() => setShowPublishModal(false)}
-                  className={`p-1.5 rounded-full transition-colors ${
-                    isDark ? "hover:bg-purple-500/20 text-zinc-400 hover:text-white" : "hover:bg-zinc-100 text-zinc-500 hover:text-zinc-950"
-                  }`}
+                  className={`p-1.5 rounded-full transition-colors ${isDark ? "hover:bg-purple-500/20 text-zinc-400 hover:text-white" : "hover:bg-zinc-100 text-zinc-500 hover:text-zinc-950"
+                    }`}
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -2573,11 +2666,10 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                     value={publishRepo}
                     onChange={(e) => setPublishRepo(e.target.value)}
                     placeholder="e.g. owner/repository"
-                    className={`w-full px-3 py-2 text-sm rounded-xl border focus:outline-none focus:ring-2 focus:ring-purple-500 transition-all ${
-                      isDark 
-                        ? "bg-zinc-900 border-zinc-800 text-white placeholder-zinc-600 focus:border-zinc-700" 
+                    className={`w-full px-3 py-2 text-sm rounded-xl border focus:outline-none focus:ring-2 focus:ring-purple-500 transition-all ${isDark
+                        ? "bg-zinc-900 border-zinc-800 text-white placeholder-zinc-600 focus:border-zinc-700"
                         : "bg-zinc-50 border-zinc-200 text-zinc-950 placeholder-zinc-400 focus:border-zinc-300"
-                    }`}
+                      }`}
                   />
                 </div>
 
@@ -2592,11 +2684,10 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                     value={publishVersion}
                     onChange={(e) => setPublishVersion(e.target.value)}
                     placeholder="e.g. 1.0.0"
-                    className={`w-full px-3 py-2 text-sm rounded-xl border focus:outline-none focus:ring-2 focus:ring-purple-500 transition-all ${
-                      isDark 
-                        ? "bg-zinc-900 border-zinc-800 text-white placeholder-zinc-600 focus:border-zinc-700" 
+                    className={`w-full px-3 py-2 text-sm rounded-xl border focus:outline-none focus:ring-2 focus:ring-purple-500 transition-all ${isDark
+                        ? "bg-zinc-900 border-zinc-800 text-white placeholder-zinc-600 focus:border-zinc-700"
                         : "bg-zinc-50 border-zinc-200 text-zinc-950 placeholder-zinc-400 focus:border-zinc-300"
-                    }`}
+                      }`}
                   />
                 </div>
 
@@ -2649,11 +2740,10 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
               initial={{ opacity: 0, scale: 0.95, y: 10 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95, y: 10 }}
-              className={`relative w-full max-w-md p-6 rounded-3xl shadow-2xl border backdrop-blur-2xl overflow-hidden ${
-                isDark 
-                  ? "bg-zinc-950/80 border-zinc-800 text-white" 
+              className={`relative w-full max-w-md p-6 rounded-3xl shadow-2xl border backdrop-blur-2xl overflow-hidden ${isDark
+                  ? "bg-zinc-950/80 border-zinc-800 text-white"
                   : "bg-white/90 border-zinc-200 text-zinc-900"
-              }`}
+                }`}
             >
               {/* Subtle top glow bar */}
               <div className="absolute top-0 left-0 right-0 h-1 bg-white" />
@@ -2670,9 +2760,8 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                 </div>
                 <button
                   onClick={() => setShowChatGPTModal(false)}
-                  className={`p-1.5 rounded-full transition-colors ${
-                    isDark ? "hover:bg-purple-500/20 text-zinc-400 hover:text-white" : "hover:bg-zinc-100 text-zinc-500 hover:text-zinc-950"
-                  }`}
+                  className={`p-1.5 rounded-full transition-colors ${isDark ? "hover:bg-purple-500/20 text-zinc-400 hover:text-white" : "hover:bg-zinc-100 text-zinc-500 hover:text-zinc-950"
+                    }`}
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -2683,18 +2772,16 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                   <label className="text-[10px] uppercase font-bold tracking-wider text-zinc-400 block">
                     Connection Prompt (Auto-copied on Launch)
                   </label>
-                  <div className={`relative p-3 rounded-xl border font-mono text-xs flex justify-between items-center ${
-                    isDark ? "bg-zinc-900/60 border-zinc-800 text-zinc-300" : "bg-zinc-50 border-zinc-200 text-zinc-700"
-                  }`}>
+                  <div className={`relative p-3 rounded-xl border font-mono text-xs flex justify-between items-center ${isDark ? "bg-zinc-900/60 border-zinc-800 text-zinc-300" : "bg-zinc-50 border-zinc-200 text-zinc-700"
+                    }`}>
                     <span className="select-all break-all pr-8">{chatgptPreFillPrompt}</span>
                     <button
                       onClick={() => {
                         navigator.clipboard.writeText(chatgptPreFillPrompt);
                         toast.success("Prompt copied to clipboard!", { icon: "📋" });
                       }}
-                      className={`absolute right-2 p-1.5 rounded-lg transition-colors ${
-                        isDark ? "hover:bg-purple-500/10 text-zinc-400 hover:text-white" : "hover:bg-zinc-200 text-zinc-600 hover:text-zinc-900"
-                      }`}
+                      className={`absolute right-2 p-1.5 rounded-lg transition-colors ${isDark ? "hover:bg-purple-500/10 text-zinc-400 hover:text-white" : "hover:bg-zinc-200 text-zinc-600 hover:text-zinc-900"
+                        }`}
                       title="Copy prompt to clipboard"
                     >
                       <Copy className="w-3.5 h-3.5" />
@@ -2702,9 +2789,8 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
                   </div>
                 </div>
 
-                <div className={`p-3 rounded-xl border text-xs leading-relaxed ${
-                  isDark ? "bg-amber-950/20 border-amber-900/40 text-amber-300" : "bg-amber-50 border-amber-200/60 text-amber-800"
-                }`}>
+                <div className={`p-3 rounded-xl border text-xs leading-relaxed ${isDark ? "bg-amber-950/20 border-amber-900/40 text-amber-300" : "bg-amber-50 border-amber-200/60 text-amber-800"
+                  }`}>
                   <p className="font-semibold mb-1">💡 Important Instruction:</p>
                   <p>When the ChatGPT window loads, click on the chat box, press <kbd className="px-1 py-0.5 rounded border border-current font-sans text-[10px]">Ctrl+V</kbd> (or <kbd className="px-1 py-0.5 rounded border border-current font-sans text-[10px]">Cmd+V</kbd>) to paste the copied prompt, and hit enter!</p>
                 </div>
@@ -2737,7 +2823,7 @@ export default function CodeGraphViewer({ data: rawData, onClose }: { data: any,
         <AlertDialogContent className="bg-zinc-950 border border-zinc-800 text-zinc-100 max-w-md rounded-3xl shadow-2xl p-6 relative overflow-hidden backdrop-blur-2xl">
           {/* Subtle top glow bar */}
           <div className="absolute top-0 left-0 right-0 h-1 bg-white" />
-          
+
           <AlertDialogHeader>
             <AlertDialogTitle className="text-lg font-bold tracking-tight text-white flex items-center gap-2">
               <span className="text-amber-500">⚡</span> Pre-indexed Bundle Exists

--- a/website/src/components/ComparisonTable.tsx
+++ b/website/src/components/ComparisonTable.tsx
@@ -63,15 +63,19 @@ const tableData = [
   },
 ];
 
-const StatusBadge = ({ status, text }: { status: string; text: string }) => {
+const StatusBadge = ({ status, text, isCGC }: { status: string; text: string; isCGC?: boolean }) => {
   const getStyles = () => {
+    if (isCGC) {
+      // For CodeGraphContext, it's always the purple pill
+      return "bg-[#1e1138] text-cyan-400 border border-purple-500/30 w-full hover:bg-[#251545] transition-colors";
+    }
     switch (status) {
       case "good":
-        return "bg-cyan-500/10 text-cyan-400 border-cyan-500/20";
+        return "bg-[#042025] text-teal-400 border-none";
       case "warning":
-        return "bg-amber-500/10 text-amber-400 border-amber-500/20";
+        return "bg-[#291c06] text-amber-500 border-none";
       case "bad":
-        return "bg-white/5 text-gray-500 border-white/5";
+        return "bg-[#141414] text-gray-500 border-none";
       default:
         return "bg-black text-gray-500 border-white/10";
     }
@@ -81,7 +85,7 @@ const StatusBadge = ({ status, text }: { status: string; text: string }) => {
       case "good":
         return "✓";
       case "warning":
-        return "⚠";
+        return "▲";
       case "bad":
         return "✕";
       default:
@@ -90,9 +94,9 @@ const StatusBadge = ({ status, text }: { status: string; text: string }) => {
   };
   return (
     <Badge
-      className={`${getStyles()} border font-bold uppercase tracking-widest text-[0.55rem] sm:text-[0.65rem] px-2 sm:px-3 py-1.5 rounded-full min-w-[80px] text-center`}
+      className={`${getStyles()} font-bold uppercase tracking-widest text-[0.65rem] px-3 py-2 rounded-full min-w-[100px] text-center justify-center flex items-center shadow-none`}
     >
-      <span className="mr-1 font-black">{getIcon()}</span>
+      <span className="mr-1.5 font-black text-[0.55rem]">{getIcon()}</span>
       <span>{text}</span>
     </Badge>
   );
@@ -124,41 +128,53 @@ export default function ComparisonTable() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: "-100px" }}
           transition={{ duration: 0.6, delay: 0.2 }}
-          className="hidden md:block"
+          className="hidden md:block w-full"
         >
-          <GlassCard hoverable={false} className="p-2 bg-black border-white/20">
-            <div className="overflow-x-auto rounded-2xl">
-              <table className="min-w-full table-auto border-separate border-spacing-0">
-                <thead className="bg-gray-900/50">
-                  <tr>
-                    <th className="p-2 text-left text-sm font-medium text-gray-300">Feature</th>
-                    <th className="p-2 text-center"><img src="/logo-copilot.svg" alt="Copilot" className="h-5 mx-auto" /></th>
-                    <th className="p-2 text-center"><img src="/logo-cursor.svg" alt="Cursor" className="h-5 mx-auto" /></th>
-                    <th className="p-2 text-center"><img src="/logo-cgc.svg" alt="CodeGraphContext" className="h-5 mx-auto" /></th>
-                  </tr>
-                </thead>
-                <tbody>
-                   {tableData.map((row, idx) => (
-                      <motion.tr
-                        key={row.feature}
-                        initial={{ opacity: 0, y: 10 }}
-                        whileInView={{ opacity: 1, y: 0 }}
-                        viewport={{ once: true }}
-                        transition={{ duration: 0.3, delay: idx * 0.05 }}
-                        className={`border-b border-white/10 hover:bg-purple-500/10 transition-colors ${idx % 2 === 0 ? "bg-black" : "bg-white/5"} p-1.5`}
-                      >
-                        <td className="p-2 text-sm font-medium text-gray-200">{row.feature}</td>
-                        <td className="p-2 text-center"><StatusBadge status={row.copilot.status} text={row.copilot.text} /></td>
-                        <td className="p-2 text-center"><StatusBadge status={row.cursor.status} text={row.cursor.text} /></td>
-                        <td className="p-2 text-center">
-                          <div className={`bg-gradient-to-r from-purple-600/30 to-indigo-600/30 p-1 rounded ${row.highlight ? "ring-2 ring-purple-400" : ""}`}> <StatusBadge status={row.cgc.status} text={row.cgc.text} /> </div>
-                        </td>
-                      </motion.tr>
-                    ))}
-                </tbody>
-              </table>
-            </div>
-          </GlassCard>
+          <div className="bg-[#050505] border border-white/10 rounded-2xl overflow-hidden shadow-2xl mx-auto w-full max-w-[1000px]">
+            <table className="w-full table-auto border-collapse">
+              <thead className="bg-[#0a0a0a] border-b border-white/10">
+                <tr>
+                  <th className="px-6 py-5 text-left text-sm font-bold text-gray-300 w-1/3">Feature</th>
+                  <th className="px-4 py-5 text-center w-1/6">
+                    <div className="w-5 h-5 mx-auto rounded-full bg-[#2a3862] text-[10px] font-bold flex items-center justify-center text-blue-300">C</div>
+                  </th>
+                  <th className="px-4 py-5 text-center w-1/6">
+                    <div className="w-5 h-5 mx-auto rounded-full bg-[#1b3d2f] text-[10px] font-bold flex items-center justify-center text-green-300">R</div>
+                  </th>
+                  <th className="px-6 py-5 text-center w-1/3">
+                    <div className="flex items-center justify-center gap-2">
+                      <span className="font-bold text-white text-sm">CodeGraphContext</span>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                 {tableData.map((row, idx) => (
+                    <motion.tr
+                      key={row.feature}
+                      initial={{ opacity: 0, y: 10 }}
+                      whileInView={{ opacity: 1, y: 0 }}
+                      viewport={{ once: true }}
+                      transition={{ duration: 0.3, delay: idx * 0.05 }}
+                      className={`border-b border-white/5 hover:bg-white/[0.02] transition-colors`}
+                    >
+                      <td className="px-6 py-4 text-sm font-semibold text-gray-200">{row.feature}</td>
+                      <td className="px-4 py-4 text-center">
+                        <StatusBadge status={row.copilot.status} text={row.copilot.text} />
+                      </td>
+                      <td className="px-4 py-4 text-center">
+                        <StatusBadge status={row.cursor.status} text={row.cursor.text} />
+                      </td>
+                      <td className="px-6 py-4 text-center">
+                        <div className={`p-0.5 rounded-full ${row.highlight ? "bg-gradient-to-r from-purple-500/50 to-indigo-500/50" : ""}`}>
+                           <StatusBadge status={row.cgc.status} text={row.cgc.text} isCGC={true} />
+                        </div>
+                      </td>
+                    </motion.tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
         </motion.div>
 
         {/* Mobile stacked cards */}
@@ -186,25 +202,6 @@ export default function ComparisonTable() {
           ))}
         </motion.div>
 
-        {/* Summary / Benefits */}
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.5, delay: 0.3 }}
-          className="text-center mt-12"
-        >
-          <h3 className="text-xl font-semibold text-white mb-4">Key Benefits</h3>
-          <ul className="text-sm text-gray-300 list-disc list-inside max-w-xl mx-auto mb-6">
-            <li>Instant dependency tracking across repositories</li>
-            <li>Deep graph‑based code understanding</li>
-            <li>AI‑powered explanations with high accuracy</li>
-            <li>Scales flawlessly to massive codebases</li>
-          </ul>
-          <MagneticButton href="#demo" className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 text-base font-bold rounded-lg transition-colors">
-            Get Started
-          </MagneticButton>
-        </motion.div>
       </div>
     </section>
   );

--- a/website/src/components/Navbar.tsx
+++ b/website/src/components/Navbar.tsx
@@ -96,29 +96,45 @@ const Navbar: React.FC = () => {
           <ul className="hidden lg:flex items-center gap-6 font-bold text-[10px] uppercase tracking-widest text-gray-500">
             {[
               { label: "Features", href: "#features" },
+              { label: "Understand", href: "/understand", isRoute: true },
               { label: "Pre-indexed", href: "#bundle-registry" },
               { label: "Cookbook", href: "#cookbook" },
               { label: "Demo", href: "#demo" },
               { label: "Installation", href: "#installation" },
             ].map((link) => {
+              const isRoute = (link as any).isRoute;
               const id = link.href.replace("#", "");
-              const isActive = activeSection === id;
+              const isActive = isRoute
+                ? location.pathname === link.href
+                : activeSection === id;
               
               return (
                 <li key={link.label} className="relative flex items-center h-full py-4">
-                  <a
-                    href={link.href}
-                    className={`transition-colors duration-200 relative pb-1 ${isActive ? "text-white" : "hover:text-white text-gray-500"}`}
-                    onClick={(e) => {
-                      setActiveSection(id); // Instant visual update on click
-                      handleScroll(e);
-                    }}
-                  >
-                    {link.label}
-                    {isActive && (
-                      <span className="absolute bottom-0 left-0 w-full h-[2px] bg-purple-500 transition-all duration-300" />
-                    )}
-                  </a>
+                  {isRoute ? (
+                    <Link
+                      to={link.href}
+                      className={`transition-colors duration-200 relative pb-1 ${isActive ? "text-white" : "hover:text-white text-gray-500"}`}
+                    >
+                      {link.label}
+                      {isActive && (
+                        <span className="absolute bottom-0 left-0 w-full h-[2px] bg-purple-500 transition-all duration-300" />
+                      )}
+                    </Link>
+                  ) : (
+                    <a
+                      href={link.href}
+                      className={`transition-colors duration-200 relative pb-1 ${isActive ? "text-white" : "hover:text-white text-gray-500"}`}
+                      onClick={(e) => {
+                        setActiveSection(id);
+                        handleScroll(e);
+                      }}
+                    >
+                      {link.label}
+                      {isActive && (
+                        <span className="absolute bottom-0 left-0 w-full h-[2px] bg-purple-500 transition-all duration-300" />
+                      )}
+                    </a>
+                  )}
                 </li>
               );
             })}

--- a/website/src/components/RepositorySummary.tsx
+++ b/website/src/components/RepositorySummary.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { FileCode2, FolderOpen, FunctionSquare, Braces, Link2, AlertTriangle, Info } from "lucide-react";
 
 interface GraphNode {
   id?: string;
@@ -38,9 +39,7 @@ const RepositorySummary: React.FC<RepositorySummaryProps> = ({
     const links = graphData.links ?? [];
     const fileContents = graphData.fileContents ?? {};
 
-    const files =
-      graphData.files?.length ?? Object.keys(fileContents).length;
-
+    const files = graphData.files?.length ?? Object.keys(fileContents).length;
     const folders = nodes.filter((n) => n.type === "Directory").length;
     const functions = nodes.filter((n) => n.type === "Function").length;
     const classes = nodes.filter((n) => n.type === "Class").length;
@@ -48,24 +47,17 @@ const RepositorySummary: React.FC<RepositorySummaryProps> = ({
 
     const largeFiles = Object.values(fileContents).filter(
       (content) =>
-        typeof content === "string" &&
-        content.length > largeFileThreshold * 50
+        typeof content === "string" && content.length > largeFileThreshold * 50
     ).length;
 
-    return {
-      files,
-      folders,
-      functions,
-      classes,
-      imports,
-      largeFiles,
-    };
+    return { files, folders, functions, classes, imports, largeFiles };
   }, [graphData, largeFileThreshold]);
 
   if (!isIndexed) {
     return (
-      <div className="mt-1 mb-2 w-full rounded-xl border border-border bg-background p-3 shadow-sm">
-        Indexing repository...
+      <div className="inline-flex items-center gap-2 px-4 py-2 bg-black/60 backdrop-blur-xl border border-white/10 rounded-full shadow-2xl">
+        <div className="w-3 h-3 border-2 border-purple-500 border-t-transparent rounded-full animate-spin" />
+        <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Indexing Repository</span>
       </div>
     );
   }
@@ -74,112 +66,78 @@ const RepositorySummary: React.FC<RepositorySummaryProps> = ({
   const unusedExports = graphData.unusedExports;
 
   return (
-    <div className="mt-1 mb-2 w-full rounded-xl border border-border/60 bg-background p-4 shadow-sm">
-      <div className="mb-3">
-        <h2 className="text-xl font-bold tracking-tight text-foreground">
-          Repository Analysis
-        </h2>
-
-        <p className="mt-1 text-sm text-muted-foreground">
-          Quick overview of the indexed repository structure and potential
-          maintainability concerns.
-        </p>
-      </div>
-
-      {/* Repository Overview */}
-      <div className="mb-3">
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Repository Overview
-        </h3>
-
-        <div className="grid grid-cols-2 gap-2 md:grid-cols-5">
-          <StatCard icon="📄" label="Files" value={summary.files} />
-          <StatCard icon="📁" label="Folders" value={summary.folders} />
-          <StatCard icon="⚙️" label="Functions" value={summary.functions} />
-          <StatCard icon="🏗️" label="Classes" value={summary.classes} />
-          <StatCard icon="🔗" label="Imports" value={summary.imports} />
+    <div className="flex flex-col gap-2 w-full max-w-4xl pointer-events-none">
+      {/* Main Stats Row */}
+      <div className="flex items-center gap-2 pointer-events-auto overflow-x-auto custom-scrollbar pb-2 md:pb-0">
+        <div className="flex items-center bg-black/50 backdrop-blur-3xl border border-white/10 rounded-2xl p-1 shadow-2xl">
+          <StatPill icon={<FileCode2 />} label="Files" value={summary.files} />
+          <Divider />
+          <StatPill icon={<FolderOpen />} label="Folders" value={summary.folders} />
+          <Divider />
+          <StatPill icon={<FunctionSquare />} label="Functions" value={summary.functions} />
+          <Divider />
+          <StatPill icon={<Braces />} label="Classes" value={summary.classes} />
+          <Divider />
+          <StatPill icon={<Link2 />} label="Imports" value={summary.imports} />
         </div>
       </div>
 
-      {/* Analysis Warnings */}
-      <div className="border-t border-border pt-3">
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Analysis Warnings
-        </h3>
-
-        <div className="grid gap-2 md:grid-cols-3">
-          <IssueCard
-            title="Circular Dependencies"
-            value={
-              circularDependencies !== undefined
-                ? circularDependencies.toString()
-                : "Backend support pending"
-            }
-          />
-
-          <IssueCard
-            title="Large Files"
-            value={summary.largeFiles.toString()}
-          />
-
-          <IssueCard
-            title="Unused Exports"
-            value={
-              unusedExports !== undefined
-                ? unusedExports.toString()
-                : "Backend support pending"
-            }
-          />
-        </div>
+      {/* Warnings Row */}
+      <div className="flex items-center gap-2 pointer-events-auto">
+        <WarningBadge
+          title="Circular Dependencies"
+          value={circularDependencies !== undefined ? circularDependencies : null}
+          isWarning={circularDependencies !== undefined && circularDependencies > 0}
+        />
+        <WarningBadge
+          title="Large Files"
+          value={summary.largeFiles}
+          isWarning={summary.largeFiles > 0}
+        />
+        <WarningBadge
+          title="Unused Exports"
+          value={unusedExports !== undefined ? unusedExports : null}
+          isWarning={unusedExports !== undefined && unusedExports > 0}
+        />
       </div>
     </div>
   );
 };
 
-interface StatCardProps {
-  label: string;
-  value: number;
-  icon: string;
-}
+const Divider = () => <div className="w-px h-6 bg-white/10 mx-1" />;
 
-const StatCard: React.FC<StatCardProps> = ({
-  label,
-  value,
-  icon,
-}) => (
-  <div className="rounded-lg border border-border bg-card p-3 text-center shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md">
-    <div className="mb-1 text-xl">
+const StatPill = ({ icon, label, value }: { icon: React.ReactNode; label: string; value: number }) => (
+  <div className="flex items-center gap-3 px-4 py-2 rounded-xl hover:bg-white/5 transition-colors group">
+    <div className="text-gray-500 group-hover:text-cyan-400 transition-colors [&>svg]:w-4 [&>svg]:h-4">
       {icon}
     </div>
-
-    <div className="text-2xl font-bold">
-      {value.toLocaleString()}
-    </div>
-
-    <div className="text-xs font-medium text-muted-foreground">
-      {label}
+    <div className="flex flex-col">
+      <span className="text-[14px] font-black text-white leading-tight">{value.toLocaleString()}</span>
+      <span className="text-[9px] font-bold uppercase tracking-widest text-gray-500 leading-tight">{label}</span>
     </div>
   </div>
 );
 
-interface IssueCardProps {
-  title: string;
-  value: string;
-}
+const WarningBadge = ({ title, value, isWarning }: { title: string; value: number | null; isWarning: boolean }) => {
+  if (value === null) {
+    return (
+      <div className="flex items-center gap-1.5 px-3 py-1.5 bg-black/40 backdrop-blur-xl border border-white/5 rounded-full shadow-lg">
+        <Info className="w-3 h-3 text-gray-600" />
+        <span className="text-[9px] font-bold uppercase tracking-widest text-gray-500">{title}: Pending</span>
+      </div>
+    );
+  }
 
-const IssueCard: React.FC<IssueCardProps> = ({
-  title,
-  value,
-}) => (
-  <div className="rounded-lg border border-yellow-500/30 bg-yellow-50 p-3 shadow-sm dark:bg-yellow-500/5">
-    <div className="mb-1 text-sm font-semibold">
-      ⚠ {title}
+  return (
+    <div className={`flex items-center gap-1.5 px-3 py-1.5 backdrop-blur-xl border rounded-full shadow-lg transition-colors ${
+      isWarning ? 'bg-amber-500/10 border-amber-500/20 text-amber-500' : 'bg-green-500/10 border-green-500/20 text-green-500'
+    }`}>
+      {isWarning ? <AlertTriangle className="w-3 h-3" /> : <div className="w-1.5 h-1.5 rounded-full bg-green-500" />}
+      <span className="text-[9px] font-bold uppercase tracking-widest">
+        {value} {title}
+      </span>
     </div>
-
-    <div className="text-xs text-muted-foreground">
-      {value}
-    </div>
-  </div>
-);
+  );
+};
 
 export default RepositorySummary;

--- a/website/src/lib/summary-engine.ts
+++ b/website/src/lib/summary-engine.ts
@@ -416,7 +416,83 @@ Respond with ONLY the summary, no markdown formatting.`;
   return null;
 }
 
-async function callGemini(prompt: string, apiKey: string, model?: string): Promise<string> {
+export async function executeClientAIQuery(
+  query: string,
+  nodes: GraphNode[],
+  links: GraphLink[],
+  config: LLMConfig
+): Promise<any> {
+  if (config.provider === 'none' || !config.apiKey) {
+    throw new Error("No LLM configured for client-side execution");
+  }
+
+  // Minify the graph to save tokens
+  // If the graph is insanely huge, a lightweight RAG can be applied here.
+  // For Gemini 2.0 Flash (1M tokens), up to ~5000 nodes is typically fine.
+  const minifiedNodes = nodes.map(n => ({
+    id: n.id,
+    name: n.name,
+    type: n.type,
+    filePath: n.filePath
+  }));
+
+  const minifiedLinks = links.map(l => ({
+    source: typeof l.source === 'object' ? l.source.id : l.source,
+    target: typeof l.target === 'object' ? l.target.id : l.target,
+    type: l.type
+  }));
+
+  const graphContext = JSON.stringify({ nodes: minifiedNodes, edges: minifiedLinks });
+
+  const prompt = `You are an expert AI software architect analyzing a code graph.
+
+Graph Data:
+${graphContext}
+
+User Query: "${query}"
+
+Based on the graph data provided, answer the user's query.
+Respond with a strict JSON object (no markdown, no backticks) containing two keys:
+1. "explanation": A detailed, plain-English explanation answering the query.
+2. "nodeIds": An array of node IDs (strings or numbers) that are relevant to your explanation and should be highlighted in the graph visualization. If no specific nodes apply, return an empty array.
+
+JSON Format:
+{
+  "explanation": "...",
+  "nodeIds": [123, 456]
+}`;
+
+  try {
+    let rawResult = "";
+    if (config.provider === 'gemini') {
+      rawResult = await callGemini(prompt, config.apiKey, config.model, 2000, true);
+    } else if (config.provider === 'mistral') {
+      rawResult = await callMistral(prompt, config.apiKey, config.model, 2000, true);
+    }
+
+    if (!rawResult) throw new Error("Empty response from LLM");
+
+    // Attempt to parse JSON. Some models still include markdown backticks.
+    const jsonStr = rawResult.replace(/^\\s*\`\`\`json/i, '').replace(/\`\`\`\\s*$/i, '').trim();
+    const resultObj = JSON.parse(jsonStr);
+
+    return {
+      success: true,
+      explanation: resultObj.explanation || "No explanation provided.",
+      nodes: (resultObj.nodeIds || []).map((id: any) => ({ id })),
+      translation_explanation: "Processed purely client-side using your BYOK LLM."
+    };
+  } catch (err: any) {
+    console.error(`Client AI Query failed (${config.provider}):`, err);
+    return {
+      success: false,
+      error: err.message || "Failed to process the query."
+    };
+  }
+}
+
+
+async function callGemini(prompt: string, apiKey: string, model?: string, maxTokens: number = 200, jsonMode: boolean = false): Promise<string> {
   const modelId = model || 'gemini-2.0-flash';
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelId}:generateContent?key=${apiKey}`;
   
@@ -426,9 +502,10 @@ async function callGemini(prompt: string, apiKey: string, model?: string): Promi
     body: JSON.stringify({
       contents: [{ parts: [{ text: prompt }] }],
       generationConfig: {
-        maxOutputTokens: 200,
+        maxOutputTokens: maxTokens,
         temperature: 0.3,
-      },
+        ...(jsonMode ? { responseMimeType: "application/json" } : {})
+      }
     }),
   });
 
@@ -441,7 +518,7 @@ async function callGemini(prompt: string, apiKey: string, model?: string): Promi
   return data?.candidates?.[0]?.content?.parts?.[0]?.text || '';
 }
 
-async function callMistral(prompt: string, apiKey: string, model?: string): Promise<string> {
+async function callMistral(prompt: string, apiKey: string, model?: string, maxTokens: number = 200, jsonMode: boolean = false): Promise<string> {
   const modelId = model || 'mistral-small-latest';
   const url = 'https://api.mistral.ai/v1/chat/completions';
 
@@ -454,8 +531,9 @@ async function callMistral(prompt: string, apiKey: string, model?: string): Prom
     body: JSON.stringify({
       model: modelId,
       messages: [{ role: 'user', content: prompt }],
-      max_tokens: 200,
+      max_tokens: maxTokens,
       temperature: 0.3,
+      ...(jsonMode ? { response_format: { type: "json_object" } } : {})
     }),
   });
 

--- a/website/src/lib/summary-engine.ts
+++ b/website/src/lib/summary-engine.ts
@@ -1,0 +1,575 @@
+/**
+ * Summary Engine — Generates plain-English summaries for code graph nodes.
+ *
+ * Supports two modes:
+ *  1. Heuristic (default) — client-side name/type/relationship analysis
+ *  2. LLM-powered (BYOK) — optional Gemini or Mistral API calls for richer summaries
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface GraphNode {
+  id: number | string;
+  name: string;
+  type: string;
+  filePath?: string;
+  parameters?: string[];
+  returnType?: string;
+  [key: string]: any;
+}
+
+export interface GraphLink {
+  source: number | string | GraphNode;
+  target: number | string | GraphNode;
+  type: string;
+  [key: string]: any;
+}
+
+export interface NodeSummary {
+  description: string;
+  architecturePosition: string;
+  dependencyImpact: string;
+  incomingCount: number;
+  outgoingCount: number;
+  depth: number;
+  neighborTypeBreakdown: Record<string, number>;
+}
+
+export type LLMProvider = 'gemini' | 'mistral' | 'none';
+
+export interface LLMConfig {
+  provider: LLMProvider;
+  apiKey: string;
+  model?: string;
+}
+
+// ─── Heuristic Helpers ───────────────────────────────────────────────────────
+
+/** Split camelCase, PascalCase, snake_case, kebab-case into words */
+function splitIdentifier(name: string): string[] {
+  return name
+    .replace(/([a-z])([A-Z])/g, '$1 $2')      // camelCase → camel Case
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2') // XMLParser → XML Parser
+    .replace(/[_\-./\\]/g, ' ')                 // snake_case, kebab-case, paths
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(w => w.toLowerCase());
+}
+
+/** Humanize an identifier into a readable phrase */
+function humanize(name: string): string {
+  const words = splitIdentifier(name);
+  if (words.length === 0) return name;
+  // Capitalize first word
+  words[0] = words[0].charAt(0).toUpperCase() + words[0].slice(1);
+  return words.join(' ');
+}
+
+/** Detect common verb prefixes and generate an action description */
+function describeAction(name: string): string {
+  const words = splitIdentifier(name);
+  if (words.length === 0) return `Performs an operation`;
+
+  const verb = words[0];
+  const rest = words.slice(1).join(' ');
+
+  const verbMap: Record<string, string> = {
+    get: 'Retrieves',
+    set: 'Sets',
+    is: 'Checks whether',
+    has: 'Checks if it has',
+    can: 'Determines if it can',
+    should: 'Determines if it should',
+    create: 'Creates',
+    make: 'Creates',
+    build: 'Builds',
+    init: 'Initializes',
+    initialize: 'Initializes',
+    setup: 'Sets up',
+    handle: 'Handles',
+    on: 'Handles',
+    process: 'Processes',
+    parse: 'Parses',
+    validate: 'Validates',
+    check: 'Checks',
+    update: 'Updates',
+    delete: 'Deletes',
+    remove: 'Removes',
+    add: 'Adds',
+    insert: 'Inserts',
+    fetch: 'Fetches',
+    load: 'Loads',
+    save: 'Saves',
+    store: 'Stores',
+    send: 'Sends',
+    emit: 'Emits',
+    dispatch: 'Dispatches',
+    render: 'Renders',
+    display: 'Displays',
+    show: 'Shows',
+    hide: 'Hides',
+    toggle: 'Toggles',
+    enable: 'Enables',
+    disable: 'Disables',
+    convert: 'Converts',
+    transform: 'Transforms',
+    format: 'Formats',
+    calculate: 'Calculates',
+    compute: 'Computes',
+    find: 'Finds',
+    search: 'Searches for',
+    filter: 'Filters',
+    sort: 'Sorts',
+    map: 'Maps',
+    reduce: 'Reduces',
+    merge: 'Merges',
+    split: 'Splits',
+    join: 'Joins',
+    connect: 'Connects',
+    disconnect: 'Disconnects',
+    open: 'Opens',
+    close: 'Closes',
+    start: 'Starts',
+    stop: 'Stops',
+    run: 'Runs',
+    execute: 'Executes',
+    test: 'Tests',
+    log: 'Logs',
+    print: 'Prints',
+    debug: 'Debugs',
+    export: 'Exports',
+    import: 'Imports',
+  };
+
+  const action = verbMap[verb];
+  if (action && rest) {
+    return `${action} ${rest}`;
+  }
+  if (action) {
+    return `${action} the value`;
+  }
+  return `Performs ${humanize(name).toLowerCase()} operation`;
+}
+
+/** Generate description based on node type */
+function describeByType(node: GraphNode): string {
+  const name = humanize(node.name);
+  switch (node.type) {
+    case 'Repository':
+      return `Root repository node representing the entire codebase "${node.name}".`;
+    case 'Directory':
+      return `Directory "${node.name}" containing related source files and modules.`;
+    case 'File':
+      return `Source file "${node.name}" that defines code entities used across the project.`;
+    case 'Class':
+      return `Class "${name}" — a blueprint that encapsulates data and behavior.`;
+    case 'Interface':
+      return `Interface "${name}" — defines a contract that other types must implement.`;
+    case 'Trait':
+      return `Trait "${name}" — provides reusable behavior that can be mixed into classes.`;
+    case 'Function':
+      return `Function that ${describeAction(node.name).toLowerCase()}.`;
+    case 'Module':
+      return `Module "${name}" — a logical grouping of related functionality.`;
+    case 'Variable':
+      return `Variable "${name}" — stores a value used within its scope.`;
+    case 'Enum':
+      return `Enum "${name}" — defines a set of named constant values.`;
+    case 'Struct':
+      return `Struct "${name}" — a value type that groups related data fields.`;
+    case 'Macro':
+      return `Macro "${name}" — a compile-time code generation directive.`;
+    case 'Record':
+      return `Record "${name}" — an immutable data carrier type.`;
+    case 'Union':
+      return `Union "${name}" — a type that can hold one of several variant types.`;
+    case 'Property':
+      return `Property "${name}" — an accessor that gets or sets a value.`;
+    case 'Annotation':
+      return `Annotation "${name}" — provides metadata for code elements.`;
+    case 'Parameter':
+      return `Parameter "${name}" — an input value passed to a function or method.`;
+    default:
+      return `Code element "${name}" of type ${node.type}.`;
+  }
+}
+
+// ─── Core Summary Generator ─────────────────────────────────────────────────
+
+export function generateNodeSummary(
+  node: GraphNode,
+  allNodes: GraphNode[],
+  allLinks: GraphLink[]
+): NodeSummary {
+  const nodeId = node.id;
+
+  // Compute incoming and outgoing edges
+  const incoming = allLinks.filter(l => {
+    const targetId = typeof l.target === 'object' ? l.target.id : l.target;
+    return targetId === nodeId;
+  });
+  const outgoing = allLinks.filter(l => {
+    const sourceId = typeof l.source === 'object' ? l.source.id : l.source;
+    return sourceId === nodeId;
+  });
+
+  // Neighbor type breakdown
+  const neighborTypeBreakdown: Record<string, number> = {};
+  const neighborIds = new Set<number | string>();
+  [...incoming, ...outgoing].forEach(link => {
+    const otherId = typeof link.source === 'object'
+      ? link.source.id === nodeId ? (typeof link.target === 'object' ? link.target.id : link.target) : link.source.id
+      : link.source === nodeId ? (typeof link.target === 'object' ? link.target.id : link.target) : link.source;
+    neighborIds.add(otherId);
+  });
+  neighborIds.forEach(nId => {
+    const neighbor = allNodes.find(n => n.id === nId);
+    if (neighbor) {
+      neighborTypeBreakdown[neighbor.type] = (neighborTypeBreakdown[neighbor.type] || 0) + 1;
+    }
+  });
+
+  // Compute depth in hierarchy via CONTAINS edges
+  let depth = 0;
+  let currentId: number | string | undefined = nodeId;
+  const visited = new Set<number | string>();
+  while (currentId !== undefined && !visited.has(currentId)) {
+    visited.add(currentId);
+    const parentLink = allLinks.find(l => {
+      const targetId = typeof l.target === 'object' ? l.target.id : l.target;
+      return targetId === currentId && l.type === 'CONTAINS';
+    });
+    if (parentLink) {
+      depth++;
+      currentId = typeof parentLink.source === 'object' ? parentLink.source.id : parentLink.source;
+    } else {
+      break;
+    }
+  }
+
+  // Generate description
+  const description = describeByType(node);
+
+  // Architecture position (breadcrumb path)
+  const breadcrumb: string[] = [node.name];
+  currentId = nodeId;
+  const visitedPath = new Set<number | string>();
+  while (currentId !== undefined && !visitedPath.has(currentId)) {
+    visitedPath.add(currentId);
+    const parentLink = allLinks.find(l => {
+      const targetId = typeof l.target === 'object' ? l.target.id : l.target;
+      return targetId === currentId && l.type === 'CONTAINS';
+    });
+    if (parentLink) {
+      const parentId = typeof parentLink.source === 'object' ? parentLink.source.id : parentLink.source;
+      const parentNode = allNodes.find(n => n.id === parentId);
+      if (parentNode) {
+        breadcrumb.unshift(parentNode.name);
+        currentId = parentId;
+      } else {
+        break;
+      }
+    } else {
+      break;
+    }
+  }
+  const architecturePosition = breadcrumb.join(' › ');
+
+  // Dependency impact
+  const totalAffected = outgoing.length;
+  const totalDependsOn = incoming.length;
+  let dependencyImpact = '';
+  if (totalAffected > 10) {
+    dependencyImpact = `High impact — ${totalAffected} downstream elements depend on this. Changes here could cascade widely.`;
+  } else if (totalAffected > 3) {
+    dependencyImpact = `Moderate impact — ${totalAffected} elements are connected downstream.`;
+  } else if (totalAffected > 0) {
+    dependencyImpact = `Low impact — only ${totalAffected} element${totalAffected > 1 ? 's' : ''} depend${totalAffected === 1 ? 's' : ''} on this.`;
+  } else {
+    dependencyImpact = `Leaf node — nothing directly depends on this element.`;
+  }
+  if (totalDependsOn > 0) {
+    dependencyImpact += ` Relies on ${totalDependsOn} upstream element${totalDependsOn > 1 ? 's' : ''}.`;
+  }
+
+  return {
+    description,
+    architecturePosition,
+    dependencyImpact,
+    incomingCount: incoming.length,
+    outgoingCount: outgoing.length,
+    depth,
+    neighborTypeBreakdown,
+  };
+}
+
+// ─── Dependency Lists ────────────────────────────────────────────────────────
+
+export interface DependencyEntry {
+  nodeId: number | string;
+  nodeName: string;
+  nodeType: string;
+  edgeType: string;
+}
+
+export function getIncomingDependencies(
+  nodeId: number | string,
+  allNodes: GraphNode[],
+  allLinks: GraphLink[]
+): DependencyEntry[] {
+  return allLinks
+    .filter(l => {
+      const targetId = typeof l.target === 'object' ? l.target.id : l.target;
+      return targetId === nodeId;
+    })
+    .map(l => {
+      const sourceId = typeof l.source === 'object' ? l.source.id : l.source;
+      const sourceNode = allNodes.find(n => n.id === sourceId);
+      return {
+        nodeId: sourceId,
+        nodeName: sourceNode?.name || String(sourceId),
+        nodeType: sourceNode?.type || 'Unknown',
+        edgeType: l.type,
+      };
+    });
+}
+
+export function getOutgoingDependencies(
+  nodeId: number | string,
+  allNodes: GraphNode[],
+  allLinks: GraphLink[]
+): DependencyEntry[] {
+  return allLinks
+    .filter(l => {
+      const sourceId = typeof l.source === 'object' ? l.source.id : l.source;
+      return sourceId === nodeId;
+    })
+    .map(l => {
+      const targetId = typeof l.target === 'object' ? l.target.id : l.target;
+      const targetNode = allNodes.find(n => n.id === targetId);
+      return {
+        nodeId: targetId,
+        nodeName: targetNode?.name || String(targetId),
+        nodeType: targetNode?.type || 'Unknown',
+        edgeType: l.type,
+      };
+    });
+}
+
+// ─── BYOK LLM Summaries ─────────────────────────────────────────────────────
+
+const LLM_STORAGE_KEY = 'cgc-llm-config';
+
+export function saveLLMConfig(config: LLMConfig): void {
+  localStorage.setItem(LLM_STORAGE_KEY, JSON.stringify(config));
+}
+
+export function loadLLMConfig(): LLMConfig {
+  try {
+    const stored = localStorage.getItem(LLM_STORAGE_KEY);
+    if (stored) return JSON.parse(stored);
+  } catch { /* ignore */ }
+  return { provider: 'none', apiKey: '' };
+}
+
+export function clearLLMConfig(): void {
+  localStorage.removeItem(LLM_STORAGE_KEY);
+}
+
+export async function generateLLMSummary(
+  node: GraphNode,
+  allNodes: GraphNode[],
+  allLinks: GraphLink[],
+  config: LLMConfig
+): Promise<string | null> {
+  if (config.provider === 'none' || !config.apiKey) return null;
+
+  // Build a compact context about the node
+  const incoming = getIncomingDependencies(node.id, allNodes, allLinks);
+  const outgoing = getOutgoingDependencies(node.id, allNodes, allLinks);
+
+  const prompt = `You are a code analysis assistant. Given this code element, provide a concise 2-3 sentence plain English summary explaining what it does, its role in the codebase, and why it matters.
+
+Code element:
+- Name: ${node.name}
+- Type: ${node.type}
+- File: ${node.filePath || 'unknown'}
+${node.parameters ? `- Parameters: ${node.parameters.join(', ')}` : ''}
+${node.returnType ? `- Returns: ${node.returnType}` : ''}
+
+Dependencies (what it uses): ${outgoing.slice(0, 10).map(d => `${d.nodeName} (${d.nodeType})`).join(', ') || 'none'}
+Dependents (what uses it): ${incoming.slice(0, 10).map(d => `${d.nodeName} (${d.nodeType})`).join(', ') || 'none'}
+
+Respond with ONLY the summary, no markdown formatting.`;
+
+  try {
+    if (config.provider === 'gemini') {
+      return await callGemini(prompt, config.apiKey, config.model);
+    } else if (config.provider === 'mistral') {
+      return await callMistral(prompt, config.apiKey, config.model);
+    }
+  } catch (err) {
+    console.error(`LLM summary failed (${config.provider}):`, err);
+    return null;
+  }
+
+  return null;
+}
+
+async function callGemini(prompt: string, apiKey: string, model?: string): Promise<string> {
+  const modelId = model || 'gemini-2.0-flash';
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelId}:generateContent?key=${apiKey}`;
+  
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: {
+        maxOutputTokens: 200,
+        temperature: 0.3,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const error = await res.text();
+    throw new Error(`Gemini API error: ${res.status} — ${error}`);
+  }
+
+  const data = await res.json();
+  return data?.candidates?.[0]?.content?.parts?.[0]?.text || '';
+}
+
+async function callMistral(prompt: string, apiKey: string, model?: string): Promise<string> {
+  const modelId = model || 'mistral-small-latest';
+  const url = 'https://api.mistral.ai/v1/chat/completions';
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: modelId,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 200,
+      temperature: 0.3,
+    }),
+  });
+
+  if (!res.ok) {
+    const error = await res.text();
+    throw new Error(`Mistral API error: ${res.status} — ${error}`);
+  }
+
+  const data = await res.json();
+  return data?.choices?.[0]?.message?.content || '';
+}
+
+// ─── Domain Clustering ───────────────────────────────────────────────────────
+
+export interface DomainCluster {
+  id: string;
+  label: string;
+  nodeIds: (number | string)[];
+  color: string;
+  x?: number;
+  y?: number;
+}
+
+const CLUSTER_COLORS = [
+  '#a855f7', '#22d3ee', '#4ade80', '#f59e0b', '#ef4444',
+  '#ec4899', '#8b5cf6', '#06b6d4', '#84cc16', '#f97316',
+  '#14b8a6', '#6366f1', '#e879f9', '#facc15', '#fb923c',
+];
+
+/**
+ * Groups nodes into domain clusters based on their directory structure.
+ * Each top-level directory becomes a "domain."
+ */
+export function buildDomainClusters(
+  nodes: GraphNode[],
+  links: GraphLink[]
+): DomainCluster[] {
+  // Group by top-level directory
+  const dirGroups = new Map<string, (number | string)[]>();
+
+  nodes.forEach(node => {
+    let dir = 'root';
+    if (node.filePath) {
+      const parts = node.filePath.replace(/\\/g, '/').split('/').filter(Boolean);
+      // Use top 1-2 directory levels as domain
+      if (parts.length >= 2) {
+        dir = parts.slice(0, 2).join('/');
+      } else if (parts.length === 1) {
+        dir = parts[0];
+      }
+    } else {
+      // Fallback: use CONTAINS edges to find parent directory
+      const parentLink = links.find(l => {
+        const targetId = typeof l.target === 'object' ? l.target.id : l.target;
+        return targetId === node.id && l.type === 'CONTAINS';
+      });
+      if (parentLink) {
+        const parentId = typeof parentLink.source === 'object' ? parentLink.source.id : parentLink.source;
+        const parentNode = nodes.find(n => n.id === parentId);
+        if (parentNode && (parentNode.type === 'Directory' || parentNode.type === 'Module')) {
+          dir = parentNode.name;
+        }
+      }
+    }
+
+    if (!dirGroups.has(dir)) {
+      dirGroups.set(dir, []);
+    }
+    dirGroups.get(dir)!.push(node.id);
+  });
+
+  // Convert to clusters
+  const clusters: DomainCluster[] = [];
+  let colorIdx = 0;
+  dirGroups.forEach((nodeIds, dir) => {
+    if (nodeIds.length < 1) return;
+    clusters.push({
+      id: dir,
+      label: humanize(dir.split('/').pop() || dir),
+      nodeIds,
+      color: CLUSTER_COLORS[colorIdx % CLUSTER_COLORS.length],
+    });
+    colorIdx++;
+  });
+
+  return clusters.sort((a, b) => b.nodeIds.length - a.nodeIds.length);
+}
+
+/**
+ * Get inter-cluster edges for the domain view.
+ */
+export function getClusterEdges(
+  clusters: DomainCluster[],
+  links: GraphLink[]
+): { source: string; target: string; count: number }[] {
+  const nodeToCluster = new Map<number | string, string>();
+  clusters.forEach(c => {
+    c.nodeIds.forEach(nId => nodeToCluster.set(nId, c.id));
+  });
+
+  const edgeCounts = new Map<string, number>();
+  links.forEach(l => {
+    const sourceId = typeof l.source === 'object' ? l.source.id : l.source;
+    const targetId = typeof l.target === 'object' ? l.target.id : l.target;
+    const sourceCluster = nodeToCluster.get(sourceId);
+    const targetCluster = nodeToCluster.get(targetId);
+    if (sourceCluster && targetCluster && sourceCluster !== targetCluster) {
+      const key = `${sourceCluster}||${targetCluster}`;
+      edgeCounts.set(key, (edgeCounts.get(key) || 0) + 1);
+    }
+  });
+
+  return Array.from(edgeCounts.entries()).map(([key, count]) => {
+    const [source, target] = key.split('||');
+    return { source, target, count };
+  });
+}


### PR DESCRIPTION

Feature: Implement Dual-Engine AI Knowledge Explorer for Static Web Mode


This PR addresses the "405 Method Not Allowed" server errors encountered in the static web deployment when using the AI Knowledge Explorer. Previously, the AI Explorer relied entirely on the Neo4j backend to process queries, which is unavailable in the static web export.

This PR introduces a "Dual-Engine Model":
1. **Neo4j Engine (Server-Side)**: When running via the Python CLI (with the backend URL parameter), the system routes queries to the backend to leverage Cypher graph search.
2. **BYOK Engine (Client-Side)**: When running in static mode, the system automatically falls back to a purely client-side engine. It prompts the user for a Bring Your Own Key (BYOK) LLM configuration (Gemini or Mistral). It then minifies the graph structure into a context-efficient JSON payload and uses the LLM directly from the browser to reason over the repository structure.

## Changes
- Added `executeClientAIQuery` in `src/lib/summary-engine.ts` to construct the prompt and handle JSON-mode LLM execution.
- Added LLM config panel inside the AI Explorer sidebar if no configuration exists in static mode.
- Updated `handleAIQuerySubmit` in `CodeGraphViewer.tsx` to intelligently toggle between the backend API fetch and the browser-based client-side execution.
- Configured dynamic UI badges to indicate which engine is currently active.

