### PR TITLE
fix: index single-line Kotlin objects

### DIFF
--- a/src/codegraphcontext/tools/languages/kotlin.py
+++ b/src/codegraphcontext/tools/languages/kotlin.py
@@ -18,6 +18,11 @@ KOTLIN_QUERIES = {
             (class_declaration (type_identifier) @name)
             (object_declaration (type_identifier) @name)
             (companion_object (type_identifier)? @name)
+            (infix_expression
+                (object_literal)
+                (simple_identifier)
+                (lambda_literal)
+            )
         ] @class
     """,
     "imports": """
@@ -149,6 +154,9 @@ class KotlinTreeSitterParser:
     def _get_parent_context(self, node: Any) -> Tuple[Optional[str], Optional[str], Optional[int]]:
         curr = node.parent
         while curr:
+            inline_object_name = self._get_inline_object_name(curr)
+            if inline_object_name:
+                return inline_object_name, "object_declaration", curr.start_point[0] + 1
             if curr.type in ("function_declaration",):
                 name_node = None
                 for child in curr.children:
@@ -204,6 +212,22 @@ class KotlinTreeSitterParser:
             curr = curr.parent
         return None, None, None
 
+    def _get_inline_object_name(self, node: Any) -> Optional[str]:
+        """Return the name from Kotlin's misparsed single-line object shape."""
+        if node.type != "infix_expression":
+            return None
+
+        children = node.named_children
+        if [child.type for child in children] != [
+            "object_literal",
+            "simple_identifier",
+            "lambda_literal",
+        ]:
+            return None
+        if self._get_node_text(children[0]) != "object":
+            return None
+        return self._get_node_text(children[1])
+
     def _get_node_text(self, node: Any) -> str:
         if not node: return ""
         return node.text.decode("utf-8")
@@ -235,6 +259,9 @@ class KotlinTreeSitterParser:
     def _get_enclosing_class_context(self, node: Any) -> Tuple[Optional[str], Optional[int]]:
         curr = node.parent
         while curr:
+            inline_object_name = self._get_inline_object_name(curr)
+            if inline_object_name:
+                return inline_object_name, curr.start_point[0] + 1
             if curr.type in ("class_declaration", "interface_declaration", "object_declaration"):
                 for child in curr.children:
                     if child.type in ("simple_identifier", "type_identifier"):
@@ -1346,13 +1373,14 @@ class KotlinTreeSitterParser:
 
         for node, capture_name in captures:
             if capture_name == "class":
+                inline_object_name = self._get_inline_object_name(node)
                 node_id = (node.start_byte, node.end_byte, node.type)
                 if node_id in seen_nodes:
                     continue
                 seen_nodes.add(node_id)
                 
                 try:
-                    if node.type in ("object_declaration", "companion_object"):
+                    if inline_object_name or node.type in ("object_declaration", "companion_object"):
                         category = "objects"
                         label = "Object"
                     else:
@@ -1368,14 +1396,15 @@ class KotlinTreeSitterParser:
                     end_line = node.end_point[0] + 1
                     
                     # Find name child (type_identifier or simple_identifier)
-                    class_name = "Anonymous"
+                    class_name = inline_object_name or "Anonymous"
                     if node.type == "companion_object":
                         class_name = "Companion" # Default name
                     
-                    for child in node.children:
-                        if child.type in ("type_identifier", "simple_identifier"):
-                            class_name = self._get_node_text(child)
-                            break
+                    if not inline_object_name:
+                        for child in node.children:
+                            if child.type in ("type_identifier", "simple_identifier"):
+                                class_name = self._get_node_text(child)
+                                break
                             
                     source_text = self._get_node_text(node)
                     context_name, context_type, context_line = self._get_parent_context(node)
@@ -1415,7 +1444,7 @@ class KotlinTreeSitterParser:
 
                     class_data = {
                         "name": class_name,
-                        "node_type": node.type,
+                        "node_type": "object_declaration" if inline_object_name else node.type,
                         "line_number": start_line,
                         "end_line": end_line,
                         "bases": bases,

--- a/tests/unit/parsers/test_kotlin_parser.py
+++ b/tests/unit/parsers/test_kotlin_parser.py
@@ -688,6 +688,21 @@ class B {
         assert runs == [(5, "Worker", 4), (10, "Worker", 9)]
         assert "class_context_line" not in top
 
+    def test_single_line_object_with_function_is_parsed(self, parser):
+        data = _write_and_parse(parser, "object A { fun x() = 1 }")
+
+        parsed_object = next(obj for obj in data["objects"] if obj["name"] == "A")
+        parsed_function = next(fn for fn in data["functions"] if fn["name"] == "x")
+
+        assert parsed_object["node_type"] == "object_declaration"
+        assert parsed_function["class_context"] == "A"
+        assert parsed_function["class_context_line"] == 1
+
+    def test_anonymous_single_line_object_is_not_indexed_as_named_object(self, parser):
+        data = _write_and_parse(parser, "val a = object { fun x() = 1 }")
+
+        assert data["objects"] == []
+
     def test_nested_constructor_call_resolves_nearest_same_named_class(self, parser):
         data = _write_and_parse(
             parser,


### PR DESCRIPTION
## Summary

- recognize the exact `infix_expression` shape produced for a single-line named Kotlin object
- preserve the object's name and class context for functions inside that object
- cover both the reported named-object case and an anonymous-object non-regression case

## Root cause

The Kotlin tree-sitter grammar parses `object A { fun x() = 1 }` differently from the equivalent multiline declaration: it emits an `infix_expression` containing `object_literal`, `simple_identifier`, and `lambda_literal`, so the existing `object_declaration` query never sees the object. The parser still sees the nested function, but without its owning object context.

## Tests

- `TMPDIR=/private/tmp pytest -q tests/unit/parsers/test_kotlin_parser.py` — 90 passed
- `TMPDIR=/private/tmp ./tests/run_tests.sh fast` — 1190 passed, 19 skipped before stopping slow unrelated golden cases; five existing failures were unrelated CLI inventory drift and `bundle_export` receiving a Typer `OptionInfo`
- `python -m compileall -q src/codegraphcontext/tools/languages/kotlin.py tests/unit/parsers/test_kotlin_parser.py`
- `git diff --check`

Fixes #1600
