### PR TITLE
Fix broken star history chart in README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ flowchart LR
 ---
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://star-history.dera.page/#CodeGraphContext/CodeGraphContext&Date)
 
 ---
 

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -119,7 +119,7 @@
 ---
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://star-history.dera.page/#CodeGraphContext/CodeGraphContext&Date)
 
 ---
 

--- a/docs/translations/README.kor.md
+++ b/docs/translations/README.kor.md
@@ -118,7 +118,7 @@
 ---
 
 ## Star 기록
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://star-history.dera.page/#CodeGraphContext/CodeGraphContext&Date)
 
 ---
 

--- a/docs/translations/README.ru-RU.md
+++ b/docs/translations/README.ru-RU.md
@@ -118,7 +118,7 @@
 ---
 
 ## Динамика звезд
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://star-history.dera.page/#CodeGraphContext/CodeGraphContext&Date)
 
 ---
 

--- a/docs/translations/README.ta.md
+++ b/docs/translations/README.ta.md
@@ -122,7 +122,7 @@
 ---
 
 ## நட்சத்திர வரலாறு
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://star-history.dera.page/#CodeGraphContext/CodeGraphContext&Date)
 
 ---
 

--- a/docs/translations/README.uk.md
+++ b/docs/translations/README.uk.md
@@ -118,7 +118,7 @@
 ---
 
 ## Історія зірок
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://star-history.dera.page/#CodeGraphContext/CodeGraphContext&Date)
 
 ---
 

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -118,7 +118,7 @@
 ---
 
 ## Star 历史
-[![Star 历史图表](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[![Star 历史图表](https://star-history.dera.page/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://star-history.dera.page/#CodeGraphContext/CodeGraphContext&Date)
 
 ---
 

--- a/website/src/components/ShowStarGraph.tsx
+++ b/website/src/components/ShowStarGraph.tsx
@@ -11,7 +11,7 @@ export default function ShowStarGraph() {
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const baseStarHistoryImageUrl =
-    "https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date";
+    "https://star-history.dera.page/svg?repos=CodeGraphContext/CodeGraphContext&type=Date";
 
   // Add cache busting parameter to force updates
   const starHistoryImageUrl = `${baseStarHistoryImageUrl}&t=${refreshKey}`;
@@ -19,7 +19,7 @@ export default function ShowStarGraph() {
 
   const githubRepoUrl = "https://github.com/CodeGraphContext/CodeGraphContext";
   const starHistoryUrl =
-    "https://star-history.com/#CodeGraphContext/CodeGraphContext&Date";
+    "https://star-history.dera.page/#CodeGraphContext/CodeGraphContext&Date";
 
   const handleImageLoad = () => {
     setImageLoaded(true);


### PR DESCRIPTION
The star history chart is currently broken because the underlying GitHub stargazer API can no longer be used without a token. This change repoints the chart (and its wrapping links) to a working mirror that needs no token, restoring the star history visualization across the README, its translations, and the website. The chart fix is necessary for the project's growth graph to display correctly again.