### PR TITLE
feat(kotlin): extract annotations into decorators on functions and classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Each language parser extracts functions, classes, methods, parameters, inheritan
 **Kotlin notes:** Annotations are recorded on functions and classes as `decorators`, retaining
 their arguments (`@Preview(showBackground = true)`). This makes `find_dead_code`'s
 `exclude_decorated_with` usable on Kotlin and Android codebases — for example excluding
-`Composable`, `Preview`, `Test`, `Inject` and `Provides`. Annotations on interfaces, objects,
+`Composable`, `Preview`, `Test`, `HiltViewModel` and `Provides`. Annotations on interfaces, objects,
 constructors, parameters and properties are not yet recorded.
 
 ---

--- a/README.md
+++ b/README.md
@@ -264,8 +264,9 @@ Each language parser extracts functions, classes, methods, parameters, inheritan
 **Kotlin notes:** Annotations are recorded on functions and classes as `decorators`, retaining
 their arguments (`@Preview(showBackground = true)`). This makes `find_dead_code`'s
 `exclude_decorated_with` usable on Kotlin and Android codebases — for example excluding
-`Composable`, `Preview`, `Test`, `HiltViewModel` and `Provides`. Annotations on interfaces, objects,
-constructors, parameters and properties are not yet recorded.
+`Composable`, `Preview`, `Test` and `Provides`. That filter matches on functions, so class-level
+annotations do not affect it. Annotations on interfaces, objects, constructors, parameters and
+properties are not yet recorded.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ Each language parser extracts functions, classes, methods, parameters, inheritan
 
 **Solidity notes:** `.sol` uses Tree-sitter via `tree-sitter-language-pack` (no SCIP). Supports Foundry remappings, modifier invocations, `using Lib for T`, and `emit` / custom-error `revert` as CALLS. See `docs/docs/contributing_languages.md` § Solidity.
 
+**Kotlin notes:** Annotations are recorded on functions and classes as `decorators`, retaining
+their arguments (`@Preview(showBackground = true)`). This makes `find_dead_code`'s
+`exclude_decorated_with` usable on Kotlin and Android codebases — for example excluding
+`Composable`, `Preview`, `Test`, `Inject` and `Provides`. Annotations on interfaces, objects,
+constructors, parameters and properties are not yet recorded.
+
 ---
 
 ## Database Options

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -118,6 +118,10 @@ Potentially unused functions across the indexed codebase.
 - **Args:** `exclude_decorated_with` (list of strings), `repo_path` (string, optional)
 - **Returns:** Candidate dead symbols
 
+`exclude_decorated_with` matches on substrings of the recorded annotation or decorator
+text, so a pattern of `Preview` excludes a function annotated `@Preview(showBackground = true)`.
+Kotlin annotations are recorded on functions and classes.
+
 ### `calculate_cyclomatic_complexity`
 
 Complexity for a single function.

--- a/docs/docs/reference/mcp.md
+++ b/docs/docs/reference/mcp.md
@@ -110,7 +110,7 @@ Returns methods with the highest cyclomatic complexity scores.
 ### `find_dead_code`
 Scans for unreferenced code declarations.
 - **Parameters**:
-  - `exclude_decorated_with` (array of strings, optional): Excludes functions carrying specified decorator annotations (e.g., `@app.route`).
+  - `exclude_decorated_with` (array of strings, optional): Excludes functions carrying specified decorator annotations (e.g., `@app.route`, or `Composable` for Kotlin). Matching is by substring, so `Preview` matches `@Preview(showBackground = true)`.
   - `repo_path` (string, optional): Restricts search scope.
 
 ---

--- a/src/codegraphcontext/tools/languages/kotlin.py
+++ b/src/codegraphcontext/tools/languages/kotlin.py
@@ -208,6 +208,30 @@ class KotlinTreeSitterParser:
         if not node: return ""
         return node.text.decode("utf-8")
 
+    def _get_node_annotations(self, node: Any) -> List[str]:
+        """Return raw annotation text for a declaration, e.g. ['@Preview(showBackground = true)'].
+
+        Only *direct* `annotation` children of the `modifiers` node are collected.
+        In `annotation class Foo`, the `annotation` keyword also produces a node of
+        type `annotation`, but nested one level down under `class_modifier` -- so a
+        recursive search would emit the bare string "annotation" as a decorator.
+        """
+        modifiers = None
+        for child in node.children:
+            if child.type == "modifiers":
+                modifiers = child
+                break
+        if not modifiers:
+            return []
+
+        annotations = []
+        for child in modifiers.children:
+            if child.type == "annotation":
+                text = " ".join(self._get_node_text(child).split())
+                if text:
+                    annotations.append(text)
+        return annotations
+
     def _get_enclosing_class_context(self, node: Any) -> Tuple[Optional[str], Optional[int]]:
         curr = node.parent
         while curr:
@@ -1271,6 +1295,7 @@ class KotlinTreeSitterParser:
                             "lang": self.language_name,
                             "context": context_name,
                             "class_context": context_name if is_class_context else None,
+                            "decorators": self._get_node_annotations(node),
                         }
                         if is_class_context and context_line is not None:
                             func_data["class_context_line"] = context_line

--- a/src/codegraphcontext/tools/languages/kotlin.py
+++ b/src/codegraphcontext/tools/languages/kotlin.py
@@ -1422,6 +1422,12 @@ class KotlinTreeSitterParser:
                         "path": str(path),
                         "lang": self.language_name,
                     }
+                    # Only the Class node table declares a `decorators` column.
+                    # Interface and Object do not, and the Kuzu backend drops
+                    # unknown properties silently -- so gate on the category
+                    # rather than setting it on the shared class_data dict.
+                    if category == "classes":
+                        class_data["decorators"] = self._get_node_annotations(node)
                     if is_nested_class:
                         class_data["class_context"] = context_name
                         if context_line is not None:

--- a/tests/fixtures/sample_projects/sample_project_kotlin/AndroidAnnotations.kt
+++ b/tests/fixtures/sample_projects/sample_project_kotlin/AndroidAnnotations.kt
@@ -5,7 +5,6 @@ package com.example.project.android
 annotation class Composable
 annotation class Preview(val showBackground: Boolean = false, val name: String = "")
 annotation class HiltViewModel
-annotation class Inject
 annotation class Entity(val tableName: String = "")
 annotation class Dao
 annotation class Query(val value: String)

--- a/tests/fixtures/sample_projects/sample_project_kotlin/AndroidAnnotations.kt
+++ b/tests/fixtures/sample_projects/sample_project_kotlin/AndroidAnnotations.kt
@@ -1,0 +1,48 @@
+package com.example.project.android
+
+// Hand-written stubs so this fixture compiles conceptually without the
+// Android SDK, Hilt, Room or the Compose compiler on the test path.
+annotation class Composable
+annotation class Preview(val showBackground: Boolean = false, val name: String = "")
+annotation class HiltViewModel
+annotation class Inject
+annotation class Entity(val tableName: String = "")
+annotation class Dao
+annotation class Query(val value: String)
+
+@Composable
+fun Greeting(name: String) {
+    Label(name)
+}
+
+@Composable
+fun Label(text: String) {
+}
+
+@Composable
+@Preview(showBackground = true, name = "Greeting preview")
+fun GreetingPreview() {
+    Greeting("Android")
+}
+
+@HiltViewModel
+class UserViewModel {
+    fun load(): String {
+        return "user"
+    }
+}
+
+@Entity(tableName = "users")
+class UserEntity(val id: Int, val name: String)
+
+@Dao
+interface UserDao {
+    @Query("SELECT * FROM users")
+    fun findAll(): List<UserEntity>
+}
+
+class PlainHelper {
+    fun helped(): Int {
+        return 1
+    }
+}

--- a/tests/unit/core/test_database_kuzu_kotlin_metadata.py
+++ b/tests/unit/core/test_database_kuzu_kotlin_metadata.py
@@ -275,3 +275,81 @@ def test_class_function_containment_uses_owner_line_in_kuzu(tmp_path):
         assert second_owner == [{"line_number": 8}]
     finally:
         manager.close_driver()
+
+
+def test_kotlin_decorators_persist_in_kuzu(tmp_path):
+    """Annotations must survive the writer and the Kuzu property allow-list.
+
+    Everything else in this feature is parser-level. This is the test that
+    backs the claim that find_dead_code(exclude_decorated_with=...) works
+    for Kotlin.
+    """
+    from codegraphcontext.tools.languages.kotlin import KotlinTreeSitterParser
+    from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
+
+    manager_ts = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "kotlin"
+    wrapper.language = manager_ts.get_language_safe("kotlin")
+    wrapper.parser = manager_ts.create_parser("kotlin")
+    parser = KotlinTreeSitterParser(wrapper)
+
+    source = tmp_path / "Android.kt"
+    source.write_text(
+        'package a\n'
+        '\n'
+        '@Composable\n'
+        '@Preview(showBackground = true)\n'
+        'fun GreetingPreview() {\n'
+        '}\n'
+        '\n'
+        '@HiltViewModel\n'
+        'class UserViewModel {\n'
+        '    fun load(): String {\n'
+        '        return "u"\n'
+        '    }\n'
+        '}\n',
+        encoding="utf-8",
+    )
+    file_data = parser.parse(source)
+
+    manager = _fresh_kuzu_manager(tmp_path / "decorators-db")
+    try:
+        driver = manager.get_driver()
+        GraphWriter(driver).add_file_to_graph(
+            file_data, "repo", {}, repo_path_str=str(tmp_path)
+        )
+
+        with driver.session() as session:
+            fn = session.run(
+                "MATCH (f:Function {name: $name}) RETURN f.decorators AS decorators",
+                name="GreetingPreview",
+            ).single()
+            cls = session.run(
+                "MATCH (c:Class {name: $name}) RETURN c.decorators AS decorators",
+                name="UserViewModel",
+            ).single()
+
+            # The writer normalizes [] -> [""] (writer.py:405) for every language,
+            # so the stored value is not literally []. What the feature actually
+            # claims is that find_dead_code's filter behaves correctly, so assert
+            # that directly -- this is the exact predicate the tool builds
+            # (code_finder.py:816-820). Before this change, un-annotated Kotlin
+            # functions stored NULL, and the predicate silently dropped them.
+            retained = session.run(
+                """
+                MATCH (f:Function)
+                WHERE NOT ANY(d IN f.decorators WHERE d CONTAINS 'Preview')
+                RETURN f.name AS name
+                """
+            ).data()
+
+        assert fn is not None
+        assert fn["decorators"] == ["@Composable", "@Preview(showBackground = true)"]
+
+        assert cls is not None
+        assert cls["decorators"] == ["@HiltViewModel"]
+
+        assert {r["name"] for r in retained} == {"load"}
+    finally:
+        manager.close_driver()

--- a/tests/unit/parsers/test_kotlin_parser.py
+++ b/tests/unit/parsers/test_kotlin_parser.py
@@ -4268,20 +4268,33 @@ class TestKotlinDecorators:
         fixture = FIXTURES / "sample_project_kotlin" / "AndroidAnnotations.kt"
         data = parser.parse(fixture)
 
-        by_name = {f["name"]: f for f in data["functions"]}
-        assert by_name["Greeting"]["decorators"] == ["@Composable"]
-        assert by_name["GreetingPreview"]["decorators"] == [
+        greeting = next(f for f in data["functions"] if f["name"] == "Greeting")
+        assert greeting["decorators"] == ["@Composable"]
+
+        greeting_preview = next(
+            f for f in data["functions"] if f["name"] == "GreetingPreview"
+        )
+        assert greeting_preview["decorators"] == [
             "@Composable",
             '@Preview(showBackground = true, name = "Greeting preview")',
         ]
-        assert by_name["findAll"]["decorators"] == ['@Query("SELECT * FROM users")']
-        assert by_name["helped"]["decorators"] == []
 
-        classes = {c["name"]: c for c in data["classes"]}
-        assert classes["UserViewModel"]["decorators"] == ["@HiltViewModel"]
-        assert classes["UserEntity"]["decorators"] == ['@Entity(tableName = "users")']
-        assert classes["PlainHelper"]["decorators"] == []
+        find_all = next(f for f in data["functions"] if f["name"] == "findAll")
+        assert find_all["decorators"] == ['@Query("SELECT * FROM users")']
+
+        helped = next(f for f in data["functions"] if f["name"] == "helped")
+        assert helped["decorators"] == []
+
+        user_view_model = next(c for c in data["classes"] if c["name"] == "UserViewModel")
+        assert user_view_model["decorators"] == ["@HiltViewModel"]
+
+        user_entity = next(c for c in data["classes"] if c["name"] == "UserEntity")
+        assert user_entity["decorators"] == ['@Entity(tableName = "users")']
+
+        plain_helper = next(c for c in data["classes"] if c["name"] == "PlainHelper")
+        assert plain_helper["decorators"] == []
 
         # The stub `annotation class` declarations must not pick up their own
         # `annotation` keyword as a decorator.
-        assert classes["Composable"]["decorators"] == []
+        composable = next(c for c in data["classes"] if c["name"] == "Composable")
+        assert composable["decorators"] == []

--- a/tests/unit/parsers/test_kotlin_parser.py
+++ b/tests/unit/parsers/test_kotlin_parser.py
@@ -4090,3 +4090,104 @@ class TestKotlinSemanticResolution:
         }
         assert calls_by_name["fromCall.applyEvent"]["inferred_obj_type"] is None
         assert calls_by_name["fromComparison.applyEvent"]["inferred_obj_type"] is None
+
+
+class TestKotlinDecorators:
+    """Annotation extraction into the `decorators` property (PR 1a)."""
+
+    def test_plain_function_emits_empty_decorators_list(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            fun plain(): Int {
+                return 1
+            }
+            """,
+        )
+        fn = next(f for f in data["functions"] if f["name"] == "plain")
+        # The key must be present and an empty list -- not missing, not None.
+        # find_dead_code filters with NOT ANY(d IN func.decorators ...), which
+        # evaluates NULL (not TRUE) against an unset property, silently dropping
+        # un-annotated functions from results.
+        assert "decorators" in fn
+        assert fn["decorators"] == []
+
+    def test_single_annotation_on_function(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            @Composable
+            fun Greeting(name: String) {
+            }
+            """,
+        )
+        fn = next(f for f in data["functions"] if f["name"] == "Greeting")
+        assert fn["decorators"] == ["@Composable"]
+
+    def test_multiple_annotations_preserve_source_order(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            @Composable
+            @Preview(showBackground = true)
+            fun GreetingPreview() {
+            }
+            """,
+        )
+        fn = next(f for f in data["functions"] if f["name"] == "GreetingPreview")
+        assert fn["decorators"] == ["@Composable", "@Preview(showBackground = true)"]
+
+    def test_annotation_arguments_are_retained_verbatim(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            @Query("SELECT * FROM users")
+            fun all() {
+            }
+            """,
+        )
+        fn = next(f for f in data["functions"] if f["name"] == "all")
+        assert fn["decorators"] == ['@Query("SELECT * FROM users")']
+
+    def test_visibility_and_function_modifiers_do_not_leak(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            @Composable
+            private inline suspend fun Greeting(name: String) {
+            }
+            """,
+        )
+        fn = next(f for f in data["functions"] if f["name"] == "Greeting")
+        # `private` and `inline` are visibility_modifier / function_modifier
+        # siblings inside the same `modifiers` node. They belong to PR 1b.
+        assert fn["decorators"] == ["@Composable"]
+
+    def test_multiline_annotation_is_collapsed_to_one_line(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            @Deprecated(
+                message = "old",
+                replaceWith = ReplaceWith("newThing()")
+            )
+            fun multiLine() {
+            }
+            """,
+        )
+        fn = next(f for f in data["functions"] if f["name"] == "multiLine")
+        assert fn["decorators"] == [
+            '@Deprecated( message = "old", replaceWith = ReplaceWith("newThing()") )'
+        ]

--- a/tests/unit/parsers/test_kotlin_parser.py
+++ b/tests/unit/parsers/test_kotlin_parser.py
@@ -4191,3 +4191,72 @@ class TestKotlinDecorators:
         assert fn["decorators"] == [
             '@Deprecated( message = "old", replaceWith = ReplaceWith("newThing()") )'
         ]
+
+    def test_annotated_class_carries_decorators(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            @HiltViewModel
+            class MyViewModel {
+                fun load() {
+                }
+            }
+            """,
+        )
+        cls = next(c for c in data["classes"] if c["name"] == "MyViewModel")
+        assert cls["decorators"] == ["@HiltViewModel"]
+
+    def test_plain_class_emits_empty_decorators_list(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            class Plain {
+            }
+            """,
+        )
+        cls = next(c for c in data["classes"] if c["name"] == "Plain")
+        assert "decorators" in cls
+        assert cls["decorators"] == []
+
+    def test_annotation_class_keyword_is_not_a_decorator(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            annotation class Fancy(val id: Int)
+            """,
+        )
+        cls = next(c for c in data["classes"] if c["name"] == "Fancy")
+        # `annotation` here is the class_modifier keyword, not an annotation.
+        # It parses to a node of type `annotation` nested under `class_modifier`,
+        # so only scanning *direct* children of `modifiers` excludes it.
+        assert cls["decorators"] == []
+
+    def test_interface_does_not_carry_decorators(self, parser):
+        data = _write_and_parse(
+            parser,
+            """
+            package com.example
+
+            @Dao
+            interface UserDao {
+                @Query("SELECT * FROM users")
+                fun all(): Int
+            }
+            """,
+        )
+        iface = next(c for c in data["interfaces"] if c["name"] == "UserDao")
+        # The Interface node table has no `decorators` column
+        # (database_embedded_kuzu.py:181, allow-list :827), and Kuzu drops
+        # unknown properties silently. Deferred to PR 1b.
+        assert "decorators" not in iface
+
+        # The interface's methods are function_declaration nodes and DO carry
+        # decorators -- which is what preserves the dead-code payoff for @Dao types.
+        fn = next(f for f in data["functions"] if f["name"] == "all")
+        assert fn["decorators"] == ['@Query("SELECT * FROM users")']

--- a/tests/unit/parsers/test_kotlin_parser.py
+++ b/tests/unit/parsers/test_kotlin_parser.py
@@ -4110,10 +4110,9 @@ class TestKotlinDecorators:
             """,
         )
         fn = next(f for f in data["functions"] if f["name"] == "plain")
-        # The key must be present and an empty list -- not missing, not None.
-        # find_dead_code filters with NOT ANY(d IN func.decorators ...), which
-        # evaluates NULL (not TRUE) against an unset property, silently dropping
-        # un-annotated functions from results.
+        # The key must be present and an empty list -- not missing, not None --
+        # so consumers can rely on it rather than testing for it. This matches
+        # the ten extractors that already populate `decorators`.
         assert "decorators" in fn
         assert fn["decorators"] == []
 

--- a/tests/unit/parsers/test_kotlin_parser.py
+++ b/tests/unit/parsers/test_kotlin_parser.py
@@ -42,6 +42,9 @@ def _write_source(root: Path, relative_path: str, src: str) -> Path:
     return path
 
 
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "sample_projects"
+
+
 EVENT_PROCESSOR_SRC = """
 package com.example
 
@@ -4260,3 +4263,25 @@ class TestKotlinDecorators:
         # decorators -- which is what preserves the dead-code payoff for @Dao types.
         fn = next(f for f in data["functions"] if f["name"] == "all")
         assert fn["decorators"] == ['@Query("SELECT * FROM users")']
+
+    def test_android_fixture_annotations_are_extracted(self, parser):
+        fixture = FIXTURES / "sample_project_kotlin" / "AndroidAnnotations.kt"
+        data = parser.parse(fixture)
+
+        by_name = {f["name"]: f for f in data["functions"]}
+        assert by_name["Greeting"]["decorators"] == ["@Composable"]
+        assert by_name["GreetingPreview"]["decorators"] == [
+            "@Composable",
+            '@Preview(showBackground = true, name = "Greeting preview")',
+        ]
+        assert by_name["findAll"]["decorators"] == ['@Query("SELECT * FROM users")']
+        assert by_name["helped"]["decorators"] == []
+
+        classes = {c["name"]: c for c in data["classes"]}
+        assert classes["UserViewModel"]["decorators"] == ["@HiltViewModel"]
+        assert classes["UserEntity"]["decorators"] == ['@Entity(tableName = "users")']
+        assert classes["PlainHelper"]["decorators"] == []
+
+        # The stub `annotation class` declarations must not pick up their own
+        # `annotation` keyword as a decorator.
+        assert classes["Composable"]["decorators"] == []


### PR DESCRIPTION
Addresses the first slice of #1595.

`kotlin.py` extracted no annotations, so `@Composable`, `@HiltViewModel`, `@Preview`, `@Entity`, `@Dao` and `@Test` were invisible to the graph. This populates `decorators` on Kotlin `Function` and `Class` nodes with raw annotation text, which immediately feeds the three consumers that already read the field — `find_dead_code`'s `exclude_decorated_with`, inheritance resolution, and the SCIP pipeline.

**No schema change.** `decorators STRING[]` is already declared for `Function` and `Class` (`database_embedded_kuzu.py:177-178`) and already in the property allow-list (`:823-824`). The write path is generic, so nothing outside `kotlin.py` changes except tests and docs.

## What it does

One helper, `_get_node_annotations` (`kotlin.py:211`), reads the `modifiers` child of a declaration and collects the text of its **direct** `annotation` children. Two call sites consume it: `_parse_functions` and `_parse_classes`.

Values are raw annotation text including the `@` and all arguments — `"@Preview(showBackground = true)"` — which matches `python.py:347` and `typescript.py:286`. This works with bare-name exclusion patterns because `find_dead_code` filters with `d CONTAINS '<pattern>'` (`code_finder.py:816`), not equality, and keeping the arguments preserves information later slices need (Room `@Query` SQL, Hilt `@InstallIn` components).

### Two details worth a reviewer's attention

**1. "Direct children" is load-bearing.** In `annotation class Fancy(val id: Int)`, the *keyword* `annotation` also produces a node of type `annotation` — but nested one level deeper, under `class_modifier`:

```
class_declaration  |annotation class Fancy(val id: Int)|
  modifiers
    class_modifier            <- keyword path
      annotation  |annotation|

class_declaration  |@Fancy(1) class Foo { … }|
  modifiers
    annotation  |@Fancy(1)|   <- real annotation, direct child
```

A recursive walk would emit the string `"annotation"` as a decorator on every `annotation class`. `test_annotation_class_keyword_is_not_a_decorator` covers this.

**2. The key is emitted unconditionally as `[]`**, set inside the `func_data` literal so it can never be absent. This matches what the ten extractors that already populate `decorators` do (`python.py:206,250`, `go.py:311,441,506`, `ruby.py:381`), and it means consumers can rely on the key existing rather than testing for it.

*Correction:* an earlier revision of this description claimed this was a correctness fix — that leaving `decorators` unset would make `NOT ANY(d IN func.decorators WHERE …)` evaluate NULL and silently drop un-annotated functions from `find_dead_code` results. I have since tested that against Kuzu directly and it is **not** true: `ANY` over a NULL list yields false, so `NOT ANY(...)` is true and the row is correctly retained. The unconditional `[]` is consistency and API cleanliness, not a bug fix. Apologies for the incorrect claim.

## Scope: `Function` and `Class` only

`_parse_classes` emits three categories through one shared append, but only `Class` has a `decorators` column:

| Label | `decorators` column |
|---|---|
| `Function` | yes — `:177` |
| `Class` | yes — `:178` |
| `Interface` | **no** — `:181`, allow-list `:827` |
| `Object` | **no** — `:193`, allow-list `:839` |

Unknown properties are dropped silently on Kuzu (`:865`), so setting the field on interfaces or objects would work on Neo4j and vanish on the default backend. The assignment is therefore gated on `category == "classes"`, and `test_interface_does_not_carry_decorators` fails if that gate is ever removed.

Honest costs of the gate: `@Dao interface UserDao` loses `@Dao`, though its `@Query`/`@Insert` methods are `function_declaration` nodes and **are** captured — so the dead-code payoff survives. `@Module object AppModule` loses `@Module` outright. Both want the `Interface`/`Object` columns, which is slice 1b in #1595.

Also out of scope, each for a structural reason: constructor annotations (`@Inject constructor` is a `primary_constructor`, not a `function_declaration`), parameter annotations (`parameter_modifiers`, inside `function_value_parameters`), and property annotations (`@field:`, `@get:` — these target `Variable`, which has no such column).

## Deliberate divergences

- **Whitespace is collapsed** with `" ".join(text.split())`, so a wrapped multi-line annotation stores on one line instead of embedding newlines in a `STRING[]`. `python.py` stores raw text, so this differs; happy to match Python instead if you prefer. Note it also collapses whitespace inside string literals, so a Room `@Query("""multi-line SQL""")` stores single-line — harmless for `CONTAINS`, but worth knowing before the Room slice.
- **`_get_node_annotations` returns `List[str]`** where `java.py:307`'s same-named method returns `List[Tuple[str, str]]`. Java splits name from arguments because it routes them to labels and `http_method`; Kotlin returns raw text because that is what `decorators` stores. Different classes, so no conflict, but it will show up in a side-by-side diff.

## Tests

11 new tests in `tests/unit/parsers/test_kotlin_parser.py` covering: empty list present (not missing, not `None`), single and stacked annotations with source order preserved, arguments retained verbatim, the `annotation class` grammar trap, `private`/`inline`/`suspend` not leaking in, multi-line collapsing, and interfaces not carrying the property.

1 new test in `tests/unit/core/test_database_kuzu_kotlin_metadata.py` — the only one that exercises the write-and-query path rather than the parser's return dict. It parses Kotlin, writes via `GraphWriter.add_file_to_graph`, and then runs `find_dead_code`'s actual predicate to assert the annotated function is excluded and the un-annotated one retained. That is the claim this PR makes, so it seemed worth testing directly rather than asserting on the stored value.

New fixture `AndroidAnnotations.kt` declares its `@Composable`/`@Preview`/`@HiltViewModel`/`@Entity`/`@Dao`/`@Query` stubs locally, so no Android SDK, Hilt, Room or Compose compiler is needed on the test path.

`./tests/run_tests.sh fast` → **12 failed, 1145 passed, 19 skipped**. All 12 failures reproduce on `c274436` (this PR's base) — verified by checking the base out and re-running them:
- 3 × `test_kotlin_parser.py::TestKotlinFunctionCallResolution` — a macOS `/var` → `/private/var` tempdir symlink artifact (`tempfile` returns `/var/…`, the parser resolves `/private/var/…`)
- 3 × `tests/unit/api/test_mcp_sse_disconnect.py`, 6 × `tests/unit/tools/test_scip_pipeline_*.py`

## Unclaimed side effect

Because `indexing/resolution/inheritance.py:370` reads `decorators`, Kotlin now also produces `DECORATED_BY` edges. Running `build_decorated_by_links` over the new fixture emits 7 correctly resolved links (`Greeting → Composable`, `Label → Composable`, `findAll → Query`, `GreetingPreview → Composable`, …). Not something this PR set out to do, but it falls out for free.

## Not attempted

No semantic resolution. CGC is tree-sitter-based with no type checker, so Kotlin extension functions, generics and overload resolution stay approximate — this PR does not change that, and does not make the call graph sound. No recomposition or state-flow analysis for Compose.
