### PR TITLE
chore(release): bump version to 0.6.2

### DIFF
--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-08-18 19:27 UTC_
+_Generated: 2026-08-18 20:07 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.1"
+version = "0.6.2"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
0.6.1 → 0.6.2 — the #1648 batch:

- **Indexing on KùzuDB/LadybugDB is ~2x faster**: relationship-only UNWIND MERGEs now batch; the per-row fallback is scoped to the node-MERGE shape whose planner mis-bind was reproduced and pinned in tests (#1605)
- Transient per-file write failures retry once instead of silently costing the graph a file's edges (#1612)
- C++ lambda parameters extracted (#1527 audit complete)
- .cgcignore CLI tests hermetic and reliable (#1422)

Full unit + integration suites green at the release commit.