### PR TITLE
ci: add cross-OS E2E tests and gracefully skip missing backends

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Check out code
@@ -25,6 +29,7 @@ jobs:
         pip install -e .[dev]
 
     - name: Run end-to-end tests
+      shell: bash
       run: |
         chmod +x tests/run_tests.sh
         ./tests/run_tests.sh e2e

--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-08-13 18:25 UTC_
+_Generated: 2026-08-18 17:20 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -80,6 +80,75 @@ def _validate_cypher_identifier(value: Any, kind: str) -> str:
     return value
 
 
+# Repo-scoped export rewrites the repository root to "." and every path under
+# it to "./rel" (#1509). Import must invert that rewrite against a per-bundle
+# destination root; otherwise every second bundle collides on path="." and
+# File keys like ./README.md.
+_BUNDLE_RELATIVE_ROOTS = {".", "./", ".\\"}
+_NON_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _sanitize_bundle_repo_slug(repo: Optional[str]) -> str:
+    """Turn metadata['repo'] into a single path segment (pallets/flask → pallets__flask)."""
+    if not repo or not isinstance(repo, str):
+        return "unknown"
+    slug = repo.strip().replace("\\", "/").replace("..", "").strip("/")
+    slug = _NON_SLUG_RE.sub("__", slug).strip("_")
+    return slug or "unknown"
+
+
+def _default_bundle_install_root(
+    metadata: Optional[Dict[str, Any]] = None,
+    destination_root: Optional[Path] = None,
+) -> str:
+    """Absolute posix dest root for one imported bundle: ~/.codegraphcontext/bundles/<slug>."""
+    slug = _sanitize_bundle_repo_slug((metadata or {}).get("repo"))
+    base = Path(destination_root) if destination_root is not None else (
+        Path.home() / ".codegraphcontext" / "bundles"
+    )
+    return (base / slug).resolve().as_posix()
+
+
+def _is_bundle_relative_path(val: Any) -> bool:
+    """True for portable export paths: '.', './', '.\\', './foo', '.\\foo'."""
+    if not isinstance(val, str) or not val:
+        return False
+    if val in _BUNDLE_RELATIVE_ROOTS:
+        return True
+    return val.startswith("./") or val.startswith(".\\")
+
+
+def _is_identifying_repo_path(repo_path: Optional[str]) -> bool:
+    """False for None, empty, and bundle-relative paths that are not unique."""
+    if not repo_path:
+        return False
+    return not _is_bundle_relative_path(repo_path)
+
+
+def _rebase_bundle_path(val: str, dest_root: str) -> str:
+    """Map '.' / './rel' onto dest_root. Non-relative strings are returned unchanged."""
+    if not _is_bundle_relative_path(val):
+        return val
+    if val in _BUNDLE_RELATIVE_ROOTS:
+        return dest_root
+    rel = val[2:].replace("\\", "/").lstrip("/")
+    if not rel:
+        return dest_root
+    return dest_root + "/" + rel
+
+
+def _rebase_property_map(
+    props: Optional[Dict[str, Any]], dest_root: Optional[str]
+) -> Dict[str, Any]:
+    """Rewrite every bundle-relative string property in *props* in place."""
+    if not props or not dest_root:
+        return props or {}
+    for key, val in list(props.items()):
+        if isinstance(val, str) and _is_bundle_relative_path(val):
+            props[key] = _rebase_bundle_path(val, dest_root)
+    return props
+
+
 class CGCBundle:
     """Handles creation and loading of .cgc bundle files."""
 
@@ -259,6 +328,7 @@ class CGCBundle:
         password: Optional[str] = None,
         verify_key: Optional[str] = None,
         graph_name: str = None,
+        destination_root: Optional[Path] = None,
     ) -> Tuple[bool, str]:
         self._active_graph = graph_name
         """
@@ -268,6 +338,11 @@ class CGCBundle:
             bundle_path: Path to the .cgc file
             clear_existing: Whether to clear existing graph data first
             readonly: If True, mount as read-only (future feature)
+            password: Optional password to decrypt an encrypted bundle
+            verify_key: Optional HMAC key to verify a signed bundle
+            destination_root: Optional base directory used to re-absolutize
+                repo-scoped relative paths ('.' / './…'). Defaults to
+                ~/.codegraphcontext/bundles/<sanitized repo>.
             
         Returns:
             Tuple[bool, str]: (success, message)
@@ -304,10 +379,15 @@ class CGCBundle:
                 
                 info_logger(f"Loading bundle: {metadata.get('repo', 'unknown')}")
                 info_logger(f"Bundle version: {metadata.get('cgc_version', 'unknown')}")
+
+                dest_root = _default_bundle_install_root(metadata, destination_root)
                 
                 # Step 4: Handle existing data
                 repo_name = metadata.get('repo', 'unknown')
                 repo_path = metadata.get('repo_path')
+                if _is_bundle_relative_path(repo_path):
+                    repo_path = _rebase_bundle_path(repo_path, dest_root)
+                    metadata["repo_path"] = repo_path
                 
                 if clear_existing:
                     # User explicitly wants to clear - remove everything
@@ -330,11 +410,11 @@ class CGCBundle:
                 
                 # Step 6: Import nodes
                 info_logger("Importing nodes...")
-                node_count = self._import_nodes(payload_path / "nodes.jsonl")
+                node_count = self._import_nodes(payload_path / "nodes.jsonl", dest_root)
                 
                 # Step 7: Import edges
                 info_logger("Importing edges...")
-                edge_count = self._import_edges(payload_path / "edges.jsonl")
+                edge_count = self._import_edges(payload_path / "edges.jsonl", dest_root)
             
             success_msg = f"✅ Successfully imported {bundle_path.name}\n"
             success_msg += f"   Repository: {metadata.get('repo', 'unknown')}\n"
@@ -1310,8 +1390,10 @@ cgc import <bundle-file>.cgc
             if result.single():
                 return True
             
-            # If repo_path is provided, also check by path
-            if repo_path:
+            # Path '.' / './…' is the portable export of every repo-scoped
+            # bundle, not a unique identity — matching on it refuses flask
+            # then requests as duplicates (#1509).
+            if _is_identifying_repo_path(repo_path):
                 result = session.run(
                     "MATCH (r:Repository {path: $path}) RETURN r LIMIT 1",
                     path=repo_path
@@ -1338,6 +1420,13 @@ cgc import <bundle-file>.cgc
                 return
             
             repo_path = record['path']
+            if not _is_identifying_repo_path(repo_path):
+                warning_logger(
+                    f"Refusing to delete repository '{repo_identifier}': "
+                    f"path {repo_path!r} is not identifying and would match "
+                    "every repo-scoped bundle import"
+                )
+                return
             
             repo_prefix = repo_path if repo_path.endswith("/") else f"{repo_path}/"
             # Delete all nodes that belong to this repository
@@ -1387,7 +1476,7 @@ cgc import <bundle-file>.cgc
         # This is a placeholder for future enhancement
         debug_log("Schema import not yet implemented - relying on application schema")
     
-    def _import_nodes(self, nodes_file: Path) -> int:
+    def _import_nodes(self, nodes_file: Path, dest_root: Optional[str] = None) -> int:
         """Import nodes from JSONL file."""
         count = 0
         batch_size = 1000
@@ -1416,12 +1505,12 @@ cgc import <bundle-file>.cgc
                     batch.append((labels, node_data, old_id))
                     
                     if len(batch) >= batch_size:
-                        count += self._import_node_batch(session, batch, id_mapping)
+                        count += self._import_node_batch(session, batch, id_mapping, dest_root)
                         batch = []
                 
                 # Import remaining nodes
                 if batch:
-                    count += self._import_node_batch(session, batch, id_mapping)
+                    count += self._import_node_batch(session, batch, id_mapping, dest_root)
         
         # Store ID mapping for edge import
         self._id_mapping = id_mapping
@@ -1469,7 +1558,13 @@ cgc import <bundle-file>.cgc
         'Object': ['name', 'path', 'line_number'],
     }
 
-    def _import_node_batch(self, session, batch: List[Tuple], id_mapping: Dict) -> int:
+    def _import_node_batch(
+        self,
+        session,
+        batch: List[Tuple],
+        id_mapping: Dict,
+        dest_root: Optional[str] = None,
+    ) -> int:
         """Import a batch of nodes."""
         id_function = self._get_id_function()
         
@@ -1483,9 +1578,14 @@ cgc import <bundle-file>.cgc
             label_str = ':'.join(labels)
             primary_label = labels[0]
 
+            if dest_root:
+                _rebase_property_map(properties, dest_root)
+
             pk_field = self._PK_MAP.get(primary_label)
-            if pk_field == 'uid' and 'uid' not in properties:
-                parts = self._UID_PARTS.get(primary_label, [])
+            parts = self._UID_PARTS.get(primary_label, []) if pk_field == 'uid' else []
+            # After rebasing './…' paths, uid must include the dest root so
+            # Function/Class MERGE keys do not collide across bundles (#1509).
+            if pk_field == 'uid' and parts and (dest_root or 'uid' not in properties):
                 properties['uid'] = ''.join(str(properties.get(p, '')) for p in parts)
 
             if pk_field and pk_field in properties:
@@ -1511,7 +1611,7 @@ cgc import <bundle-file>.cgc
         
         return len(batch)
     
-    def _import_edges(self, edges_file: Path) -> int:
+    def _import_edges(self, edges_file: Path, dest_root: Optional[str] = None) -> int:
         """Import edges from JSONL file."""
         count = 0
         batch_size = 1000
@@ -1524,16 +1624,18 @@ cgc import <bundle-file>.cgc
                     batch.append(edge_data)
                     
                     if len(batch) >= batch_size:
-                        count += self._import_edge_batch(session, batch)
+                        count += self._import_edge_batch(session, batch, dest_root)
                         batch = []
                 
                 # Import remaining edges
                 if batch:
-                    count += self._import_edge_batch(session, batch)
+                    count += self._import_edge_batch(session, batch, dest_root)
         
         return count
     
-    def _import_edge_batch(self, session, batch: List[Dict]) -> int:
+    def _import_edge_batch(
+        self, session, batch: List[Dict], dest_root: Optional[str] = None
+    ) -> int:
         """Import a batch of edges."""
         id_mapping = getattr(self, '_id_mapping', {})
         # Detect database backend to use appropriate ID function
@@ -1548,7 +1650,9 @@ cgc import <bundle-file>.cgc
             if isinstance(old_to, dict):
                 old_to = (old_to.get('table', 0), old_to.get('offset', 0))
             rel_type = _validate_cypher_identifier(edge.get('type'), "relationship type")
-            properties = edge.get('properties', {})
+            properties = edge.get('properties', {}) or {}
+            if dest_root:
+                properties = _rebase_property_map(properties, dest_root)
             
             # Map old IDs to new IDs
             new_from = id_mapping.get(old_from)

--- a/src/codegraphcontext/core/jobs.py
+++ b/src/codegraphcontext/core/jobs.py
@@ -121,6 +121,14 @@ class JobManager:
                     
             return None
 
+    def list_active_jobs(self) -> List[JobInfo]:
+        """Return all jobs that are still PENDING or RUNNING (#1536)."""
+        with self.lock:
+            return [
+                job for job in self.jobs.values()
+                if job.status in (JobStatus.PENDING, JobStatus.RUNNING)
+            ]
+
     def cleanup_old_jobs(self, max_age_hours: int = 24):
         """Removes old jobs from memory to prevent memory leaks.
 

--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -692,10 +692,14 @@ class MCPServer:
         # different meanings (path = file path, repo_path = repo filter).
         if isinstance(args, dict):
             args = dict(args)
+            # path_means_file: for these tools `path` is a file disambiguator and
+            # `repo_path` is a separate repo-prefix filter. Aliasing either way
+            # collapses the two meanings (#1532: path → repo_path made
+            # calculate_cyclomatic_complexity return null).
             path_means_file = tool_name in ("calculate_cyclomatic_complexity",)
             if "repo_path" in args and "path" not in args and not path_means_file:
                 args["path"] = args["repo_path"]
-            elif "path" in args and "repo_path" not in args:
+            elif "path" in args and "repo_path" not in args and not path_means_file:
                 args["repo_path"] = args["path"]
 
         tool_map: Dict[str, Coroutine] = {

--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -557,6 +557,25 @@ class MCPServer:
         except Exception as exc:
             warning_logger(f"Failed to start new code watcher after context switch: {exc}")
 
+    def _active_jobs_block_context_switch(self) -> Optional[Dict[str, Any]]:
+        """Refuse context switches while indexing jobs still hold the current DB (#1536)."""
+        active = self.job_manager.list_active_jobs()
+        if not active:
+            return None
+        job_ids = [j.job_id for j in active]
+        details = [
+            {"job_id": j.job_id, "status": j.status.value, "path": j.path}
+            for j in active
+        ]
+        return {
+            "error": (
+                "Cannot switch context while indexing jobs are still active "
+                f"({', '.join(job_ids)}). Wait for them to finish "
+                "(check_job_status / list_jobs), then retry switch_context."
+            ),
+            "active_jobs": details,
+        }
+
     def switch_context_tool(self, **args) -> Dict[str, Any]:
         raw_path = args.get("context_path", "")
         should_save = args.get("save", True)
@@ -566,6 +585,9 @@ class MCPServer:
 
         # --- Special case: switch back to the global context ---
         if raw_path == "global":
+            blocked = self._active_jobs_block_context_switch()
+            if blocked:
+                return blocked
             try:
                 watcher_was_running = self._stop_current_watcher()
                 try:
@@ -621,6 +643,10 @@ class MCPServer:
 
         if not cgc_dir.exists() or not cgc_dir.is_dir():
             return {"error": f"No .codegraphcontext directory found at {cgc_dir}."}
+
+        blocked = self._active_jobs_block_context_switch()
+        if blocked:
+            return blocked
 
         local_db = "falkordb"
         local_yaml = cgc_dir / "config.yaml"

--- a/src/codegraphcontext/tool_definitions.py
+++ b/src/codegraphcontext/tool_definitions.py
@@ -372,7 +372,10 @@ TOOLS = {
 
     "switch_context": {
         "name": "switch_context",
-        "description": "Switch active graph context.",
+        "description": (
+            "Switch active graph context. Refuses while any indexing job is "
+            "PENDING or RUNNING — wait for check_job_status / list_jobs, then retry."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/src/codegraphcontext/tools/languages/php.py
+++ b/src/codegraphcontext/tools/languages/php.py
@@ -230,18 +230,27 @@ class PhpTreeSitterParser:
                         if params_node:
                             # PHP parameters: function($a, $b)
                             for child in params_node.children:
-                                if "variable_name" in child.type or "simple_parameter" in child.type:
-                                     var_node = child if "variable_name" in child.type else child.child_by_field_name("name")
-                                     type_node = child.child_by_field_name("type") if "simple_parameter" in child.type else None
-                                     
-                                     if var_node:
-                                         var_name = self._get_node_text(var_node)
-                                         parameters.append(var_name)
-                                         if type_node:
-                                             var_type = self._get_node_text(type_node)
-                                             # Extract actual type from union/nullable types
-                                             var_type = var_type.lstrip("?").split("|")[0].strip()
-                                             var_type_map[(func_name, var_name)] = var_type
+                                if child.type == "variable_name":
+                                    var_node = child
+                                    type_node = None
+                                elif child.type in (
+                                    "simple_parameter",
+                                    "property_promotion_parameter",
+                                    "variadic_parameter",
+                                ):
+                                    var_node = child.child_by_field_name("name")
+                                    type_node = child.child_by_field_name("type")
+                                else:
+                                    continue
+
+                                if var_node:
+                                    var_name = self._get_node_text(var_node)
+                                    parameters.append(var_name)
+                                    if type_node:
+                                        var_type = self._get_node_text(type_node)
+                                        # Extract actual type from union/nullable types
+                                        var_type = var_type.lstrip("?").split("|")[0].strip()
+                                        var_type_map[(func_name, var_name)] = var_type
 
                         source_text = self._get_node_text(node)
                         

--- a/tests/e2e/test_verify_databases_parity.py
+++ b/tests/e2e/test_verify_databases_parity.py
@@ -182,7 +182,7 @@ async def _run_database_parity_e2e(temp_test_dir):
     project_path = Path("tests/fixtures/sample_projects").resolve()
     
     db_types_to_run = []
-    pkg_map = {"kuzudb": "kuzu", "ladybugdb": "ladybug", "falkordb": "falkordblite", "neo4j": "neo4j"}
+    pkg_map = {"kuzudb": "kuzu", "ladybugdb": "ladybug", "falkordb": "falkordb", "neo4j": "neo4j"}
     for db in ["kuzudb", "ladybugdb", "falkordb", "neo4j"]:
         if importlib.util.find_spec(pkg_map[db]) is None:
             print(f"Skipping {db}: {pkg_map[db]} driver not installed.")

--- a/tests/e2e/test_verify_databases_parity.py
+++ b/tests/e2e/test_verify_databases_parity.py
@@ -178,9 +178,18 @@ async def _run_database_parity_e2e(temp_test_dir):
     os.environ.setdefault('NEO4J_USERNAME', 'neo4j')
     os.environ.setdefault('NEO4J_PASSWORD', '12345678')
     
+    import importlib.util
     project_path = Path("tests/fixtures/sample_projects").resolve()
     
-    db_types = ["kuzudb", "ladybugdb", "falkordb", "neo4j"]
+    db_types_to_run = []
+    pkg_map = {"kuzudb": "kuzu", "ladybugdb": "ladybug", "falkordb": "falkordblite", "neo4j": "neo4j"}
+    for db in ["kuzudb", "ladybugdb", "falkordb", "neo4j"]:
+        if importlib.util.find_spec(pkg_map[db]) is None:
+            print(f"Skipping {db}: {pkg_map[db]} driver not installed.")
+            continue
+        db_types_to_run.append(db)
+        
+    db_types = db_types_to_run
     results = {}
     
     for db_type in db_types:
@@ -198,12 +207,18 @@ async def _run_database_parity_e2e(temp_test_dir):
             
     # Compile comparison and assert parity
     print("\n================= E2E PARITY TEST REPORT =================")
-    print(f"{'Metric':<25} | {'KuzuDB':<8} | {'LadybugDB':<9} | {'FalkorDB':<8} | {'Neo4j':<8} | Match?")
-    print("-" * 78)
+    header_dbs = "".join(f"{db.title():<10} | " for db in db_types)
+    print(f"{'Metric':<25} | {header_dbs}Match?")
+    print("-" * (35 + 13 * len(db_types)))
     
+    if not results:
+        pytest.skip("No database drivers are installed to run parity tests.")
+    
+    # We will use the keys from the first available database as reference
+    ref_db = next(iter(results.values()))
     # REL_CALLS_DISTINCT is a diagnostic, not a parity metric.
     keys_to_compare = sorted(
-        k for k in results["neo4j"]["stats"].keys() if k != "REL_CALLS_DISTINCT"
+        k for k in ref_db["stats"].keys() if k != "REL_CALLS_DISTINCT"
     )
     # Some relationship resolvers dedupe differently across embedded backends.
     # REL_CALLS: KuzuDB/LadybugDB may drop ≤1 edge when the Neo4j fast/slow MATCH
@@ -212,23 +227,21 @@ async def _run_database_parity_e2e(temp_test_dir):
     all_match = True
     
     for key in keys_to_compare:
-        kuzu_val = results["kuzudb"]["stats"].get(key, 0)
-        ladybug_val = results["ladybugdb"]["stats"].get(key, 0)
-        falkor_val = results["falkordb"]["stats"].get(key, 0)
-        neo4j_val = results["neo4j"]["stats"].get(key, 0)
+        vals = [results[db]["stats"].get(key, 0) for db in db_types if db in results]
         
-        spread = max(kuzu_val, ladybug_val, falkor_val, neo4j_val) - min(
-            kuzu_val, ladybug_val, falkor_val, neo4j_val
-        )
+        spread = max(vals) - min(vals) if vals else 0
         matches = spread <= allowed_spread.get(key, 0)
         match_str = "YES" if matches else "NO"
         if not matches:
             all_match = False
             
-        print(f"{key:<25} | {kuzu_val:<8} | {ladybug_val:<9} | {falkor_val:<8} | {neo4j_val:<8} | {match_str}")
+        vals_str = "".join(f"{v:<10} | " for v in vals)
+        print(f"{key:<25} | {vals_str}{match_str}")
         
-    print("-" * 78)
-    print(f"{'Indexing Duration (s)':<25} | {results['kuzudb']['duration']:<8.2f} | {results['ladybugdb']['duration']:<9.2f} | {results['falkordb']['duration']:<8.2f} | {results['neo4j']['duration']:<8.2f} | -")
+    print("-" * (35 + 13 * len(db_types)))
+    
+    dur_str = "".join(f"{results[db]['duration']:<10.2f} | " for db in db_types if db in results)
+    print(f"{'Indexing Duration (s)':<25} | {dur_str}-")
 
     _report_calls_edge_diff(results, db_types)
 

--- a/tests/integration/mcp/test_mcp_server.py
+++ b/tests/integration/mcp/test_mcp_server.py
@@ -229,3 +229,70 @@ class TestMCPServer:
             assert kwargs["repo_path"] == "/some/repo"
 
         asyncio.run(run_test())
+
+    def test_switch_context_refuses_while_job_running(self, mock_server):
+        """#1536: must not tear down the DB under an in-flight indexing job."""
+        from codegraphcontext.core.jobs import JobManager, JobStatus
+
+        jobs = JobManager()
+        job_id = jobs.create_job("/big/monorepo")
+        jobs.update_job(job_id, status=JobStatus.RUNNING)
+        mock_server.job_manager = jobs
+
+        with patch("codegraphcontext.server._teardown_db_manager") as teardown:
+            result = mock_server.switch_context_tool(context_path="global")
+
+        assert "error" in result
+        assert job_id in result["error"]
+        assert result["active_jobs"][0]["job_id"] == job_id
+        assert result["active_jobs"][0]["status"] == "running"
+        assert result["active_jobs"][0]["path"] == "/big/monorepo"
+        teardown.assert_not_called()
+
+    def test_switch_context_refuses_while_job_pending(self, mock_server):
+        """Race window starts at create_job, before pipeline flips to RUNNING."""
+        from codegraphcontext.core.jobs import JobManager
+
+        jobs = JobManager()
+        job_id = jobs.create_job("/still/pending")
+        mock_server.job_manager = jobs
+
+        with patch("codegraphcontext.server._teardown_db_manager") as teardown:
+            result = mock_server.switch_context_tool(context_path="global")
+
+        assert "error" in result
+        assert job_id in result["error"]
+        assert result["active_jobs"][0]["status"] == "pending"
+        teardown.assert_not_called()
+
+    def test_switch_context_global_proceeds_without_active_jobs(self, mock_server):
+        """With no active jobs, switch_context may tear down and rebuild."""
+        from codegraphcontext.core.jobs import JobManager
+        from codegraphcontext.cli.config_manager import ResolvedContext
+
+        mock_server.job_manager = JobManager()
+        mock_server.resolved_context = ResolvedContext(
+            mode="per-repo",
+            context_name="",
+            database="kuzudb",
+            db_path="/tmp/old-db",
+            cgcignore_path="/tmp/.cgcignore",
+            is_local=True,
+        )
+        mock_server.code_watcher = MagicMock()
+        mock_server.code_watcher.observer.is_alive.return_value = False
+
+        new_manager = MagicMock()
+        with patch("codegraphcontext.server._teardown_db_manager") as teardown, \
+             patch("codegraphcontext.server.get_database_manager", return_value=new_manager) as get_db, \
+             patch("codegraphcontext.server.GraphBuilder"), \
+             patch("codegraphcontext.server.CodeFinder"), \
+             patch("codegraphcontext.server.CodeWatcher"), \
+             patch("codegraphcontext.server._default_global_db_path", return_value="/tmp/global-db"), \
+             patch("codegraphcontext.server.load_config", return_value={"DEFAULT_DATABASE": "kuzudb"}):
+            result = mock_server.switch_context_tool(context_path="global")
+
+        assert result.get("status") == "ok", result
+        teardown.assert_called_once()
+        get_db.assert_called_once()
+        new_manager.get_driver.assert_called_once()

--- a/tests/integration/mcp/test_mcp_server.py
+++ b/tests/integration/mcp/test_mcp_server.py
@@ -172,3 +172,60 @@ class TestMCPServer:
             assert result == {"error": "Tool 'find_code' is disabled in mcp.json (disabledTools)."}
 
         asyncio.run(run_test())
+
+    def test_complexity_path_is_not_aliased_into_repo_path(self, mock_server):
+        """#1532: path is a file disambiguator; copying it into repo_path made
+        STARTS WITH never match absolute f.path and returned results: null."""
+        async def run_test():
+            mock_server.calculate_cyclomatic_complexity_tool = MagicMock(
+                return_value={"success": True, "results": {"complexity": 3}}
+            )
+
+            await mock_server.handle_tool_call(
+                "calculate_cyclomatic_complexity",
+                {"function_name": "parse", "path": "src/foo.py"},
+            )
+
+            kwargs = mock_server.calculate_cyclomatic_complexity_tool.call_args.kwargs
+            assert kwargs["function_name"] == "parse"
+            assert kwargs["path"] == "src/foo.py"
+            assert "repo_path" not in kwargs
+
+        asyncio.run(run_test())
+
+    def test_complexity_repo_path_is_not_aliased_into_path(self, mock_server):
+        """Reverse direction was already guarded; keep it that way."""
+        async def run_test():
+            mock_server.calculate_cyclomatic_complexity_tool = MagicMock(
+                return_value={"success": True, "results": {"complexity": 3}}
+            )
+
+            await mock_server.handle_tool_call(
+                "calculate_cyclomatic_complexity",
+                {"function_name": "parse", "repo_path": "/abs/repo"},
+            )
+
+            kwargs = mock_server.calculate_cyclomatic_complexity_tool.call_args.kwargs
+            assert kwargs["function_name"] == "parse"
+            assert kwargs["repo_path"] == "/abs/repo"
+            assert "path" not in kwargs
+
+        asyncio.run(run_test())
+
+    def test_other_tools_still_alias_path_into_repo_path(self, mock_server):
+        """General path/repo_path aliasing must keep working for tools where
+        the two keys mean the same thing."""
+        async def run_test():
+            mock_server.find_code_tool = MagicMock(return_value={"result": "found"})
+
+            await mock_server.handle_tool_call(
+                "find_code",
+                {"query": "x", "path": "/some/repo"},
+            )
+
+            kwargs = mock_server.find_code_tool.call_args.kwargs
+            assert kwargs["query"] == "x"
+            assert kwargs["path"] == "/some/repo"
+            assert kwargs["repo_path"] == "/some/repo"
+
+        asyncio.run(run_test())

--- a/tests/unit/core/test_bundle_repo_scoped_import.py
+++ b/tests/unit/core/test_bundle_repo_scoped_import.py
@@ -1,0 +1,253 @@
+"""
+Regression tests for #1509 — repo-scoped bundle paths collide on import.
+
+Export with --repo rewrites the repo root to '.' and files to './README.md'.
+Import used to write those relative strings into the graph, so:
+
+* _check_existing_repository(path='.') matched any previously imported bundle
+* File MERGE keys collapsed across flask vs requests
+* Function uid built from name+path+line_number collided the same way
+
+Import now rebases '.' / './…' onto a per-bundle destination root. These tests
+mock the driver; they do not need a live graph database.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codegraphcontext.core.cgc_bundle import (
+    CGCBundle,
+    _default_bundle_install_root,
+    _is_bundle_relative_path,
+    _is_identifying_repo_path,
+    _rebase_bundle_path,
+    _sanitize_bundle_repo_slug,
+)
+
+
+def _bundle(backend: str = "falkordb") -> CGCBundle:
+    db_manager = MagicMock()
+    db_manager.get_backend_type.return_value = backend
+    return CGCBundle(db_manager)
+
+
+def _session_for(bundle: CGCBundle) -> MagicMock:
+    session = MagicMock()
+    bundle.db_manager.get_driver.return_value.session.return_value.__enter__.return_value = session
+    return session
+
+
+def _empty_result():
+    result = MagicMock()
+    result.single.return_value = None
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (".", True),
+        ("./", True),
+        (".\\", True),
+        ("./README.md", True),
+        (".\\src\\a.py", True),
+        ("./src/foo.py", True),
+        ("/abs/flask", False),
+        ("os.path", False),
+        ("E:/repo", False),
+        ("C:/Users/hp/project", False),
+        ("", False),
+        (None, False),
+        ("README.md", False),
+    ],
+)
+def test_is_bundle_relative_path(val, expected):
+    assert _is_bundle_relative_path(val) is expected
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (None, False),
+        ("", False),
+        (".", False),
+        ("./README.md", False),
+        ("/abs/flask", True),
+        ("C:/Users/hp/.codegraphcontext/bundles/flask", True),
+    ],
+)
+def test_is_identifying_repo_path(val, expected):
+    assert _is_identifying_repo_path(val) is expected
+
+
+def test_rebase_dot_is_dest_root():
+    assert _rebase_bundle_path(".", "/dest/flask") == "/dest/flask"
+
+
+def test_rebase_posix_relative_file():
+    assert _rebase_bundle_path("./README.md", "/dest/flask") == "/dest/flask/README.md"
+
+
+def test_rebase_windows_relative_file():
+    assert _rebase_bundle_path(".\\src\\a.py", "/dest/flask") == "/dest/flask/src/a.py"
+
+
+def test_rebase_leaves_absolute_paths_alone():
+    assert _rebase_bundle_path("/abs/flask", "/dest/x") == "/abs/flask"
+    assert _rebase_bundle_path("os.path", "/dest/x") == "os.path"
+    assert _rebase_bundle_path("E:/repo", "/dest/x") == "E:/repo"
+
+
+def test_slug_owner_slash_repo():
+    assert _sanitize_bundle_repo_slug("pallets/flask") == "pallets__flask"
+
+
+def test_slug_empty_falls_back_to_unknown():
+    assert _sanitize_bundle_repo_slug("") == "unknown"
+    assert _sanitize_bundle_repo_slug(None) == "unknown"
+
+
+def test_default_install_root_uses_home_and_slug(tmp_path):
+    root = _default_bundle_install_root({"repo": "pallets/flask"}, tmp_path)
+    assert root == (tmp_path / "pallets__flask").resolve().as_posix()
+
+
+# ---------------------------------------------------------------------------
+# _check_existing_repository
+# ---------------------------------------------------------------------------
+
+
+def test_check_existing_skips_dot_path_match():
+    """path='.' must not issue MATCH (r:Repository {path: $path})."""
+    bundle = _bundle()
+    session = _session_for(bundle)
+    session.run.return_value = _empty_result()
+
+    found = bundle._check_existing_repository("requests", ".")
+
+    assert found is False
+    queries = [call.args[0] for call in session.run.call_args_list]
+    assert any("name: $name" in q for q in queries)
+    assert not any("{path: $path}" in q for q in queries)
+
+
+def test_check_existing_still_matches_absolute_path():
+    bundle = _bundle()
+    session = _session_for(bundle)
+    session.run.return_value = _empty_result()
+
+    bundle._check_existing_repository("flask", "/abs/flask")
+
+    queries = [call.args[0] for call in session.run.call_args_list]
+    assert any("{path: $path}" in q for q in queries)
+    path_call = next(c for c in session.run.call_args_list if "{path: $path}" in c.args[0])
+    assert path_call.kwargs["path"] == "/abs/flask"
+
+
+def test_check_existing_name_match_still_runs():
+    bundle = _bundle()
+    session = _session_for(bundle)
+    name_hit = MagicMock()
+    name_hit.single.return_value = {"r": object()}
+    session.run.return_value = name_hit
+
+    assert bundle._check_existing_repository("flask", ".") is True
+    assert session.run.call_count == 1
+    assert "name: $name" in session.run.call_args.args[0]
+    assert session.run.call_args.kwargs["name"] == "flask"
+
+
+# ---------------------------------------------------------------------------
+# _import_node_batch — File PK uniqueness + uid
+# ---------------------------------------------------------------------------
+
+
+def _pk_vals(session: MagicMock):
+    return [c.kwargs["pk_val"] for c in session.run.call_args_list if "pk_val" in c.kwargs]
+
+
+def test_file_rows_with_same_relative_path_get_distinct_merge_keys():
+    flask_root = "/dest/flask"
+    requests_root = "/dest/requests"
+    row = (["File"], {"path": "./README.md"}, "1")
+
+    flask_session = MagicMock()
+    flask_session.run.return_value.single.return_value = {"new_id": 1}
+    _bundle()._import_node_batch(flask_session, [row], {}, flask_root)
+
+    requests_session = MagicMock()
+    requests_session.run.return_value.single.return_value = {"new_id": 1}
+    _bundle()._import_node_batch(
+        requests_session, [(["File"], {"path": "./README.md"}, "1")], {}, requests_root
+    )
+
+    flask_pk = _pk_vals(flask_session)[0]
+    requests_pk = _pk_vals(requests_session)[0]
+    assert flask_pk == f"{flask_root}/README.md"
+    assert requests_pk == f"{requests_root}/README.md"
+    assert flask_pk != requests_pk
+
+
+def test_function_uid_includes_dest_root_not_relative_path():
+    dest = "/dest/flask"
+    session = MagicMock()
+    session.run.return_value.single.return_value = {"new_id": 1}
+    props = {"name": "parse", "path": "./src/foo.py", "line_number": 12, "uid": "parse./src/foo.py12"}
+
+    _bundle()._import_node_batch(session, [(["Function"], props, "1")], {}, dest)
+
+    pk = _pk_vals(session)[0]
+    assert dest in pk
+    assert "./" not in pk
+    assert pk == f"parse{dest}/src/foo.py12"
+
+
+def test_absolute_paths_are_unchanged_when_not_repo_scoped():
+    session = MagicMock()
+    session.run.return_value.single.return_value = {"new_id": 1}
+    abs_path = "/home/me/numpy/core.py"
+
+    _bundle()._import_node_batch(
+        session, [(["File"], {"path": abs_path}, "1")], {}, dest_root=None
+    )
+
+    assert _pk_vals(session)[0] == abs_path
+
+
+def test_absolute_paths_are_unchanged_even_with_dest_root():
+    session = MagicMock()
+    session.run.return_value.single.return_value = {"new_id": 1}
+    abs_path = "/home/me/numpy/core.py"
+
+    _bundle()._import_node_batch(
+        session, [(["File"], {"path": abs_path}, "1")], {}, dest_root="/dest/numpy"
+    )
+
+    assert _pk_vals(session)[0] == abs_path
+
+
+# ---------------------------------------------------------------------------
+# _delete_repository
+# ---------------------------------------------------------------------------
+
+
+def test_delete_repository_noops_when_path_is_dot():
+    bundle = _bundle()
+    session = _session_for(bundle)
+    found = MagicMock()
+    found.single.return_value = {"path": "."}
+    session.run.return_value = found
+
+    bundle._delete_repository("flask")
+
+    assert session.run.call_count == 1, (
+        "DETACH DELETE must not run when r.path is '.' — that would wipe "
+        "every repo-scoped bundle import"
+    )
+    assert "DETACH DELETE" not in session.run.call_args.args[0]

--- a/tests/unit/core/test_jobs.py
+++ b/tests/unit/core/test_jobs.py
@@ -33,3 +33,20 @@ class TestJobManager:
         job = manager.get_job("non_existent_id")
         assert job is None
 
+    def test_list_active_jobs_includes_pending_and_running_only(self):
+        """#1536: switch_context must see PENDING as well as RUNNING."""
+        manager = JobManager()
+        pending_id = manager.create_job("/pending")
+        running_id = manager.create_job("/running")
+        done_id = manager.create_job("/done")
+        failed_id = manager.create_job("/failed")
+        cancelled_id = manager.create_job("/cancelled")
+
+        manager.update_job(running_id, status=JobStatus.RUNNING)
+        manager.update_job(done_id, status=JobStatus.COMPLETED)
+        manager.update_job(failed_id, status=JobStatus.FAILED)
+        manager.update_job(cancelled_id, status=JobStatus.CANCELLED)
+
+        active_ids = {job.job_id for job in manager.list_active_jobs()}
+        assert active_ids == {pending_id, running_id}
+

--- a/tests/unit/parsers/test_php_parser.py
+++ b/tests/unit/parsers/test_php_parser.py
@@ -5,6 +5,16 @@ from codegraphcontext.tools.languages.php import PhpTreeSitterParser
 from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
 
 
+@pytest.fixture(scope="module")
+def parser():
+    manager = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "php"
+    wrapper.language = manager.get_language_safe("php")
+    wrapper.parser = manager.create_parser("php")
+    return PhpTreeSitterParser(wrapper)
+
+
 class TestPhpImports:
     """PHP `use` handling.
 
@@ -12,15 +22,6 @@ class TestPhpImports:
     use inside a class body — not a top-level import. That dropped every real
     import and labelled trait uses as imports instead.
     """
-
-    @pytest.fixture(scope="class")
-    def parser(self):
-        manager = get_tree_sitter_manager()
-        wrapper = MagicMock()
-        wrapper.language_name = "php"
-        wrapper.language = manager.get_language_safe("php")
-        wrapper.parser = manager.create_parser("php")
-        return PhpTreeSitterParser(wrapper)
 
     def _imports(self, parser, tmp_path, code):
         f = tmp_path / "sample.php"
@@ -82,3 +83,22 @@ class TestPhpImports:
         )
         imports = self._imports(parser, tmp_path, code)
         assert [i["line_number"] for i in imports] == [2, 3, 4]
+
+
+def test_promoted_and_variadic_parameters(parser, tmp_path):
+    code = (
+        "<?php\n"
+        "class Service {\n"
+        "    public function __construct(private string $dsn) {}\n"
+        "}\n"
+        "function all(...$filters) {}\n"
+    )
+    f = tmp_path / "parameters.php"
+    f.write_text(code, encoding="utf-8")
+
+    functions = parser.parse(str(f))["functions"]
+
+    assert {function["name"]: function["parameters"] for function in functions} == {
+        "__construct": ["$dsn"],
+        "all": ["$filters"],
+    }


### PR DESCRIPTION
Resolves #549
This PR updates our CI pipelines to ensure End-to-End tests are validated against all supported Operating Systems natively, rather than just Linux.
***
#### **What changed:**
1. **GitHub Actions Workflow Matrix:**
   - Updated `.github/workflows/e2e-tests.yml` to use a `matrix` strategy covering `ubuntu-latest`, `macos-latest`, and `windows-latest`.
   - Explicitly configured the E2E test execution step to use `shell: bash`. This allows the existing `./tests/run_tests.sh` script to execute flawlessly on Windows runners using Git Bash.

2. **Graceful Database Driver Fallbacks:**
   - Modified `test_verify_databases_parity.py` to dynamically detect which database drivers are available on the current OS (`falkordblite`, `kuzu`, etc.).
   - Parity tests now gracefully skip unsupported backends instead of crashing with `StopIteration` or `KeyError` on systems where they aren't installed (e.g., `falkordblite` on Windows).
   - The parity results table dynamically updates its columns based solely on the available drivers.

#### **How to verify:**
- Push to this branch and observe the GitHub Actions tab.
- Verify that the `End-to-end Tests` workflow spawns three separate jobs for Ubuntu, macOS, and Windows.
- Confirm all three jobs pass successfully.

#### 📸 **Screenshots (CI Results):**
<img width="1232" height="502" alt="image" src="https://github.com/user-attachments/assets/b3cfaa63-c3e0-48e6-81ad-8c15f9252664" />
***