### PR TITLE
test(goldens): fail clearly when indexing yields an empty graph

### DIFF
--- a/tests/integration/test_parser_goldens.py
+++ b/tests/integration/test_parser_goldens.py
@@ -19,6 +19,12 @@ GENERATED_BUILD_DIRS = {"obj"}
 def clean_path(p):
     return str(p).replace("\\", "/")
 
+def count_jsonl_records(path):
+    if not os.path.exists(path):
+        return 0
+    with open(path, "r", encoding="utf-8") as f:
+        return sum(1 for line in f if line.strip())
+
 def normalize_labels(labels):
     if labels is None:
         return []
@@ -290,7 +296,33 @@ bundle_export(output=bundle_path, repo=project_path, no_stats=False, context=Non
     actual_nodes_path = extract_dir / "nodes.jsonl"
     actual_edges_path = extract_dir / "edges.jsonl"
     actual_metadata_path = extract_dir / "metadata.json"
-    
+
+    # 4.5. Guard: the index/export subprocess can exit 0 and still produce an
+    # empty graph. FalkorDB Lite runs its storage in a worker subprocess whose
+    # startup is timing-sensitive; under CPU contention that worker can fail to
+    # come up while indexing reports success anyway, so the export bundle
+    # exists but is empty. Left unchecked, the golden diff below would then
+    # report every expected node as "missing", which looks exactly like a
+    # parser regression but is actually an infrastructure failure. Catch that
+    # here, before any golden comparison, so this applies under
+    # --update-goldens too (bootstrapping a golden from an empty graph would
+    # be worse than failing).
+    actual_node_count = count_jsonl_records(actual_nodes_path)
+    actual_edge_count = count_jsonl_records(actual_edges_path)
+    assert actual_node_count > 0, (
+        f"Indexing produced an EMPTY graph for {project_name} ({actual_node_count} nodes, "
+        f"{actual_edge_count} edges) even though the subprocess exited 0 and wrote a bundle. "
+        "This means the indexing/database step failed, NOT that the parser regressed -- do "
+        "not read a subsequent golden diff as evidence of a parser change.\n"
+        "Known cause: FalkorDB Lite runs its storage in a worker subprocess with a "
+        "timing-sensitive startup; under CPU contention (e.g. another long-running index "
+        "competing for the machine) that worker can fail to come up while the index step "
+        "still exits 0 with an empty graph. Re-run this test on an idle machine before "
+        "investigating the parser.\n"
+        f"Subprocess STDOUT:\n{run_res.stdout}\n"
+        f"Subprocess STDERR:\n{run_res.stderr}"
+    )
+
     # 5. Handle --update-goldens Option
     if update_goldens:
         # Overwrite the regression baselines ("What We Have") with current raw actual outputs


### PR DESCRIPTION
`test_language_golden` asserts that the index/export subprocess exited 0 and that a bundle file exists — but never that the bundle **contains anything**.

FalkorDB Lite runs its storage in a worker subprocess with a timing-sensitive startup. Under CPU contention the worker can fail to come up; indexing then completes **exit 0 with an empty graph**, and the export happily writes an empty bundle. The golden diff that follows reports every node as missing:

```
AssertionError: Nodes regression mismatch for project sample_project_go:
  Missing 672 expected nodes:
    - Directory:internal:...
    - ExternalClass:bool:...
```

So an infrastructure failure is indistinguishable from a total parser regression.

I lost several hours to exactly this. I concluded the golden suite was broadly broken — "17 of 20 failing on main" — and reasoned at length about shared state and unix-socket path limits. It was neither: my machine was saturated by an unrelated long-running index. Idle, **all 20 pass in 5m18s**.

This adds a guard between extraction and comparison. If the extracted graph is empty it fails immediately, states that this indicates the indexing/database step failed rather than a parser regression, names CPU contention and the FalkorDB worker as the known cause, and includes the subprocess stdout/stderr so the real error is visible.

No retries, no sleeps, no masking — the goal is a failure that explains itself, not one that disappears.

Verified the guard fires: with a successful run, truncating the extracted `nodes.jsonl`/`edges.jsonl` produces the new message rather than a "Missing N expected nodes" diff. Goldens still pass normally (`sample_project_java`, `sample_project_go` checked on this branch).

One file, +33/-1, tests only.
