### PR TITLE
fix(php): extract promoted and variadic parameters

### DIFF
--- a/src/codegraphcontext/tools/languages/php.py
+++ b/src/codegraphcontext/tools/languages/php.py
@@ -230,18 +230,27 @@ class PhpTreeSitterParser:
                         if params_node:
                             # PHP parameters: function($a, $b)
                             for child in params_node.children:
-                                if "variable_name" in child.type or "simple_parameter" in child.type:
-                                     var_node = child if "variable_name" in child.type else child.child_by_field_name("name")
-                                     type_node = child.child_by_field_name("type") if "simple_parameter" in child.type else None
-                                     
-                                     if var_node:
-                                         var_name = self._get_node_text(var_node)
-                                         parameters.append(var_name)
-                                         if type_node:
-                                             var_type = self._get_node_text(type_node)
-                                             # Extract actual type from union/nullable types
-                                             var_type = var_type.lstrip("?").split("|")[0].strip()
-                                             var_type_map[(func_name, var_name)] = var_type
+                                if child.type == "variable_name":
+                                    var_node = child
+                                    type_node = None
+                                elif child.type in (
+                                    "simple_parameter",
+                                    "property_promotion_parameter",
+                                    "variadic_parameter",
+                                ):
+                                    var_node = child.child_by_field_name("name")
+                                    type_node = child.child_by_field_name("type")
+                                else:
+                                    continue
+
+                                if var_node:
+                                    var_name = self._get_node_text(var_node)
+                                    parameters.append(var_name)
+                                    if type_node:
+                                        var_type = self._get_node_text(type_node)
+                                        # Extract actual type from union/nullable types
+                                        var_type = var_type.lstrip("?").split("|")[0].strip()
+                                        var_type_map[(func_name, var_name)] = var_type
 
                         source_text = self._get_node_text(node)
                         

--- a/tests/unit/parsers/test_php_parser.py
+++ b/tests/unit/parsers/test_php_parser.py
@@ -5,6 +5,16 @@ from codegraphcontext.tools.languages.php import PhpTreeSitterParser
 from codegraphcontext.utils.tree_sitter_manager import get_tree_sitter_manager
 
 
+@pytest.fixture(scope="module")
+def parser():
+    manager = get_tree_sitter_manager()
+    wrapper = MagicMock()
+    wrapper.language_name = "php"
+    wrapper.language = manager.get_language_safe("php")
+    wrapper.parser = manager.create_parser("php")
+    return PhpTreeSitterParser(wrapper)
+
+
 class TestPhpImports:
     """PHP `use` handling.
 
@@ -12,15 +22,6 @@ class TestPhpImports:
     use inside a class body — not a top-level import. That dropped every real
     import and labelled trait uses as imports instead.
     """
-
-    @pytest.fixture(scope="class")
-    def parser(self):
-        manager = get_tree_sitter_manager()
-        wrapper = MagicMock()
-        wrapper.language_name = "php"
-        wrapper.language = manager.get_language_safe("php")
-        wrapper.parser = manager.create_parser("php")
-        return PhpTreeSitterParser(wrapper)
 
     def _imports(self, parser, tmp_path, code):
         f = tmp_path / "sample.php"
@@ -82,3 +83,22 @@ class TestPhpImports:
         )
         imports = self._imports(parser, tmp_path, code)
         assert [i["line_number"] for i in imports] == [2, 3, 4]
+
+
+def test_promoted_and_variadic_parameters(parser, tmp_path):
+    code = (
+        "<?php\n"
+        "class Service {\n"
+        "    public function __construct(private string $dsn) {}\n"
+        "}\n"
+        "function all(...$filters) {}\n"
+    )
+    f = tmp_path / "parameters.php"
+    f.write_text(code, encoding="utf-8")
+
+    functions = parser.parse(str(f))["functions"]
+
+    assert {function["name"]: function["parameters"] for function in functions} == {
+        "__construct": ["$dsn"],
+        "all": ["$filters"],
+    }


### PR DESCRIPTION
## Summary

- recognize `property_promotion_parameter` and `variadic_parameter` nodes during PHP function parsing
- retain type extraction for the newly handled parameter shapes
- cover promoted constructor and variadic parameters with a focused regression

Addresses the remaining PHP parameter case in #1527. The independent C++ lambda case remains open.

## Test

```console
PYTHONPATH=src uv run --isolated --no-project --with pytest --with pytest-mock --with tree-sitter==0.25.2 --with "tree-sitter-language-pack>=1.6,<2" pytest -q tests/unit/parsers/test_php_parser.py
7 passed in 0.11s
```