### PR TITLE
chore(release): bump version to 0.6.1

### DIFF
--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-08-18 18:51 UTC_
+_Generated: 2026-08-18 19:27 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.0"
+version = "0.6.1"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
0.6.0 → 0.6.1 — the backlog-fix batch from #1646:

- jobs: cleanup no longer deletes active indexing jobs (#1537)
- watcher: stop() clears watch state (#1519)
- read-only Cypher gate: no more false positives on `load`/`set`/`update`/`insert` as identifiers (#1511)
- simulate_metrics works on KùzuDB/LadybugDB (#1512)
- `add_code_to_graph` honours `graph_name` on FalkorDB, refuses clearly elsewhere (#1558)
- JS/TS ES import bindings (named/default/namespace) fully extracted (#1526)
- .NET `obj/` excluded from default ignores (#1585)
- stale-venv grammar divergence now fails loudly (#1625)

Full unit + integration suites green at the release commit.