### PR TITLE
fix(indexer): root-anchor .cgcignore patterns containing a slash (#1513)

### DIFF
--- a/src/codegraphcontext/core/cgcignore.py
+++ b/src/codegraphcontext/core/cgcignore.py
@@ -151,6 +151,16 @@ class CGCIgnoreMatcher:
             if is_root_anchored:
                 pat = pat[1:]
 
+            # Under gitignore semantics a slash anywhere except the trailing
+            # position anchors the pattern to the ignore root: `src/generated`
+            # matches <root>/src/generated only, never vendor/src/generated.
+            # Only a *leading* slash used to anchor here, so any multi-segment
+            # pattern matched at every depth and silently over-ignored.
+            # `build/` keeps matching at any depth -- its slash was already
+            # stripped as is_dir_only, so no internal slash remains.
+            if '/' in pat:
+                is_root_anchored = True
+
             # `**` spans whole path segments, never part of one. Joining the
             # translated pieces with a bare `.*` lets the wildcard match inside a
             # segment, so `docs/**` would swallow `docstring.py` and `**/build`

--- a/tests/unit/core/test_cgcignore_patterns.py
+++ b/tests/unit/core/test_cgcignore_patterns.py
@@ -14,6 +14,7 @@ from pathspec import PathSpec
 
 # ✅ CORRECT IMPORT PATH
 from codegraphcontext.tools.graph_builder import DEFAULT_IGNORE_PATTERNS
+from codegraphcontext.core.cgcignore import build_ignore_spec
 
 # Use unique directory for EACH test run to avoid conflicts
 BASE_TEST_DIR = Path("/tmp/cgc_test")
@@ -636,3 +637,47 @@ def test_tc23_cgcignore_auto_created_with_default_content():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])
+
+
+# --- Root anchoring of multi-segment patterns (#1513) -------------------------
+#
+# Under gitignore semantics a slash anywhere except the trailing position
+# anchors the pattern to the ignore root. Previously only a *leading* slash
+# anchored, so `src/generated` also ignored `vendor/src/generated` -- copying a
+# line out of .gitignore, which the docs encourage, silently over-ignored real
+# source. Every expectation below was cross-checked against `git check-ignore`.
+
+
+@pytest.mark.parametrize(
+    "pattern,path,expected",
+    [
+        # multi-segment patterns are anchored to the root
+        ("src/generated", "src/generated/a.py", True),
+        ("src/generated", "vendor/src/generated/a.py", False),
+        ("a/**/b", "a/b/f.py", True),
+        ("a/**/b", "a/x/y/b/f.py", True),
+        ("a/**/b", "z/a/b/f.py", False),
+        ("docs/**", "docs/a.md", True),
+        ("docs/**", "vendor/docs/a.md", False),
+        # a trailing slash is not an internal slash: still matches at any depth
+        ("build/", "build/a.py", True),
+        ("build/", "sub/build/a.py", True),
+        # ...but must still respect segment boundaries
+        ("build/", "layout/a.py", False),
+        # single-segment patterns keep matching at any depth
+        ("node_modules", "node_modules/x.js", True),
+        ("node_modules", "web/node_modules/x.js", True),
+        # a leading `**/` means any depth even though a slash is present
+        ("**/dist", "dist/a.js", True),
+        ("**/dist", "web/dist/a.js", True),
+        # an explicit leading slash anchors, as before
+        ("/foo", "foo/a.py", True),
+        ("/foo", "bar/foo/a.py", False),
+    ],
+)
+def test_multi_segment_patterns_are_root_anchored(tmp_path, pattern, path, expected):
+    (tmp_path / ".cgcignore").write_text(pattern + "\n", encoding="utf-8")
+    spec, _ = build_ignore_spec(
+        ignore_root=tmp_path, default_patterns=[], explicit_path=None
+    )
+    assert bool(spec.match_file(path)) is expected


### PR DESCRIPTION
Fixes #1513.

`.cgcignore` is documented as using `.gitignore` syntax, but only a **leading** slash anchored. Every other pattern got the match-at-any-depth prefix, so a multi-segment pattern over-matched:

```
pattern: src/generated
  src/generated/a.py           ignored=True
  vendor/src/generated/a.py    ignored=True   <- should be False
```

Under gitignore semantics a slash anywhere except the trailing position anchors the pattern to the ignore root. So copying a line out of `.gitignore` — the workflow the docs encourage, and the point of #729 — silently dropped real source from the index with no warning.

## The fix

One condition: after the leading `/` and trailing `/` have already been stripped, if a slash remains, anchor.

The trailing-slash case is what makes this safe: `build/` has its slash removed as `is_dir_only` *before* the check, so directory patterns keep matching at any depth, exactly as gitignore does. Similarly `**/dist` stays depth-independent because the leading `**` compiles to `(?:.*/)?`, which absorbs the anchor.

## Verification against real git

Every expectation was cross-checked against `git check-ignore` in a scratch repo — 7 patterns × 17 paths, output identical:

| pattern | path | ignored |
|---|---|---|
| `src/generated` | `src/generated/a.py` | yes |
| `src/generated` | `vendor/src/generated/a.py` | **no** |
| `build/` | `build/a.py`, `sub/build/a.py` | yes |
| `build/` | `layout/a.py` | no |
| `/foo` | `foo/a.py` | yes |
| `/foo` | `bar/foo/a.py` | no |
| `node_modules` | `node_modules/x.js`, `web/node_modules/x.js` | yes |
| `**/dist` | `dist/a.js`, `web/dist/a.js` | yes |
| `docs/**` | `docs/a.md` | yes |
| `docs/**` | `vendor/docs/a.md`, `docstring.py` | **no** |
| `a/**/b` | `a/b/f.py`, `a/x/y/b/f.py` | yes |
| `a/**/b` | `z/a/b/f.py` | **no** |

## Tests

16 parametrized cases added to `test_cgcignore_patterns.py`. Verified the three over-ignoring cases fail on `main` and all 16 pass with the fix.

```
tests/unit/         1194 passed, 7 skipped
tests/integration/    44 passed
```