### PR TITLE
fix(writer): propagate is_dependency so find_dead_code works for all languages

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -327,6 +327,14 @@ class GraphWriter:
                 for item in item_list:
                     row = dict(item)
                     row["path"] = file_path_str
+                    # Inherit the file's is_dependency unless the extractor set its
+                    # own. Only ~half the language extractors emit this per item, and
+                    # find_dead_code filters on `func.is_dependency = false` -- in
+                    # Cypher `null = false` is null, not false, so every function from
+                    # an extractor that omitted it was silently dropped and the tool
+                    # returned an empty list. Module has no such column in the schema.
+                    if label != "Module":
+                        row.setdefault("is_dependency", is_dependency)
                     if label == "Function" and "cyclomatic_complexity" not in row:
                         row["cyclomatic_complexity"] = 1
                     sanitized, findings = sanitize_props_with_secrets(row, redact=_should_redact)

--- a/tests/unit/core/test_writer_is_dependency_propagation.py
+++ b/tests/unit/core/test_writer_is_dependency_propagation.py
@@ -1,0 +1,122 @@
+"""Regression tests for is_dependency propagation through the writer.
+
+`find_dead_code` filters on `func.is_dependency = false`. In Cypher `null = false`
+evaluates to null rather than false, so a Function node that never received the
+property is silently discarded and the tool returns an empty list.
+
+Only about half the language extractors emit `is_dependency` per item, so the
+writer has to supply the file-level value for the rest. Tests that hand-build
+`file_data` normally include `is_dependency` on each item dict, which is exactly
+why this survived the suite -- so these tests deliberately *omit* it, the way a
+real extractor such as kotlin.py does.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("kuzu")
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+
+def _fresh_kuzu_manager(db_path: Path) -> KuzuDBManager:
+    if KuzuDBManager._instance is not None:
+        KuzuDBManager._instance.close_driver()
+    KuzuDBManager._instance = None
+    KuzuDBManager._db = None
+    KuzuDBManager._conn = None
+    return KuzuDBManager(db_path=str(db_path))
+
+
+def _file_data(path: str, *, is_dependency: bool):
+    """A file whose items carry no is_dependency of their own."""
+    return {
+        "path": path,
+        "name": Path(path).name,
+        "is_dependency": is_dependency,
+        "lang": "kotlin",
+        "functions": [
+            {"name": "orphan", "line_number": 3, "context": None},
+        ],
+        "classes": [
+            {"name": "Widget", "line_number": 7},
+        ],
+        "variables": [],
+        "imports": [],
+        "function_calls": [],
+    }
+
+
+def test_project_items_inherit_is_dependency_false(tmp_path):
+    manager = _fresh_kuzu_manager(tmp_path / "isdep-project-db")
+    try:
+        driver = manager.get_driver()
+        GraphWriter(driver).add_file_to_graph(
+            _file_data("/repo/Main.kt", is_dependency=False),
+            "repo",
+            {},
+            repo_path_str="/repo",
+        )
+
+        with driver.session() as session:
+            fn = session.run(
+                "MATCH (f:Function {name: $n}) RETURN f.is_dependency AS d", n="orphan"
+            ).single()
+            cls = session.run(
+                "MATCH (c:Class {name: $n}) RETURN c.is_dependency AS d", n="Widget"
+            ).single()
+
+        # Not merely "falsy": null is falsy in Python but breaks the Cypher
+        # predicate, which is the whole point of this test.
+        assert fn["d"] is False
+        assert cls["d"] is False
+    finally:
+        manager.close_driver()
+
+
+def test_dependency_items_inherit_is_dependency_true(tmp_path):
+    """Items inside a dependency file must be marked as dependencies."""
+    manager = _fresh_kuzu_manager(tmp_path / "isdep-dependency-db")
+    try:
+        driver = manager.get_driver()
+        GraphWriter(driver).add_file_to_graph(
+            _file_data("/deps/Lib.kt", is_dependency=True),
+            "repo",
+            {},
+            repo_path_str="/deps",
+        )
+
+        with driver.session() as session:
+            fn = session.run(
+                "MATCH (f:Function {name: $n}) RETURN f.is_dependency AS d", n="orphan"
+            ).single()
+
+        assert fn["d"] is True
+    finally:
+        manager.close_driver()
+
+
+def test_extractor_supplied_is_dependency_is_not_overwritten(tmp_path):
+    """A per-item value wins over the file-level default.
+
+    The writer uses setdefault, so an extractor that already computes this
+    per item (python.py and c.py among others) keeps its own answer.
+    """
+    manager = _fresh_kuzu_manager(tmp_path / "isdep-explicit-db")
+    try:
+        data = _file_data("/repo/Mixed.kt", is_dependency=False)
+        data["functions"][0]["is_dependency"] = True
+
+        driver = manager.get_driver()
+        GraphWriter(driver).add_file_to_graph(data, "repo", {}, repo_path_str="/repo")
+
+        with driver.session() as session:
+            fn = session.run(
+                "MATCH (f:Function {name: $n}) RETURN f.is_dependency AS d", n="orphan"
+            ).single()
+
+        assert fn["d"] is True
+    finally:
+        manager.close_driver()


### PR DESCRIPTION
Fixes the 7th report in #1595 (credit @rrodriguesNutrium). This is a total feature outage for roughly half the supported languages.

## The bug

`find_dead_code` opens with (`code_finder.py:857`):

```cypher
MATCH (func:Function)
WHERE func.is_dependency = false ...
```

but the writer never sets that property on contained items. `add_file_to_graph` builds each row as `row = dict(item)` and adds only `path` and `cyclomatic_complexity` — `is_dependency` is read from `file_data` for the **File** node and never propagated down.

In Cypher `null = false` evaluates to null, not false, so every affected Function row is discarded and the tool returns an empty list.

## It's language-dependent

The original report suggested this affects everything. It's narrower and that's why it hid so well: about half the extractors emit `is_dependency` per item and half don't. `python.py` does, so Python works; `kotlin.py` doesn't, so Kotlin silently returns nothing.

Reproduced on a 4-function Kotlin project, both backends:

```
before:  MATCH (f:Function) RETURN f.is_dependency  ->  null, null, null, null
         cgc analyze dead-code                      ->  "✓ No dead code found!"

after:   MATCH (f:Function) RETURN f.is_dependency  ->  false, false, false, false
         cgc analyze dead-code                      ->  2 functions (GreetingPreview, orphanNeverCalled)
```

Same Python project as a control returned 25 functions both before and after — unaffected, as expected.

## The fix

One line in the item loop:

```python
if label != "Module":
    row.setdefault("is_dependency", is_dependency)
```

`setdefault` rather than assignment so extractors that compute this per item keep their own answer — which also correctly marks functions inside dependency files. `Module` is excluded because it is the one label in `item_mappings` with no `is_dependency` column in the schema.

I chose the writer over making the query null-tolerant (`coalesce(...)`) because the property is genuinely expected to be present — `code_finder.py` reads `caller.is_dependency` a few lines later, and the asymmetry between the two sides is itself the hint.

## Combined effect with #1596

The chain the reporter was actually after now works end to end:

```
find_dead_code()                                      -> ['GreetingPreview', 'orphanNeverCalled']
find_dead_code(exclude_decorated_with=['Preview'])    -> ['orphanNeverCalled']
find_dead_code(exclude_decorated_with=['Composable']) -> ['orphanNeverCalled']
```

## Tests

Three regression tests driving the real `GraphWriter` path with item dicts that **omit** `is_dependency` — the reporter correctly identified that existing tests hand-build `file_data` *with* the property, which is exactly why the suite never caught this. Verified they fail on `main` and pass with the fix.

```
tests/unit/         1181 passed, 7 skipped
tests/integration/    44 passed
```

Stacked on #1599 (the CI fix); the integration numbers above include it.