### PR TITLE
fix(graph): re-absolutize repo-scoped bundle paths on import (#1509)

### DIFF
--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -80,6 +80,75 @@ def _validate_cypher_identifier(value: Any, kind: str) -> str:
     return value
 
 
+# Repo-scoped export rewrites the repository root to "." and every path under
+# it to "./rel" (#1509). Import must invert that rewrite against a per-bundle
+# destination root; otherwise every second bundle collides on path="." and
+# File keys like ./README.md.
+_BUNDLE_RELATIVE_ROOTS = {".", "./", ".\\"}
+_NON_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _sanitize_bundle_repo_slug(repo: Optional[str]) -> str:
+    """Turn metadata['repo'] into a single path segment (pallets/flask → pallets__flask)."""
+    if not repo or not isinstance(repo, str):
+        return "unknown"
+    slug = repo.strip().replace("\\", "/").replace("..", "").strip("/")
+    slug = _NON_SLUG_RE.sub("__", slug).strip("_")
+    return slug or "unknown"
+
+
+def _default_bundle_install_root(
+    metadata: Optional[Dict[str, Any]] = None,
+    destination_root: Optional[Path] = None,
+) -> str:
+    """Absolute posix dest root for one imported bundle: ~/.codegraphcontext/bundles/<slug>."""
+    slug = _sanitize_bundle_repo_slug((metadata or {}).get("repo"))
+    base = Path(destination_root) if destination_root is not None else (
+        Path.home() / ".codegraphcontext" / "bundles"
+    )
+    return (base / slug).resolve().as_posix()
+
+
+def _is_bundle_relative_path(val: Any) -> bool:
+    """True for portable export paths: '.', './', '.\\', './foo', '.\\foo'."""
+    if not isinstance(val, str) or not val:
+        return False
+    if val in _BUNDLE_RELATIVE_ROOTS:
+        return True
+    return val.startswith("./") or val.startswith(".\\")
+
+
+def _is_identifying_repo_path(repo_path: Optional[str]) -> bool:
+    """False for None, empty, and bundle-relative paths that are not unique."""
+    if not repo_path:
+        return False
+    return not _is_bundle_relative_path(repo_path)
+
+
+def _rebase_bundle_path(val: str, dest_root: str) -> str:
+    """Map '.' / './rel' onto dest_root. Non-relative strings are returned unchanged."""
+    if not _is_bundle_relative_path(val):
+        return val
+    if val in _BUNDLE_RELATIVE_ROOTS:
+        return dest_root
+    rel = val[2:].replace("\\", "/").lstrip("/")
+    if not rel:
+        return dest_root
+    return dest_root + "/" + rel
+
+
+def _rebase_property_map(
+    props: Optional[Dict[str, Any]], dest_root: Optional[str]
+) -> Dict[str, Any]:
+    """Rewrite every bundle-relative string property in *props* in place."""
+    if not props or not dest_root:
+        return props or {}
+    for key, val in list(props.items()):
+        if isinstance(val, str) and _is_bundle_relative_path(val):
+            props[key] = _rebase_bundle_path(val, dest_root)
+    return props
+
+
 class CGCBundle:
     """Handles creation and loading of .cgc bundle files."""
 
@@ -259,6 +328,7 @@ class CGCBundle:
         password: Optional[str] = None,
         verify_key: Optional[str] = None,
         graph_name: str = None,
+        destination_root: Optional[Path] = None,
     ) -> Tuple[bool, str]:
         self._active_graph = graph_name
         """
@@ -268,6 +338,11 @@ class CGCBundle:
             bundle_path: Path to the .cgc file
             clear_existing: Whether to clear existing graph data first
             readonly: If True, mount as read-only (future feature)
+            password: Optional password to decrypt an encrypted bundle
+            verify_key: Optional HMAC key to verify a signed bundle
+            destination_root: Optional base directory used to re-absolutize
+                repo-scoped relative paths ('.' / './…'). Defaults to
+                ~/.codegraphcontext/bundles/<sanitized repo>.
             
         Returns:
             Tuple[bool, str]: (success, message)
@@ -304,10 +379,15 @@ class CGCBundle:
                 
                 info_logger(f"Loading bundle: {metadata.get('repo', 'unknown')}")
                 info_logger(f"Bundle version: {metadata.get('cgc_version', 'unknown')}")
+
+                dest_root = _default_bundle_install_root(metadata, destination_root)
                 
                 # Step 4: Handle existing data
                 repo_name = metadata.get('repo', 'unknown')
                 repo_path = metadata.get('repo_path')
+                if _is_bundle_relative_path(repo_path):
+                    repo_path = _rebase_bundle_path(repo_path, dest_root)
+                    metadata["repo_path"] = repo_path
                 
                 if clear_existing:
                     # User explicitly wants to clear - remove everything
@@ -330,11 +410,11 @@ class CGCBundle:
                 
                 # Step 6: Import nodes
                 info_logger("Importing nodes...")
-                node_count = self._import_nodes(payload_path / "nodes.jsonl")
+                node_count = self._import_nodes(payload_path / "nodes.jsonl", dest_root)
                 
                 # Step 7: Import edges
                 info_logger("Importing edges...")
-                edge_count = self._import_edges(payload_path / "edges.jsonl")
+                edge_count = self._import_edges(payload_path / "edges.jsonl", dest_root)
             
             success_msg = f"✅ Successfully imported {bundle_path.name}\n"
             success_msg += f"   Repository: {metadata.get('repo', 'unknown')}\n"
@@ -1310,8 +1390,10 @@ cgc import <bundle-file>.cgc
             if result.single():
                 return True
             
-            # If repo_path is provided, also check by path
-            if repo_path:
+            # Path '.' / './…' is the portable export of every repo-scoped
+            # bundle, not a unique identity — matching on it refuses flask
+            # then requests as duplicates (#1509).
+            if _is_identifying_repo_path(repo_path):
                 result = session.run(
                     "MATCH (r:Repository {path: $path}) RETURN r LIMIT 1",
                     path=repo_path
@@ -1338,6 +1420,13 @@ cgc import <bundle-file>.cgc
                 return
             
             repo_path = record['path']
+            if not _is_identifying_repo_path(repo_path):
+                warning_logger(
+                    f"Refusing to delete repository '{repo_identifier}': "
+                    f"path {repo_path!r} is not identifying and would match "
+                    "every repo-scoped bundle import"
+                )
+                return
             
             repo_prefix = repo_path if repo_path.endswith("/") else f"{repo_path}/"
             # Delete all nodes that belong to this repository
@@ -1387,7 +1476,7 @@ cgc import <bundle-file>.cgc
         # This is a placeholder for future enhancement
         debug_log("Schema import not yet implemented - relying on application schema")
     
-    def _import_nodes(self, nodes_file: Path) -> int:
+    def _import_nodes(self, nodes_file: Path, dest_root: Optional[str] = None) -> int:
         """Import nodes from JSONL file."""
         count = 0
         batch_size = 1000
@@ -1416,12 +1505,12 @@ cgc import <bundle-file>.cgc
                     batch.append((labels, node_data, old_id))
                     
                     if len(batch) >= batch_size:
-                        count += self._import_node_batch(session, batch, id_mapping)
+                        count += self._import_node_batch(session, batch, id_mapping, dest_root)
                         batch = []
                 
                 # Import remaining nodes
                 if batch:
-                    count += self._import_node_batch(session, batch, id_mapping)
+                    count += self._import_node_batch(session, batch, id_mapping, dest_root)
         
         # Store ID mapping for edge import
         self._id_mapping = id_mapping
@@ -1469,7 +1558,13 @@ cgc import <bundle-file>.cgc
         'Object': ['name', 'path', 'line_number'],
     }
 
-    def _import_node_batch(self, session, batch: List[Tuple], id_mapping: Dict) -> int:
+    def _import_node_batch(
+        self,
+        session,
+        batch: List[Tuple],
+        id_mapping: Dict,
+        dest_root: Optional[str] = None,
+    ) -> int:
         """Import a batch of nodes."""
         id_function = self._get_id_function()
         
@@ -1483,9 +1578,14 @@ cgc import <bundle-file>.cgc
             label_str = ':'.join(labels)
             primary_label = labels[0]
 
+            if dest_root:
+                _rebase_property_map(properties, dest_root)
+
             pk_field = self._PK_MAP.get(primary_label)
-            if pk_field == 'uid' and 'uid' not in properties:
-                parts = self._UID_PARTS.get(primary_label, [])
+            parts = self._UID_PARTS.get(primary_label, []) if pk_field == 'uid' else []
+            # After rebasing './…' paths, uid must include the dest root so
+            # Function/Class MERGE keys do not collide across bundles (#1509).
+            if pk_field == 'uid' and parts and (dest_root or 'uid' not in properties):
                 properties['uid'] = ''.join(str(properties.get(p, '')) for p in parts)
 
             if pk_field and pk_field in properties:
@@ -1511,7 +1611,7 @@ cgc import <bundle-file>.cgc
         
         return len(batch)
     
-    def _import_edges(self, edges_file: Path) -> int:
+    def _import_edges(self, edges_file: Path, dest_root: Optional[str] = None) -> int:
         """Import edges from JSONL file."""
         count = 0
         batch_size = 1000
@@ -1524,16 +1624,18 @@ cgc import <bundle-file>.cgc
                     batch.append(edge_data)
                     
                     if len(batch) >= batch_size:
-                        count += self._import_edge_batch(session, batch)
+                        count += self._import_edge_batch(session, batch, dest_root)
                         batch = []
                 
                 # Import remaining edges
                 if batch:
-                    count += self._import_edge_batch(session, batch)
+                    count += self._import_edge_batch(session, batch, dest_root)
         
         return count
     
-    def _import_edge_batch(self, session, batch: List[Dict]) -> int:
+    def _import_edge_batch(
+        self, session, batch: List[Dict], dest_root: Optional[str] = None
+    ) -> int:
         """Import a batch of edges."""
         id_mapping = getattr(self, '_id_mapping', {})
         # Detect database backend to use appropriate ID function
@@ -1548,7 +1650,9 @@ cgc import <bundle-file>.cgc
             if isinstance(old_to, dict):
                 old_to = (old_to.get('table', 0), old_to.get('offset', 0))
             rel_type = _validate_cypher_identifier(edge.get('type'), "relationship type")
-            properties = edge.get('properties', {})
+            properties = edge.get('properties', {}) or {}
+            if dest_root:
+                properties = _rebase_property_map(properties, dest_root)
             
             # Map old IDs to new IDs
             new_from = id_mapping.get(old_from)

--- a/tests/unit/core/test_bundle_repo_scoped_import.py
+++ b/tests/unit/core/test_bundle_repo_scoped_import.py
@@ -1,0 +1,253 @@
+"""
+Regression tests for #1509 — repo-scoped bundle paths collide on import.
+
+Export with --repo rewrites the repo root to '.' and files to './README.md'.
+Import used to write those relative strings into the graph, so:
+
+* _check_existing_repository(path='.') matched any previously imported bundle
+* File MERGE keys collapsed across flask vs requests
+* Function uid built from name+path+line_number collided the same way
+
+Import now rebases '.' / './…' onto a per-bundle destination root. These tests
+mock the driver; they do not need a live graph database.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.core.cgc_bundle import (
+    CGCBundle,
+    _default_bundle_install_root,
+    _is_bundle_relative_path,
+    _is_identifying_repo_path,
+    _rebase_bundle_path,
+    _sanitize_bundle_repo_slug,
+)
+
+
+def _bundle(backend: str = "falkordb") -> CGCBundle:
+    db_manager = MagicMock()
+    db_manager.get_backend_type.return_value = backend
+    return CGCBundle(db_manager)
+
+
+def _session_for(bundle: CGCBundle) -> MagicMock:
+    session = MagicMock()
+    bundle.db_manager.get_driver.return_value.session.return_value.__enter__.return_value = session
+    return session
+
+
+def _empty_result():
+    result = MagicMock()
+    result.single.return_value = None
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (".", True),
+        ("./", True),
+        (".\\", True),
+        ("./README.md", True),
+        (".\\src\\a.py", True),
+        ("./src/foo.py", True),
+        ("/abs/flask", False),
+        ("os.path", False),
+        ("E:/repo", False),
+        ("C:/Users/hp/project", False),
+        ("", False),
+        (None, False),
+        ("README.md", False),
+    ],
+)
+def test_is_bundle_relative_path(val, expected):
+    assert _is_bundle_relative_path(val) is expected
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (None, False),
+        ("", False),
+        (".", False),
+        ("./README.md", False),
+        ("/abs/flask", True),
+        ("C:/Users/hp/.codegraphcontext/bundles/flask", True),
+    ],
+)
+def test_is_identifying_repo_path(val, expected):
+    assert _is_identifying_repo_path(val) is expected
+
+
+def test_rebase_dot_is_dest_root():
+    assert _rebase_bundle_path(".", "/dest/flask") == "/dest/flask"
+
+
+def test_rebase_posix_relative_file():
+    assert _rebase_bundle_path("./README.md", "/dest/flask") == "/dest/flask/README.md"
+
+
+def test_rebase_windows_relative_file():
+    assert _rebase_bundle_path(".\\src\\a.py", "/dest/flask") == "/dest/flask/src/a.py"
+
+
+def test_rebase_leaves_absolute_paths_alone():
+    assert _rebase_bundle_path("/abs/flask", "/dest/x") == "/abs/flask"
+    assert _rebase_bundle_path("os.path", "/dest/x") == "os.path"
+    assert _rebase_bundle_path("E:/repo", "/dest/x") == "E:/repo"
+
+
+def test_slug_owner_slash_repo():
+    assert _sanitize_bundle_repo_slug("pallets/flask") == "pallets__flask"
+
+
+def test_slug_empty_falls_back_to_unknown():
+    assert _sanitize_bundle_repo_slug("") == "unknown"
+    assert _sanitize_bundle_repo_slug(None) == "unknown"
+
+
+def test_default_install_root_uses_home_and_slug(tmp_path):
+    root = _default_bundle_install_root({"repo": "pallets/flask"}, tmp_path)
+    assert root == (tmp_path / "pallets__flask").resolve().as_posix()
+
+
+# ---------------------------------------------------------------------------
+# _check_existing_repository
+# ---------------------------------------------------------------------------
+
+
+def test_check_existing_skips_dot_path_match():
+    """path='.' must not issue MATCH (r:Repository {path: $path})."""
+    bundle = _bundle()
+    session = _session_for(bundle)
+    session.run.return_value = _empty_result()
+
+    found = bundle._check_existing_repository("requests", ".")
+
+    assert found is False
+    queries = [call.args[0] for call in session.run.call_args_list]
+    assert any("name: $name" in q for q in queries)
+    assert not any("{path: $path}" in q for q in queries)
+
+
+def test_check_existing_still_matches_absolute_path():
+    bundle = _bundle()
+    session = _session_for(bundle)
+    session.run.return_value = _empty_result()
+
+    bundle._check_existing_repository("flask", "/abs/flask")
+
+    queries = [call.args[0] for call in session.run.call_args_list]
+    assert any("{path: $path}" in q for q in queries)
+    path_call = next(c for c in session.run.call_args_list if "{path: $path}" in c.args[0])
+    assert path_call.kwargs["path"] == "/abs/flask"
+
+
+def test_check_existing_name_match_still_runs():
+    bundle = _bundle()
+    session = _session_for(bundle)
+    name_hit = MagicMock()
+    name_hit.single.return_value = {"r": object()}
+    session.run.return_value = name_hit
+
+    assert bundle._check_existing_repository("flask", ".") is True
+    assert session.run.call_count == 1
+    assert "name: $name" in session.run.call_args.args[0]
+    assert session.run.call_args.kwargs["name"] == "flask"
+
+
+# ---------------------------------------------------------------------------
+# _import_node_batch — File PK uniqueness + uid
+# ---------------------------------------------------------------------------
+
+
+def _pk_vals(session: MagicMock):
+    return [c.kwargs["pk_val"] for c in session.run.call_args_list if "pk_val" in c.kwargs]
+
+
+def test_file_rows_with_same_relative_path_get_distinct_merge_keys():
+    flask_root = "/dest/flask"
+    requests_root = "/dest/requests"
+    row = (["File"], {"path": "./README.md"}, "1")
+
+    flask_session = MagicMock()
+    flask_session.run.return_value.single.return_value = {"new_id": 1}
+    _bundle()._import_node_batch(flask_session, [row], {}, flask_root)
+
+    requests_session = MagicMock()
+    requests_session.run.return_value.single.return_value = {"new_id": 1}
+    _bundle()._import_node_batch(
+        requests_session, [(["File"], {"path": "./README.md"}, "1")], {}, requests_root
+    )
+
+    flask_pk = _pk_vals(flask_session)[0]
+    requests_pk = _pk_vals(requests_session)[0]
+    assert flask_pk == f"{flask_root}/README.md"
+    assert requests_pk == f"{requests_root}/README.md"
+    assert flask_pk != requests_pk
+
+
+def test_function_uid_includes_dest_root_not_relative_path():
+    dest = "/dest/flask"
+    session = MagicMock()
+    session.run.return_value.single.return_value = {"new_id": 1}
+    props = {"name": "parse", "path": "./src/foo.py", "line_number": 12, "uid": "parse./src/foo.py12"}
+
+    _bundle()._import_node_batch(session, [(["Function"], props, "1")], {}, dest)
+
+    pk = _pk_vals(session)[0]
+    assert dest in pk
+    assert "./" not in pk
+    assert pk == f"parse{dest}/src/foo.py12"
+
+
+def test_absolute_paths_are_unchanged_when_not_repo_scoped():
+    session = MagicMock()
+    session.run.return_value.single.return_value = {"new_id": 1}
+    abs_path = "/home/me/numpy/core.py"
+
+    _bundle()._import_node_batch(
+        session, [(["File"], {"path": abs_path}, "1")], {}, dest_root=None
+    )
+
+    assert _pk_vals(session)[0] == abs_path
+
+
+def test_absolute_paths_are_unchanged_even_with_dest_root():
+    session = MagicMock()
+    session.run.return_value.single.return_value = {"new_id": 1}
+    abs_path = "/home/me/numpy/core.py"
+
+    _bundle()._import_node_batch(
+        session, [(["File"], {"path": abs_path}, "1")], {}, dest_root="/dest/numpy"
+    )
+
+    assert _pk_vals(session)[0] == abs_path
+
+
+# ---------------------------------------------------------------------------
+# _delete_repository
+# ---------------------------------------------------------------------------
+
+
+def test_delete_repository_noops_when_path_is_dot():
+    bundle = _bundle()
+    session = _session_for(bundle)
+    found = MagicMock()
+    found.single.return_value = {"path": "."}
+    session.run.return_value = found
+
+    bundle._delete_repository("flask")
+
+    assert session.run.call_count == 1, (
+        "DETACH DELETE must not run when r.path is '.' — that would wipe "
+        "every repo-scoped bundle import"
+    )
+    assert "DETACH DELETE" not in session.run.call_args.args[0]


### PR DESCRIPTION
## Summary

Fixes #1509 (GSSoC'26).

Repo-scoped export (`cgc bundle export --repo`) correctly rewrites absolute paths to portable `.` / `./…` form. Import never inverted that rewrite, so every imported bundle landed with `Repository.path = "."`. `_check_existing_repository` then matched on that path, so loading a second registry bundle (for example flask, then requests) was always refused as a duplicate. `--clear` was the only workaround and it wiped the first bundle, which breaks the bundle-registry use case (#1180).

Even if the existence check were skipped, File MERGE keys such as `./README.md` and Function/Class `uid`s built from `name + path + line_number` would collide across repos.

Export is unchanged. Relative `.cgc` contents stay portable. Import is now the inverse of the rewrite.

## Problem

1. False duplicate: after import, `metadata.repo_path` and the Repository node path are `"."`. The path MATCH in `_check_existing_repository` then hits any previously imported repo-scoped bundle.
2. File primary-key collision: `_PK_MAP` MERGEs File/Directory/Repository on `path`, so `./README.md` from two repos would become one node.
3. Function/Class identity: `_UID_PARTS` builds `uid` from `name + path + line_number`. Relative paths would make `parse` at line 1 collide across repos.

## Solution

On import, rebase `.` / `./…` onto a per-bundle destination root:

`~/.codegraphcontext/bundles/<sanitized_repo>`

Example: `pallets/flask` becomes slug `pallets__flask`. Tests can pass `destination_root=` so they never touch the real home directory.

Behaviour:

- Rebase `metadata.repo_path` and all bundle-relative node/edge string properties before MERGE.
- `_check_existing_repository` still matches by name (same repo twice is still a duplicate) but does not treat `.` / `./…` as an identifying path.
- After rebase, Function/Class `uid` is rebuilt from `_UID_PARTS` so identity includes the dest root.
- `_delete_repository` refuses to delete when `r.path` is `.`, because `STARTS WITH "./"` would wipe every repo-scoped import.

Upstream encryption/signing (`password`, `verify_key`, `payload_path`) is preserved after rebase onto `main`.

## Files changed

- `src/codegraphcontext/core/cgc_bundle.py` — path helpers, import rebase, existence-check hardening, delete guard. Also threads `destination_root` on `import_from_bundle` without breaking `password` / `verify_key`.
- `tests/unit/core/test_bundle_repo_scoped_import.py` — new unit tests (mocked driver, no live graph DB).

CLI and MCP call sites are unchanged. They pick up the default dest root.

## Tests performed

Command:

python -m pytest tests/unit/core/test_bundle_repo_scoped_import.py tests/unit/core/test_bundle_edge_zero_id.py tests/unit/core/test_bundle_identifier_validation.py tests/unit/core/test_bundle_pk_map_coverage.py -q

Result: 87 passed.

Covered:

- Rebase of `.`, `./README.md`, `.\src\a.py`; absolute paths and `os.path` left alone.
- Slug `pallets/flask` -> `pallets__flask`; empty -> `unknown`.
- Path `"."` does not issue MATCH (r:Repository {path: $path}); real absolute paths still do; name match still runs.
- Two File rows both `./README.md` MERGE with distinct pk_val values (flask vs requests dest roots).
- Function uid contains dest root, not `./`.
- `_delete_repository` no-ops when found path is `"."`.

Related existing bundle tests still pass: edge zero-id, identifier validation, `_PK_MAP` coverage.

## Checklist

- Focused on a single bug (#1509)
- Tests added for the fix
- Linked to the issue
- Rebased onto upstream/main
