### PR TITLE
chore(release): bump version to 0.5.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.5.7"
+version = "0.5.8"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
**0.5.8 is already published**: https://pypi.org/project/codegraphcontext/0.5.8/

Merging this keeps `pyproject.toml` in step with PyPI. Without it the repo says 0.5.7 while PyPI serves 0.5.8 — which is exactly the drift #1262 reported, and I closed that issue earlier today on the basis that the three sources agree.

## What shipped in 0.5.8

Everything merged to `main` since 0.5.7:

| PR | Change |
|---|---|
| #1596 | Kotlin annotations extracted into `decorators` (Hilt/Compose/Room now visible) |
| #1594 | `TOOL_RESULT_LIMITS` honoured; `truncated`/`result_limit` flags (fixes #1542) |
| #1588 | Dual-engine AI knowledge explorer for static web mode |
| #1321 | Secret scanner + opt-in `REDACT_SECRETS` (fixes #1313) |
| #1060 | `.cgc` bundle signing (HMAC-SHA256) and encryption (AES-256-GCM) |
| #1599 | CI repair for the two regressions #1060 introduced |

## Verification before upload

Unzipped the built wheel and confirmed each change is actually present rather than trusting a possibly-stale `build/`:

```
ok  secret_scanner module (#1321)
ok  REDACT_SECRETS config (#1321)
ok  kotlin decorators (#1596)
ok  tool_limits truncation (#1594)
ok  bundle signing (#1060)
ok  CI sentinel fix (#1599)
version in METADATA: 0.5.8
```

`twine check` passed on both artifacts. PyPI's JSON API confirms both files are live.

## Not in this release

#1609, #1613 and #1614 are still open, so the `is_dependency`, bundle-`languages` and `.cgcignore` fixes are **not** in 0.5.8. They'd warrant a 0.5.9 once merged — #1609 in particular, since `find_dead_code` currently returns nothing for about half the supported languages.