### PR TITLE
fix(cli/mcp): stop path→repo_path alias from breaking calculate_cyclomatic_complexity (#1532)

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -692,10 +692,14 @@ class MCPServer:
         # different meanings (path = file path, repo_path = repo filter).
         if isinstance(args, dict):
             args = dict(args)
+            # path_means_file: for these tools `path` is a file disambiguator and
+            # `repo_path` is a separate repo-prefix filter. Aliasing either way
+            # collapses the two meanings (#1532: path → repo_path made
+            # calculate_cyclomatic_complexity return null).
             path_means_file = tool_name in ("calculate_cyclomatic_complexity",)
             if "repo_path" in args and "path" not in args and not path_means_file:
                 args["path"] = args["repo_path"]
-            elif "path" in args and "repo_path" not in args:
+            elif "path" in args and "repo_path" not in args and not path_means_file:
                 args["repo_path"] = args["path"]
 
         tool_map: Dict[str, Coroutine] = {

--- a/tests/integration/mcp/test_mcp_server.py
+++ b/tests/integration/mcp/test_mcp_server.py
@@ -172,3 +172,60 @@ class TestMCPServer:
             assert result == {"error": "Tool 'find_code' is disabled in mcp.json (disabledTools)."}
 
         asyncio.run(run_test())
+
+    def test_complexity_path_is_not_aliased_into_repo_path(self, mock_server):
+        """#1532: path is a file disambiguator; copying it into repo_path made
+        STARTS WITH never match absolute f.path and returned results: null."""
+        async def run_test():
+            mock_server.calculate_cyclomatic_complexity_tool = MagicMock(
+                return_value={"success": True, "results": {"complexity": 3}}
+            )
+
+            await mock_server.handle_tool_call(
+                "calculate_cyclomatic_complexity",
+                {"function_name": "parse", "path": "src/foo.py"},
+            )
+
+            kwargs = mock_server.calculate_cyclomatic_complexity_tool.call_args.kwargs
+            assert kwargs["function_name"] == "parse"
+            assert kwargs["path"] == "src/foo.py"
+            assert "repo_path" not in kwargs
+
+        asyncio.run(run_test())
+
+    def test_complexity_repo_path_is_not_aliased_into_path(self, mock_server):
+        """Reverse direction was already guarded; keep it that way."""
+        async def run_test():
+            mock_server.calculate_cyclomatic_complexity_tool = MagicMock(
+                return_value={"success": True, "results": {"complexity": 3}}
+            )
+
+            await mock_server.handle_tool_call(
+                "calculate_cyclomatic_complexity",
+                {"function_name": "parse", "repo_path": "/abs/repo"},
+            )
+
+            kwargs = mock_server.calculate_cyclomatic_complexity_tool.call_args.kwargs
+            assert kwargs["function_name"] == "parse"
+            assert kwargs["repo_path"] == "/abs/repo"
+            assert "path" not in kwargs
+
+        asyncio.run(run_test())
+
+    def test_other_tools_still_alias_path_into_repo_path(self, mock_server):
+        """General path/repo_path aliasing must keep working for tools where
+        the two keys mean the same thing."""
+        async def run_test():
+            mock_server.find_code_tool = MagicMock(return_value={"result": "found"})
+
+            await mock_server.handle_tool_call(
+                "find_code",
+                {"query": "x", "path": "/some/repo"},
+            )
+
+            kwargs = mock_server.find_code_tool.call_args.kwargs
+            assert kwargs["query"] == "x"
+            assert kwargs["path"] == "/some/repo"
+            assert kwargs["repo_path"] == "/some/repo"
+
+        asyncio.run(run_test())


### PR DESCRIPTION
## Summary

Fixes #1532 (GSSoC'26).

The MCP dispatcher in `server.py` aliases `path` and `repo_path` in both directions so tools that only declare one of those keys still work. For `calculate_cyclomatic_complexity`, those keys mean different things: `path` is an optional **file** path used to disambiguate a function, and `repo_path` is a separate **repository prefix** filter.

`path_means_file` already skipped the `repo_path → path` direction for this tool, but the reverse `path → repo_path` branch still ran. Passing the documented disambiguation arg therefore copied the file path into `repo_path`. The Cypher query then required `f.path STARTS WITH $repo_path` on an absolute stored path, which never matched, and the tool returned `results: null` for a function that exists. Omitting `path` worked — so the schema-documented parameter was the thing that broke the call.

## Problem

Captured params for `calculate_cyclomatic_complexity(function_name="parse", path="src/foo.py")` before the fix:

```
{'function_name': 'parse', 'path': 'src/foo.py', 'repo_path': 'src/foo.py'}
```

Handler query shape:

```
WHERE (f.path ENDS WITH $path OR f.path = $path)
  AND f.path STARTS WITH $repo_path
```

Stored `f.path` is absolute (`FILE_MERGE_KEYS`), so `STARTS WITH 'src/foo.py'` is never true.

## Solution

Apply the existing `path_means_file` guard to **both** alias directions for `calculate_cyclomatic_complexity`:

- `path` alone stays a file disambiguator (no invented `repo_path`)
- `repo_path` alone stays a repo filter (no invented `path`)
- both provided together are left unchanged
- other tools (e.g. `find_code`) still alias `path` ↔ `repo_path` as before

No changes to `analysis_handlers.py`, `code_finder.py`, or tool schemas. The Cypher is correct when `repo_path` is only set when the agent truly means a repo prefix.

## Files changed

- `src/codegraphcontext/server.py` — guard `path → repo_path` with `path_means_file` in `handle_tool_call`
- `tests/integration/mcp/test_mcp_server.py` — regression tests for complexity aliasing and a control case for other tools

## Tests performed

Command:

python -m pytest tests/integration/mcp/test_mcp_server.py::TestMCPServer::test_complexity_path_is_not_aliased_into_repo_path tests/integration/mcp/test_mcp_server.py::TestMCPServer::test_complexity_repo_path_is_not_aliased_into_path tests/integration/mcp/test_mcp_server.py::TestMCPServer::test_other_tools_still_alias_path_into_repo_path tests/integration/mcp/test_mcp_server.py tests/unit/test_tool_definitions.py tests/unit/tools/test_mcp_contracts.py -q

Result: 19 passed (full MCP server + contracts slice); the three new regression cases pass on their own as well.

Covered:

- `path="src/foo.py"` does not invent `repo_path`
- `repo_path="/abs/repo"` does not invent `path`
- `find_code` with `path="/some/repo"` still aliases into `repo_path`

## Checklist

- Focused on a single bug (#1532)
- Tests added for the fix
- Linked to the issue
- Branched from / rebased onto upstream/main
