### PR TITLE
fix(kuzu): build-system and datasource graphs never wrote on embedded backends

### DIFF
--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -1524,9 +1524,9 @@ cgc import <bundle-file>.cgc
     # not a slow path, it is a hard import failure for any bundle containing
     # that label (#1322).
     #
-    # Not yet covered: DbColumn PK(name, table_fqn) and RedisKeyPattern
-    # PK(pattern, datasource_name). Composite keys need a multi-key MERGE and a
-    # wider `_node_lookup_key` tuple; tracked separately.
+    # DbColumn and RedisKeyPattern had composite natural keys, which Kùzu
+    # cannot declare as a PRIMARY KEY; they are keyed on a synthesized uid
+    # (name+table_fqn / pattern+datasource_name) like the positional labels.
     _PK_MAP = {
         'Repository': 'path', 'File': 'path', 'Directory': 'path',
         'Module': 'name',
@@ -1536,7 +1536,9 @@ cgc import <bundle-file>.cgc
         'Annotation': 'uid', 'Record': 'uid', 'Property': 'uid',
         'Parameter': 'uid', 'EnumMember': 'uid', 'Mixin': 'uid',
         'Extension': 'uid', 'Object': 'uid',
-        'DbTable': 'name', 'Datasource': 'name', 'ExternalClass': 'name',
+        'DbTable': 'fqn', 'Datasource': 'name', 'ExternalClass': 'name',
+        'DbColumn': 'uid', 'RedisKeyPattern': 'uid',
+        'GradleModule': 'name', 'MavenModule': 'uid', 'ExternalLibrary': 'uid',
     }
     _UID_PARTS = {
         'Function': ['name', 'path', 'line_number', 'occurrence_index'],
@@ -1556,6 +1558,10 @@ cgc import <bundle-file>.cgc
         'Mixin': ['name', 'path', 'line_number', 'occurrence_index'],
         'Extension': ['name', 'path', 'line_number', 'occurrence_index'],
         'Object': ['name', 'path', 'line_number', 'occurrence_index'],
+        'DbColumn': ['name', 'table_fqn'],
+        'RedisKeyPattern': ['pattern', 'datasource_name'],
+        'MavenModule': ['group_id', 'artifact_id'],
+        'ExternalLibrary': ['group_id', 'artifact_id'],
     }
 
     def _import_node_batch(

--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -191,11 +191,17 @@ class EmbeddedGraphManager(GraphQueryInterface):
             ("Mixin", "uid STRING, name STRING, path STRING, line_number INT64, occurrence_index INT64, end_line INT64, source STRING, docstring STRING, lang STRING, is_dependency BOOLEAN, PRIMARY KEY (uid)"),
             ("Extension", "uid STRING, name STRING, path STRING, line_number INT64, occurrence_index INT64, end_line INT64, source STRING, docstring STRING, lang STRING, is_dependency BOOLEAN, PRIMARY KEY (uid)"),
             ("Object", "uid STRING, name STRING, path STRING, line_number INT64, occurrence_index INT64, end_line INT64, source STRING, docstring STRING, lang STRING, is_dependency BOOLEAN, decorators STRING[], visibility STRING, modifiers STRING[], PRIMARY KEY (uid)"),
-            ("DbTable", "name STRING, fqn STRING, datasource_name STRING, path STRING, PRIMARY KEY (name)"),
+            ("DbTable", "fqn STRING, name STRING, datasource_name STRING, table_type STRING, comment STRING, path STRING, PRIMARY KEY (fqn)"),
             ("Datasource", "name STRING, kind STRING, host STRING, env STRING, PRIMARY KEY (name)"),
-            ("DbColumn", "name STRING, table_fqn STRING, type STRING, nullable BOOLEAN, datasource_name STRING, is_primary_key BOOLEAN, PRIMARY KEY (name, table_fqn)"),
-            ("RedisKeyPattern", "pattern STRING, datasource_name STRING, key_type STRING, example_key STRING, count INT64, PRIMARY KEY (pattern, datasource_name)"),
-            ("ExternalClass", "name STRING, path STRING, PRIMARY KEY (name)")
+            ("DbColumn", "uid STRING, name STRING, table_fqn STRING, type STRING, nullable BOOLEAN, datasource_name STRING, is_primary_key BOOLEAN, PRIMARY KEY (uid)"),
+            ("RedisKeyPattern", "uid STRING, pattern STRING, datasource_name STRING, key_type STRING, example_key STRING, count INT64, PRIMARY KEY (uid)"),
+            ("ExternalClass", "name STRING, path STRING, PRIMARY KEY (name)"),
+            # Build-system entities (#1603): these were never declared, so the
+            # whole Gradle/Maven build graph silently failed to write on the
+            # embedded backends. Composite natural keys use a synthesized uid.
+            ("GradleModule", "name STRING, build_file STRING, path STRING, repo_path STRING, PRIMARY KEY (name)"),
+            ("MavenModule", "uid STRING, group_id STRING, artifact_id STRING, version STRING, packaging STRING, pom_path STRING, path STRING, repo_path STRING, PRIMARY KEY (uid)"),
+            ("ExternalLibrary", "uid STRING, group_id STRING, artifact_id STRING, version STRING, PRIMARY KEY (uid)")
         ]
         
         # rel_tables: list of (table_name, schema, use_group)
@@ -299,6 +305,27 @@ class EmbeddedGraphManager(GraphQueryInterface):
             ("STORED_IN", "FROM DbTable TO Datasource, FROM RedisKeyPattern TO Datasource", True),
             ("HAS_COLUMN", "FROM DbTable TO DbColumn", False),
         ]
+
+        # Legacy Kùzu databases may carry a DbTable created with PRIMARY KEY
+        # (name) before #1393-era fixes; the writer merges DbTable on `fqn`,
+        # so that shape never received a row. Drop the empty legacy table so
+        # the CREATE below rebuilds it keyed on fqn. Only an *empty* table is
+        # dropped -- a populated one is left untouched.
+        try:
+            info = self._conn.execute("CALL TABLE_INFO('DbTable') RETURN *")
+            legacy_pk_name = False
+            while info.has_next():
+                row = info.get_next()
+                if row[1] == "name" and row[-1]:
+                    legacy_pk_name = True
+            if legacy_pk_name:
+                count_res = self._conn.execute("MATCH (n:DbTable) RETURN count(n)")
+                empty = count_res.get_next()[0] == 0 if count_res.has_next() else True
+                if empty:
+                    self._conn.execute("DROP TABLE DbTable")
+                    debug_log("Dropped empty legacy DbTable (PK name) for rebuild keyed on fqn")
+        except Exception:
+            pass  # table absent -- nothing to migrate
 
         for table_name, schema in node_tables:
             try:
@@ -425,6 +452,10 @@ class EmbeddedGraphManager(GraphQueryInterface):
             ("PART_OF", "FROM File TO File", False),
             ("BINDS", "FROM Interface TO Class, FROM Class TO Class, FROM Interface TO Interface, line_number INT64, provider STRING, confidence_label STRING", True),
             ("PREVIEWS", "FROM Function TO Function, line_number INT64", False),
+            # Build-system relationships (#1603)
+            ("MODULE_DEPENDS_ON", "FROM GradleModule TO GradleModule, FROM MavenModule TO MavenModule, configuration STRING, scope STRING", True),
+            ("USES_LIBRARY", "FROM GradleModule TO ExternalLibrary, FROM MavenModule TO ExternalLibrary, configuration STRING, scope STRING", True),
+            ("CHILD_MODULE", "FROM MavenModule TO MavenModule", False),
         ]
         for table_name, schema, use_group in rel_table_migrations:
             try:
@@ -614,7 +645,13 @@ class EmbeddedSessionWrapper:
             'Parameter': ['name', 'path', 'function_line_number'],
             'Mixin': ['name', 'path', 'line_number', 'occurrence_index'],
             'Extension': ['name', 'path', 'line_number', 'occurrence_index'],
-            'Object': ['name', 'path', 'line_number', 'occurrence_index']
+            'Object': ['name', 'path', 'line_number', 'occurrence_index'],
+            # Datasource entities: Kùzu cannot declare composite primary keys,
+            # so these tables are keyed on a synthesized uid (#see write_datasource_graph)
+            'DbColumn': ['name', 'table_fqn'],
+            'RedisKeyPattern': ['pattern', 'datasource_name'],
+            'MavenModule': ['group_id', 'artifact_id'],
+            'ExternalLibrary': ['group_id', 'artifact_id']
         }
     
     def __enter__(self):
@@ -815,6 +852,19 @@ class EmbeddedSessionWrapper:
                         props_used = set(re.findall(rf'{row_var}\.(\w+)', loop_query))
                         for p in props_used:
                             loop_query = loop_query.replace(f"{row_var}.{p}", f"${row_var}_{p}")
+                        # The row var itself may still appear bare in WITH lists
+                        # ("WITH tbl, t") once the UNWIND is gone; a dangling
+                        # reference binder-errors and the row is silently
+                        # dropped. Scrub it from WITH clauses.
+                        loop_query = re.sub(
+                            rf'(WITH\s+[^\n]*?),\s*{row_var}\b(?!\.)', r'\1', loop_query
+                        )
+                        loop_query = re.sub(
+                            rf'WITH\s+{row_var}\s*,\s*', 'WITH ', loop_query
+                        )
+                        loop_query = re.sub(
+                            rf'WITH\s+{row_var}\b(?!\.)\s*\n', 'WITH 1 AS _row_scrubbed\n', loop_query
+                        )
                         
                         last_result = None
                         for item in batch_data:
@@ -844,7 +894,7 @@ class EmbeddedSessionWrapper:
             'File': 'path',
             'Directory': 'path',
             'Module': 'name',
-            'DbTable': 'name',
+            'DbTable': 'fqn',
             'ExternalClass': 'name'
         }
         
@@ -1016,9 +1066,26 @@ class EmbeddedSessionWrapper:
                          # Kuzu node tables are keyed by uid for these labels, so MERGE
                          # should match on the primary key only. Matching on additional
                          # non-PK fields can still lead to duplicate PK insert attempts.
+                         # The displaced pattern properties must be re-applied with an
+                         # explicit SET, though: unlike Neo4j, the uid-only MERGE no
+                         # longer assigns them on create, and queries whose follow-up
+                         # SET does not repeat them (e.g. MavenModule/ExternalLibrary
+                         # writes) would otherwise leave the key columns NULL and break
+                         # every later MATCH on them.
+                         displaced_pairs = [
+                             (k.strip(), v.strip())
+                             for k, v in re.findall(r'(\w+)\s*:\s*([^,{}]+)', props_str)
+                             if k.strip() != 'uid'
+                         ]
+                         displaced_set = ''
+                         if displaced_pairs:
+                             assignments = ', '.join(
+                                 f"{var_name}.{k} = {v}" for k, v in displaced_pairs
+                             )
+                             displaced_set = f" SET {assignments}"
                          query = re.sub(
                              rf"MERGE\s+\({re.escape(var_name)}:{re.escape(label_raw)}\s*\{{[^}}]*uid:\s*{re.escape(row_var)}\.uid[^}}]*\}}\)",
-                             f"MERGE ({var_name}:{label_raw} {{uid: {row_var}.uid}})",
+                             f"MERGE ({var_name}:{label_raw} {{uid: {row_var}.uid}}){displaced_set}",
                              query,
                              count=1,
                          )

--- a/src/codegraphcontext/tools/languages/gradle.py
+++ b/src/codegraphcontext/tools/languages/gradle.py
@@ -164,8 +164,12 @@ class GradleParser:
                 "configuration": configuration,
             })
 
-        # Extract inter-module project dependencies
-        for m in re.finditer(r"""(\w+)\s+project\(['"]:([\w.\-/:]+)['"]\)""", source):
+        # Extract inter-module project dependencies. The configuration may be
+        # followed by whitespace (Groovy: `implementation project(":x")`) or an
+        # opening paren (Kotlin DSL: `implementation(project(":x"))`); requiring
+        # whitespace made every Kotlin-DSL module dependency invisible, which
+        # left MODULE_DEPENDS_ON empty on standard Android projects (#1603).
+        for m in re.finditer(r"""(\w+)\s*\(?\s*project\(['"]:([\w.\-/:]+)['"]\)""", source):
             configuration = m.group(1)
             # Canonical target identity — same construction as module_name,
             # so both endpoints of MODULE_DEPENDS_ON agree by construction.

--- a/tests/unit/core/test_bundle_pk_map_coverage.py
+++ b/tests/unit/core/test_bundle_pk_map_coverage.py
@@ -22,10 +22,11 @@ SCHEMA_FILE = (
     / "src" / "codegraphcontext" / "core" / "database_embedded_kuzu.py"
 )
 
-# Composite primary keys need a multi-key MERGE and a wider `_node_lookup_key`
-# tuple than the current (label, field, value) shape. Tracked separately; listed
-# here so this test states the gap instead of hiding it.
-KNOWN_COMPOSITE_PK_LABELS = {"DbColumn", "RedisKeyPattern"}
+# Composite primary keys no longer exist in the Kùzu schema: Kùzu cannot
+# declare them at all (the DDL fails to parse), so DbColumn and RedisKeyPattern
+# are keyed on a synthesized uid like the positional code labels. Kept as an
+# empty set so a future composite key re-fails this test loudly.
+KNOWN_COMPOSITE_PK_LABELS = set()
 
 
 def declared_node_tables():
@@ -57,8 +58,13 @@ def test_single_key_label_is_mapped(label, pk_fields):
 
 
 def test_labels_reported_in_1322_are_mapped():
-    """The two labels named in the issue report, pinned explicitly."""
-    assert CGCBundle._PK_MAP.get("DbTable") == "name"
+    """The two labels named in the issue report, pinned explicitly.
+
+    DbTable moved from name to fqn: the writer merges DbTable on `fqn`
+    (names collide across datasources), and the Kùzu table is keyed
+    accordingly, so bundles must import it by fqn too.
+    """
+    assert CGCBundle._PK_MAP.get("DbTable") == "fqn"
     assert CGCBundle._PK_MAP.get("ExternalClass") == "name"
 
 

--- a/tests/unit/parsers/test_gradle_parser.py
+++ b/tests/unit/parsers/test_gradle_parser.py
@@ -170,3 +170,45 @@ def test_single_root_module_with_no_includes_keeps_working(tmp_path: Path):
     assert module["name"] == "repo"
     assert len(data["external_libs"]) == 1
     assert data["external_libs"][0]["src_name"] == module["name"]
+
+
+def test_kotlin_dsl_project_deps_are_extracted(tmp_path: Path):
+    """`implementation(project(":x"))` — the Kotlin DSL form with no whitespace
+    before the paren — must produce MODULE_DEPENDS_ON rows just like the
+    Groovy `implementation project(':x')` form (#1603, report 6 of 9)."""
+    repo = tmp_path / "repo"
+    _write(repo / "settings.gradle.kts", """
+        include(":app")
+        include(":core:network")
+    """)
+    _write(repo / "app" / "build.gradle.kts", """
+        dependencies {
+            implementation(project(":core:network"))
+            api(project(":core:network"))
+        }
+    """)
+    _write(repo / "core" / "network" / "build.gradle.kts", "")
+
+    data = parse_repo_gradle(repo)
+    deps = data["inter_module_deps"]
+    assert {"src_name": ":app", "tgt_name": ":core:network", "configuration": "implementation"} in deps
+    assert {"src_name": ":app", "tgt_name": ":core:network", "configuration": "api"} in deps
+
+
+def test_groovy_whitespace_project_deps_still_extracted(tmp_path: Path):
+    """The Groovy form must keep matching after the Kotlin DSL fix."""
+    repo = tmp_path / "repo"
+    _write(repo / "settings.gradle", """
+        include ':app'
+        include ':lib'
+    """)
+    _write(repo / "app" / "build.gradle", """
+        dependencies {
+            implementation project(':lib')
+        }
+    """)
+    _write(repo / "lib" / "build.gradle", "")
+
+    data = parse_repo_gradle(repo)
+    deps = data["inter_module_deps"]
+    assert {"src_name": ":app", "tgt_name": ":lib", "configuration": "implementation"} in deps

--- a/tests/unit/tools/test_build_and_datasource_kuzu_writes.py
+++ b/tests/unit/tools/test_build_and_datasource_kuzu_writes.py
@@ -1,0 +1,131 @@
+"""The Gradle/Maven build graph and datasource graph must write on KuzuDB.
+
+Regression tests for the embedded-backend gaps behind #1603: none of
+GradleModule / MavenModule / ExternalLibrary / DbColumn / RedisKeyPattern
+was declared in the Kùzu schema (DbColumn and RedisKeyPattern used composite
+PRIMARY KEYs, which Kùzu cannot parse), so every one of these writes either
+binder-errored or silently dropped all rows. The UNWIND per-row fallback also
+left the bare row variable in `WITH node, row` clauses, which binder-errored
+and skipped each row one at a time.
+"""
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+kuzu = pytest.importorskip("kuzu")
+
+
+@pytest.fixture()
+def driver(tmp_path: Path):
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    yield manager.get_driver()
+    manager.close_driver()
+
+
+def _count(session, query: str) -> int:
+    return session.run(query).data()[0]["c"]
+
+
+def test_gradle_build_graph_writes_on_kuzu(driver):
+    w = GraphWriter(driver)
+    w.write_gradle_build_graph(
+        {
+            "modules": [
+                {"name": ":app", "build_file": "/r/app/build.gradle"},
+                {"name": ":core", "build_file": "/r/core/build.gradle"},
+            ],
+            "inter_module_deps": [
+                {"src_name": ":app", "tgt_name": ":core", "configuration": "implementation"}
+            ],
+            "external_libs": [
+                {"group_id": "com.squareup.retrofit2", "artifact_id": "retrofit",
+                 "version": "2.9.0", "src_name": ":app", "configuration": "implementation"}
+            ],
+        },
+        "/r",
+    )
+    with driver.session() as s:
+        assert _count(s, "MATCH (n:GradleModule) RETURN count(n) AS c") == 2
+        assert _count(s, "MATCH (n:ExternalLibrary) RETURN count(n) AS c") == 1
+        assert _count(s, "MATCH (:GradleModule)-[:MODULE_DEPENDS_ON]->(:GradleModule) RETURN count(*) AS c") == 1
+        assert _count(s, "MATCH (:GradleModule)-[:USES_LIBRARY]->(:ExternalLibrary) RETURN count(*) AS c") == 1
+
+
+def test_maven_build_graph_writes_on_kuzu(driver):
+    w = GraphWriter(driver)
+    w.write_maven_build_graph(
+        {
+            "modules": [
+                {"group_id": "com.acme", "artifact_id": "parent", "version": "1.0",
+                 "packaging": "pom", "pom_path": "/r/pom.xml"},
+                {"group_id": "com.acme", "artifact_id": "child", "version": "1.0",
+                 "packaging": "jar", "pom_path": "/r/child/pom.xml"},
+            ],
+            "child_relations": [
+                {"parent_artifact_id": "parent", "child_artifact_id": "child"}
+            ],
+            "inter_module_deps": [
+                {"src_artifact_id": "child", "tgt_artifact_id": "parent", "scope": "compile"}
+            ],
+            "external_libs": [
+                {"group_id": "junit", "artifact_id": "junit", "version": "4.13",
+                 "src_artifact_id": "child", "scope": "test"}
+            ],
+        },
+        "/r",
+    )
+    with driver.session() as s:
+        assert _count(s, "MATCH (n:MavenModule) RETURN count(n) AS c") == 2
+        assert _count(s, "MATCH (:MavenModule)-[:CHILD_MODULE]->(:MavenModule) RETURN count(*) AS c") == 1
+        assert _count(s, "MATCH (:MavenModule)-[:MODULE_DEPENDS_ON]->(:MavenModule) RETURN count(*) AS c") == 1
+        assert _count(s, "MATCH (:MavenModule)-[:USES_LIBRARY]->(:ExternalLibrary) RETURN count(*) AS c") == 1
+
+
+def test_datasource_graph_writes_on_kuzu(driver):
+    w = GraphWriter(driver)
+    w.write_datasource_graph(
+        {
+            "datasource": {"name": "mydb", "kind": "mysql", "host": "localhost", "env": "dev"},
+            "tables": [
+                {"fqn": "mydb.users", "name": "users", "datasource_name": "mydb"},
+                {"fqn": "mydb.orders", "name": "orders", "datasource_name": "mydb"},
+            ],
+            # Same column name on two tables: must stay two distinct nodes.
+            "columns": [
+                {"name": "id", "table_fqn": "mydb.users", "type": "INT", "nullable": False,
+                 "datasource_name": "mydb", "is_primary_key": True},
+                {"name": "id", "table_fqn": "mydb.orders", "type": "INT", "nullable": False,
+                 "datasource_name": "mydb", "is_primary_key": True},
+            ],
+            "key_patterns": [
+                {"pattern": "session:*", "datasource_name": "redis1", "key_type": "hash",
+                 "example_key": "session:1", "count": 10}
+            ],
+        }
+    )
+    with driver.session() as s:
+        assert _count(s, "MATCH (n:Datasource) RETURN count(n) AS c") == 1
+        assert _count(s, "MATCH (n:DbTable) RETURN count(n) AS c") == 2
+        assert _count(s, "MATCH (n:DbColumn) RETURN count(n) AS c") == 2
+        assert _count(s, "MATCH (n:RedisKeyPattern) RETURN count(n) AS c") == 1
+        assert _count(s, "MATCH (:DbTable)-[:HAS_COLUMN]->(:DbColumn) RETURN count(*) AS c") == 2
+        assert _count(s, "MATCH (:DbTable)-[:STORED_IN]->(:Datasource) RETURN count(*) AS c") == 2
+
+
+def test_datasource_writes_are_idempotent_on_kuzu(driver):
+    w = GraphWriter(driver)
+    payload = {
+        "datasource": {"name": "mydb", "kind": "mysql", "host": "h", "env": "dev"},
+        "tables": [{"fqn": "mydb.users", "name": "users", "datasource_name": "mydb"}],
+        "columns": [{"name": "id", "table_fqn": "mydb.users", "type": "INT",
+                     "nullable": False, "datasource_name": "mydb", "is_primary_key": True}],
+        "key_patterns": [],
+    }
+    w.write_datasource_graph(payload)
+    w.write_datasource_graph(payload)
+    with driver.session() as s:
+        assert _count(s, "MATCH (n:DbTable) RETURN count(n) AS c") == 1
+        assert _count(s, "MATCH (n:DbColumn) RETURN count(n) AS c") == 1


### PR DESCRIPTION
## What this fixes

Found by direct feature exercise against a real KùzuDB after the day's merge queue — none of it is reachable from the mocked unit paths, which is why it survived so long.

1. **The entire Gradle/Maven build graph was dead on embedded backends** (the default). `GradleModule`, `MavenModule` and `ExternalLibrary` node tables — and `MODULE_DEPENDS_ON` / `USES_LIBRARY` / `CHILD_MODULE` rel tables — were never declared in the Kùzu schema, so `write_gradle_build_graph` binder-errored on the first write. This is the missing write-side half of #1603.
2. **The entire datasource ingest (mysql/redis/cassandra) was dead on embedded backends.** `DbColumn` and `RedisKeyPattern` declared composite `PRIMARY KEY (a, b)`, which Kùzu cannot parse — the `CREATE NODE TABLE` failed at every startup, taking the `STORED_IN`/`HAS_COLUMN` rel tables down with it. Both are now keyed on a synthesized uid (`uid_map`, bundle `_PK_MAP`/`_UID_PARTS` updated to match). `DbTable` is now keyed on `fqn` — the key the writer actually merges on (`name` collides across datasources) — with a drop-empty-legacy-table migration.
3. **The UNWIND per-row fallback silently dropped every row of node+edge combo queries.** It strips the `UNWIND` but left the bare row variable in `WITH tbl, t` clauses; the dangling reference binder-errors and the row is skipped with `continue`. Every datasource and gradle/maven external-lib write goes through this shape.
4. **The uid-only MERGE rewrite dropped displaced pattern properties.** `MERGE (m:MavenModule {group_id: …, artifact_id: …})` became `MERGE (m {uid: …})`, and since the follow-up `SET` doesn't repeat the key fields, `group_id`/`artifact_id` stayed NULL — so the CHILD_MODULE/MODULE_DEPENDS_ON MATCHes by `artifact_id` found nothing. Displaced properties are now re-applied with an injected SET.
5. **Kotlin DSL inter-module deps never matched** (`gradle.py`): the pattern required whitespace before `project(`, so `implementation(project(":core:network"))` produced nothing — the remaining open half of #1603's headline symptom.

## Verification

- New real-Kùzu regression tests: gradle graph, maven graph (incl. CHILD_MODULE via artifact_id MATCH), datasource graph (incl. same-named columns on two tables staying distinct), idempotent re-ingest; Kotlin-DSL + Groovy gradle parser tests.
- Full unit suite: 1371 passed / 19 skipped. Full integration suite: 51 passed (all 21 goldens).
- End-to-end CLI smoke (`cgc index` + analyze commands) on a mixed py/js project.

Fixes #1603