### PR TITLE
feat: vector-resolve visibility, complexity CI gate, dead-code confidence, diagram export

### DIFF
--- a/docs/CI_INTEGRATION.md
+++ b/docs/CI_INTEGRATION.md
@@ -1,0 +1,52 @@
+# CI Integration
+
+`cgc analyze complexity` can act as a quality gate in CI (#1333): it has
+machine-readable output on a clean stdout and an opt-in non-zero exit code.
+
+## GitHub Actions example
+
+```yaml
+- name: Enforce complexity threshold
+  run: |
+    pip install codegraphcontext
+    cgc index .
+    cgc analyze complexity --threshold 10 --format json --fail-on-violations \
+      | tee complexity-report.json
+  # --fail-on-violations exits 1 when any function exceeds the threshold → PR blocked
+
+- name: Upload complexity report
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: complexity-report
+    path: complexity-report.json
+```
+
+## Output formats
+
+`--format json` (schema):
+
+```json
+{
+  "threshold": 10,
+  "violations_count": 1,
+  "violations": [
+    {"function": "process_order", "file": "src/orders.py", "line": 45,
+     "complexity": 23, "exceeds_by": 13}
+  ]
+}
+```
+
+`--format csv` emits `function,file,line,complexity,exceeds_by` rows
+(violations only), suitable for spreadsheets and dashboards.
+
+Notes:
+
+- Progress/status chatter goes to **stderr**; stdout carries only the document,
+  so `cgc analyze complexity --format json | jq .` works.
+- In `json`/`csv` (or with `--fail-on-violations`), the full violation set is
+  reported — the interactive display page size (`--limit`) does not truncate it.
+- Without `--fail-on-violations` the exit code stays 0, so exploratory use and
+  existing scripts are unaffected.
+- The synthetic `<module>` frame is excluded — it attributes module-level
+  calls and is not a function anyone can refactor.

--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -123,6 +123,10 @@ def _print_index_execution_summary(graph_builder: GraphBuilder) -> None:
         f"{summary.get('serialization_seconds', 0.0):.2f}",
     )
     console.print(table)
+    # Always-visible warnings (#1597): these describe an explicitly enabled
+    # feature that did NOT run — they must not depend on the log level.
+    for warning in summary.get("warnings", []):
+        console.print(f"[bold yellow]⚠ {warning}[/bold yellow]")
 
 
 def _initialize_services(

--- a/src/codegraphcontext/cli/config_manager.py
+++ b/src/codegraphcontext/cli/config_manager.py
@@ -685,6 +685,21 @@ def set_config_value(key: str, value: str) -> bool:
     save_config(config)
     
     console.print(f"[green]✅ Set {key} = {value}[/green]")
+
+    # Surface a missing embedding backend at the moment of intent, not after
+    # an index run that silently generated nothing (#1597).
+    if key == "ENABLE_VECTOR_RESOLVE" and value.lower() == "true":
+        try:
+            from codegraphcontext.tools.indexing.embeddings import probe_embedding_backend
+            ok, detail = probe_embedding_backend()
+            if not ok:
+                console.print(
+                    f"[bold yellow]⚠ Vector resolve is enabled but cannot run yet: "
+                    f"{detail}. Indexing will proceed without embeddings until "
+                    f"this is installed.[/bold yellow]"
+                )
+        except Exception:
+            pass
     return True
 
 

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -2905,9 +2905,11 @@ def analyze_inheritance_tree(
 def analyze_complexity(
     path: Optional[str] = typer.Argument(None, help="Function name or file path to analyze"),
     threshold: Optional[int] = typer.Option(None, "--threshold", "-t", help="Complexity threshold for warnings (default: from config or 10)"),
-    limit: int = typer.Option(20, "--limit", "-l", help="Maximum results to show"),
+    limit: Optional[int] = typer.Option(None, "--limit", "-l", help="Maximum results to show (default 20 for text; unlimited for json/csv)"),
     file: Optional[str] = typer.Option(None, "--file", "-f", help="Specific file path to scope analysis"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
+    output_format: str = typer.Option("text", "--format", help="Output format: text, json or csv (#1333)"),
+    fail_on_violations: bool = typer.Option(False, "--fail-on-violations", help="Exit with code 1 when any function exceeds the threshold (CI gate)"),
 ):
     """
     Show cyclomatic complexity for functions.
@@ -2920,7 +2922,19 @@ def analyze_complexity(
         cgc analyze complexity src/main.py        # Most complex functions in file
         cgc analyze complexity main.py            # Most complex functions in file
         cgc analyze complexity --file src/main.py # Alternative file syntax
+        cgc analyze complexity -t 10 --format json --fail-on-violations  # CI gate
     """
+    output_format = output_format.lower()
+    if output_format not in ("text", "json", "csv"):
+        console.print(f"[red]Unknown --format '{output_format}' (expected text, json or csv)[/red]")
+        raise typer.Exit(code=2)
+    if output_format in ("json", "csv"):
+        # stdout must carry ONLY the parseable document: the service-init
+        # chatter from cli_helpers prints to stdout, so reroute that console
+        # to stderr before initializing anything (`--format json | jq .`).
+        import sys as _sys
+        from . import cli_helpers as _cli_helpers
+        _cli_helpers.console.file = _sys.stderr
     _load_credentials()
     services = _initialize_services(context)
     if not all(services[:3]):
@@ -2937,6 +2951,47 @@ def analyze_complexity(
                 threshold = 10
         else:
             threshold = 10
+
+    machine_output = output_format in ("json", "csv")
+    # Enforcement and export need the full set: a display page must never
+    # truncate the violation count a CI gate acts on (#1333).
+    effective_limit = limit if limit is not None else (None if (machine_output or fail_on_violations) else 20)
+
+    def _violations_from(results):
+        rows = []
+        for func in results or []:
+            # The synthetic `<module>` frame is the attribution target for
+            # module-level calls, not a function anyone can refactor.
+            if func.get("function_name") == "<module>":
+                continue
+            complexity = func.get("complexity", 0) or 0
+            if complexity > threshold:
+                rows.append({
+                    "function": func.get("function_name", ""),
+                    "file": func.get("path", ""),
+                    "line": func.get("line_number"),
+                    "complexity": complexity,
+                    "exceeds_by": complexity - threshold,
+                })
+        return rows
+
+    def _emit_machine(violations):
+        import csv as _csv
+        import io as _io
+        import json as _json
+        if output_format == "json":
+            print(_json.dumps({
+                "threshold": threshold,
+                "violations_count": len(violations),
+                "violations": violations,
+            }, indent=2))
+        else:
+            buf = _io.StringIO()
+            w = _csv.writer(buf)
+            w.writerow(["function", "file", "line", "complexity", "exceeds_by"])
+            for v in violations:
+                w.writerow([v["function"], v["file"], v["line"], v["complexity"], v["exceeds_by"]])
+            print(buf.getvalue(), end="")
 
     _FILE_EXTENSIONS = ('.py', '.js', '.ts', '.jsx', '.tsx', '.go', '.rs', '.rb',
                         '.java', '.cpp', '.c', '.cs', '.swift', '.kt', '.scala',
@@ -2970,15 +3025,31 @@ def analyze_complexity(
         console.print(table)
         console.print(f"\n[dim]{len([f for f in results if f.get('complexity', 0) > threshold])} function(s) exceed threshold[/dim]")
 
+    violations = None
     try:
         if path and _is_file_path(path):
             # File path provided as positional argument
-            results = code_finder.find_most_complex_functions_in_file(path, limit)
-            _render_complexity_table(results, f"Most Complex Functions in '{path}' (threshold: {threshold}):")
+            results = code_finder.find_most_complex_functions_in_file(path, effective_limit)
+            violations = _violations_from(results)
+            if machine_output:
+                _emit_machine(violations)
+            else:
+                _render_complexity_table(results, f"Most Complex Functions in '{path}' (threshold: {threshold}):")
         elif path:
             # Specific function name
             result = code_finder.get_cyclomatic_complexity(path, file)
+            single = []
             if result:
+                single = [{
+                    "function_name": path,
+                    "path": result.get("path", ""),
+                    "line_number": result.get("line_number"),
+                    "complexity": result.get("complexity", 0) or 0,
+                }]
+            violations = _violations_from(single)
+            if machine_output:
+                _emit_machine(violations)
+            elif result:
                 console.print(f"\n[bold cyan]Complexity for '{path}':[/bold cyan]")
                 console.print(f"  Cyclomatic Complexity: [yellow]{result.get('complexity', 'N/A')}[/yellow]")
                 console.print(f"  File: [dim]{result.get('path', '')}[/dim]")
@@ -2987,14 +3058,29 @@ def analyze_complexity(
                 console.print(f"[yellow]Function '{path}' not found or has no complexity data[/yellow]")
         elif file:
             # --file option without positional arg
-            results = code_finder.find_most_complex_functions_in_file(file, limit)
-            _render_complexity_table(results, f"Most Complex Functions in '{file}' (threshold: {threshold}):")
+            results = code_finder.find_most_complex_functions_in_file(file, effective_limit)
+            violations = _violations_from(results)
+            if machine_output:
+                _emit_machine(violations)
+            else:
+                _render_complexity_table(results, f"Most Complex Functions in '{file}' (threshold: {threshold}):")
         else:
             # Global - most complex functions
-            results = code_finder.find_most_complex_functions(limit)
-            _render_complexity_table(results, f"Most Complex Functions (threshold: {threshold}):")
+            results = code_finder.find_most_complex_functions(effective_limit)
+            violations = _violations_from(results)
+            if machine_output:
+                _emit_machine(violations)
+            else:
+                _render_complexity_table(results, f"Most Complex Functions (threshold: {threshold}):")
     finally:
         db_manager.close_driver()
+
+    # CI gate (#1333): explicit opt-in keeps exploratory usage exit-0 —
+    # the config default threshold means most codebases have *some*
+    # function above it, and failing every casual invocation would break
+    # innocent `cgc analyze complexity && …` chains.
+    if fail_on_violations and violations:
+        raise typer.Exit(code=1)
 
 @analyze_app.command("dead-code")
 def analyze_dead_code(

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -1149,6 +1149,96 @@ def export_shortcut(
         context=context,
     )
 
+@app.command("diagram")
+def diagram(
+    path: Optional[str] = typer.Argument(None, help="Repository path to scope the diagram to"),
+    output_format: str = typer.Option("mermaid", "--format", help="Diagram format: mermaid or dot (#1287)"),
+    level: str = typer.Option("file", "--level", help="Granularity: 'file' (file→module imports) or 'call' (function call graph)"),
+    output: Optional[str] = typer.Option(None, "--output", "-o", help="Write to a file instead of stdout"),
+    limit: int = typer.Option(300, "--limit", "-l", help="Maximum edges to include (truncation is reported in the diagram)"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
+):
+    """
+    Export the context graph as a Mermaid or Graphviz DOT diagram.
+
+    Mermaid output pastes straight into GitHub Markdown / Notion; DOT renders
+    locally with graphviz. The diagram is a generated artifact of the current
+    index — regenerate it after refactors rather than committing it as
+    documentation.
+
+    Example:
+        cgc diagram . > architecture.mmd
+        cgc diagram . --format dot -o graph.dot && dot -Tsvg graph.dot -o graph.svg
+        cgc diagram . --level call --limit 100
+    """
+    output_format = output_format.lower()
+    if output_format not in ("mermaid", "dot"):
+        console.print(f"[red]Unknown --format '{output_format}' (expected mermaid or dot)[/red]")
+        raise typer.Exit(code=2)
+    if level not in ("file", "call"):
+        console.print(f"[red]Unknown --level '{level}' (expected file or call)[/red]")
+        raise typer.Exit(code=2)
+    if output is None:
+        # stdout carries only the diagram; init chatter goes to stderr.
+        import sys as _sys
+        from . import cli_helpers as _cli_helpers
+        _cli_helpers.console.file = _sys.stderr
+
+    _load_credentials()
+    services = _initialize_services(context)
+    if not all(services[:3]):
+        raise typer.Exit(code=1)
+    db_manager, graph_builder, code_finder = services[:3]
+
+    try:
+        repo_path = Path(path).resolve().as_posix() if path else None
+        result = code_finder.export_diagram_edges(level=level, repo_path=repo_path, limit=limit)
+    finally:
+        db_manager.close_driver()
+
+    edges = result["edges"]
+    ids: dict = {}
+
+    def _node_id(name: str) -> str:
+        if name not in ids:
+            ids[name] = f"n{len(ids)}"
+        return ids[name]
+
+    lines = []
+    if output_format == "mermaid":
+        lines.append("graph LR")
+        if result["truncated"]:
+            lines.append(f"    %% truncated: showing {len(edges)} of {result['total_count']} edges (raise --limit)")
+        for src, dst in edges:
+            sid, did = _node_id(src), _node_id(dst)
+            s_label = src.replace('"', "'")
+            d_label = dst.replace('"', "'")
+            lines.append(f'    {sid}["{s_label}"] --> {did}["{d_label}"]')
+        if not edges:
+            lines.append("    %% no edges found for this scope")
+    else:
+        lines.append("digraph cgc {")
+        lines.append("    rankdir=LR;")
+        if result["truncated"]:
+            lines.append(f"    // truncated: showing {len(edges)} of {result['total_count']} edges (raise --limit)")
+        for src, dst in edges:
+            sid, did = _node_id(src), _node_id(dst)
+            lines.append(f'    {sid} -> {did};')
+        for name, nid in ids.items():
+            label = name.replace('"', "'")
+            lines.append(f'    {nid} [label="{label}"];')
+        lines.append("}")
+
+    text = "\n".join(lines) + "\n"
+    if output:
+        Path(output).write_text(text, encoding="utf-8")
+        console.print(f"[green]✅ Wrote {output_format} diagram ({len(edges)} edges) to {output}[/green]")
+        if result["truncated"]:
+            console.print(f"[yellow]⚠ Truncated: {result['total_count']} total edges; raise --limit to include all[/yellow]")
+    else:
+        print(text, end="")
+
+
 @app.command("load", rich_help_panel="Bundle Shortcuts")
 def load_shortcut(
     bundle_name: str = typer.Argument(..., help="Bundle name or path to load"),

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -3087,6 +3087,7 @@ def analyze_dead_code(
     path: Optional[str] = typer.Argument(None, help="Repository path to scope the analysis to"),
     exclude_decorators: Optional[str] = typer.Option(None, "--exclude", "-e", help="Comma-separated decorators to exclude"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
+    show_all: bool = typer.Option(False, "--show-all", help="Include low-confidence rows (dunders, test hooks, entry-point names) normally hidden (#1332)"),
 ):
     """
     Find potentially unused functions.
@@ -3116,7 +3117,8 @@ def analyze_dead_code(
         # of table rows. The true count comes from total_count below (#1606).
         display_limit = get_tool_result_limit("find_dead_code")
         results = code_finder.find_dead_code(
-            exclude_list, repo_path=repo_path, limit=display_limit
+            exclude_list, repo_path=repo_path, limit=display_limit,
+            include_low_confidence=show_all,
         )
 
         unused_funcs = results.get('potentially_unused_functions', [])
@@ -3128,16 +3130,22 @@ def analyze_dead_code(
         
         table = Table(show_header=True, header_style="bold magenta", box=box.ROUNDED)
         table.add_column("Function", style="cyan")
+        table.add_column("Confidence", justify="center")
         table.add_column("Location", style="dim", overflow="fold")
-        
-        for func in unused_funcs:
-            path = func.get('path', '')
-            line_str = str(func.get('line_number', ''))
-            location_str = f"{path}:{line_str}" if line_str else path
 
+        _conf_render = {
+            "high": "[red]● high[/red]",
+            "medium": "[yellow]● medium[/yellow]",
+            "low": "[dim]● low[/dim]",
+        }
+        for func in unused_funcs:
+            fpath = func.get('path', '')
+            line_str = str(func.get('line_number', ''))
+            location_str = f"{fpath}:{line_str}" if line_str else fpath
             table.add_row(
                 func.get('function_name', ''),
-                location_str
+                _conf_render.get(func.get('confidence', 'high'), func.get('confidence', '')),
+                location_str,
             )
         
         console.print("\n[bold yellow]⚠️  Potentially Unused Functions:[/bold yellow]")
@@ -3149,6 +3157,16 @@ def analyze_dead_code(
             )
         else:
             console.print(f"\n[dim]Total: {total_count} function(s)[/dim]")
+        counts = results.get('confidence_counts') or {}
+        if counts:
+            summary = (
+                f"[red]{counts.get('high', 0)} high[/red], "
+                f"[yellow]{counts.get('medium', 0)} medium[/yellow], "
+                f"[dim]{counts.get('low', 0)} low[/dim] confidence"
+            )
+            if not show_all:
+                summary += " [dim](low-confidence categories are hidden — use --show-all)[/dim]"
+            console.print(summary)
         console.print(f"[dim]Note: {results.get('note', '')}[/dim]")
     finally:
         db_manager.close_driver()

--- a/src/codegraphcontext/core/watcher.py
+++ b/src/codegraphcontext/core/watcher.py
@@ -324,14 +324,26 @@ class RepositoryEventHandler(FileSystemEventHandler):
             _inherit_enabled = False
 
         if _vector_enabled:
-            try:
-                from codegraphcontext.tools.indexing.embeddings import EmbeddingPipeline
-                embed_pipeline = EmbeddingPipeline(self.graph_builder.driver)
-                embed_pipeline.invalidate_for_file(changed_path_str)
-                embed_pipeline.run(str(self.repo_path))
-                info_logger(f"[EMBED] Incremental embedding complete for {changed_path_str}")
-            except Exception as _e:
-                warning_logger(f"[EMBED] Incremental embedding failed: {_e}")
+            # Probe once per handler: with no backend installed, the old code
+            # re-attempted (and re-failed) the import on every file event and
+            # only said so at a suppressed log level (#1597).
+            if not hasattr(self, "_embed_backend_ok"):
+                from codegraphcontext.tools.indexing.embeddings import probe_embedding_backend
+                self._embed_backend_ok, _detail = probe_embedding_backend()
+                if not self._embed_backend_ok:
+                    error_logger(
+                        f"[EMBED] ENABLE_VECTOR_RESOLVE=true but incremental embeddings "
+                        f"cannot run: {_detail} (reported once; further file events skip this)"
+                    )
+            if self._embed_backend_ok:
+                try:
+                    from codegraphcontext.tools.indexing.embeddings import EmbeddingPipeline
+                    embed_pipeline = EmbeddingPipeline(self.graph_builder.driver)
+                    embed_pipeline.invalidate_for_file(changed_path_str)
+                    embed_pipeline.run(str(self.repo_path))
+                    info_logger(f"[EMBED] Incremental embedding complete for {changed_path_str}")
+                except Exception as _e:
+                    warning_logger(f"[EMBED] Incremental embedding failed: {_e}")
 
         if _inherit_enabled:
             try:

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -44,6 +44,41 @@ _ANDROID_ENTRY_POINT_NAMES = (
     "onconfigurationchanged", "onlowmemory", "ontrimmemory",
     "onbindviewholder", "oncreateviewholder", "getitemcount",
 )
+_TEST_HOOK_NAMES = {
+    "setup", "teardown", "setupclass", "teardownclass",
+    "setupmodule", "teardownmodule", "setup_method", "teardown_method",
+}
+
+
+def _classify_dead_code_confidence(row: dict) -> tuple:
+    """(confidence, reason) for a zero-caller symbol (#1332).
+
+    low    — matches a category that is almost always a false positive
+             (dunder, test hook/prefix, entry-point name, override, test file)
+    medium — decorated: decorators frequently register implicit callers
+             (@property, @app.route, @pytest.fixture, …)
+    high   — none of the above; very likely genuinely dead
+    """
+    name = (row.get("function_name") or "")
+    lname = name.lower()
+    path = (row.get("path") or "")
+    if name.startswith("__") and name.endswith("__"):
+        return "low", "dunder — called implicitly by the runtime"
+    if lname in _TEST_HOOK_NAMES or name.startswith(("test_", "_test")):
+        return "low", "test hook/prefix — invoked by the test runner"
+    if lname in {n.lower() for n in _ENTRY_POINT_NAMES}:
+        return "low", "entry-point name — typically called externally"
+    if lname in {n.lower() for n in _ANDROID_ENTRY_POINT_NAMES}:
+        return "low", "framework entry point"
+    if "override" in (row.get("modifiers") or []):
+        return "low", "override — dispatched via its base declaration"
+    if "/tests/" in path or "/test/" in path or path.endswith("conftest.py"):
+        return "low", "test-tree file — commonly runner-invoked"
+    if row.get("decorators"):
+        return "medium", "decorated — decorators often add implicit callers"
+    return "high", "no callers, no excluding signal"
+
+
 _ANDROID_ENTRY_POINT_NAMES_CYPHER = "[" + ", ".join(
     f"'{n}'" for n in _ANDROID_ENTRY_POINT_NAMES
 ) + "]"
@@ -938,7 +973,7 @@ class CodeFinder:
             
             return result.data()
     
-    def find_dead_code(self, exclude_decorated_with: Optional[List[str]] = None, repo_path: Optional[str] = None, graph_name: str = None, limit: Optional[int] = None) -> Dict[str, Any]:
+    def find_dead_code(self, exclude_decorated_with: Optional[List[str]] = None, repo_path: Optional[str] = None, graph_name: str = None, limit: Optional[int] = None, include_low_confidence: bool = False) -> Dict[str, Any]:
         self._active_graph = graph_name
         """Find potentially unused functions (not called by other functions in the project), optionally excluding those with specific decorators.
 
@@ -996,6 +1031,8 @@ class CodeFinder:
                     func.line_number as line_number,
                     func.docstring as docstring,
                     func.context as context,
+                    func.decorators as decorators,
+                    func.modifiers as modifiers,
                     file.name as file_name
                 ORDER BY func.path, func.line_number
             """
@@ -1014,12 +1051,69 @@ class CodeFinder:
             # exclude_decorated_with look inert: excluded rows were backfilled
             # by the next ones in path order and the count came back 50 either
             # way (#1606).
+            for row in rows:
+                confidence, reason = _classify_dead_code_confidence(row)
+                row["confidence"] = confidence
+                row["confidence_reason"] = reason
+
+            if include_low_confidence:
+                # The main query hard-excludes categories that are almost
+                # always false positives (dunders, test hooks, entry-point
+                # names, overrides). --show-all reintroduces them as
+                # low-confidence rows instead of leaving them invisible
+                # (#1332).
+                low_query = f"""
+                    MATCH (func:Function)
+                    WHERE func.is_dependency = false {repo_filter} {func_ignore}
+                      AND func.name <> '<module>'
+                      AND (
+                            toLower(func.name) IN {_ENTRY_POINT_NAMES_CYPHER}
+                            OR (func.lang IN {_JVM_LANGS_CYPHER}
+                                AND toLower(func.name) IN {_ANDROID_ENTRY_POINT_NAMES_CYPHER})
+                            OR (func.modifiers IS NOT NULL AND 'override' IN func.modifiers)
+                            OR (func.name STARTS WITH '__' AND func.name ENDS WITH '__')
+                            OR func.name STARTS WITH '_test'
+                            OR func.name STARTS WITH 'test_'
+                          )
+                      {decorator_filter}
+                    WITH func
+                    OPTIONAL MATCH (caller)-[:CALLS|HEURISTIC_CALLS]->(func)
+                    WHERE (caller.is_dependency IS NULL OR caller.is_dependency = false)
+                      {caller_ignore}
+                    WITH func, count(caller) as caller_count
+                    WHERE caller_count = 0
+                    OPTIONAL MATCH (file:File)-[:CONTAINS]->(func)
+                    RETURN
+                        func.name as function_name,
+                        func.path as path,
+                        func.line_number as line_number,
+                        func.docstring as docstring,
+                        func.context as context,
+                        func.decorators as decorators,
+                        func.modifiers as modifiers,
+                        file.name as file_name
+                    ORDER BY func.path, func.line_number
+                """
+                low_rows = session.run(low_query, **params).data()
+                for row in low_rows:
+                    confidence, reason = _classify_dead_code_confidence(row)
+                    # Everything the main query excluded is low by construction,
+                    # but reuse the classifier so the reason strings match.
+                    row["confidence"] = "low" if confidence == "high" else confidence
+                    row["confidence_reason"] = reason
+                rows = rows + low_rows
+                rows.sort(key=lambda r: (str(r.get("path") or ""), r.get("line_number") or 0))
+
             total_count = len(rows)
+            confidence_counts = {"high": 0, "medium": 0, "low": 0}
+            for row in rows:
+                confidence_counts[row.get("confidence", "high")] += 1
             page = rows[:limit] if limit else rows
 
             return {
                 "potentially_unused_functions": page,
                 "total_count": total_count,
+                "confidence_counts": confidence_counts,
                 "note": "These functions might be unused, but could be entry points, callbacks, or called dynamically"
             }
     

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -1634,28 +1634,40 @@ class CodeFinder:
                 return result_data[0]
             return None
 
-    def find_most_complex_functions(self, limit: int = 10, repo_path: Optional[str] = None, graph_name: str = None) -> List[Dict]:
+    def find_most_complex_functions(self, limit: Optional[int] = 10, repo_path: Optional[str] = None, graph_name: str = None) -> List[Dict]:
         self._active_graph = graph_name
-        """Find the most complex functions based on cyclomatic complexity."""
+        """Find the most complex functions based on cyclomatic complexity.
+
+        ``limit=None`` returns the full set — CI enforcement must not have its
+        violation count truncated by a display page (#1333).
+        """
         repo_path = self._normalize_repo_path_filter(repo_path)
         with self.driver.session() as session:
             repo_filter = "AND f.path STARTS WITH $repo_path" if repo_path else ""
             path_ignore = cypher_path_not_under_ignore_dirs("f.path")
+            limit_clause = "LIMIT $limit" if limit is not None else ""
+            params = {"repo_path": repo_path}
+            if limit is not None:
+                params["limit"] = limit
             query = f"""
                 MATCH (f:Function)
                 WHERE f.cyclomatic_complexity IS NOT NULL AND f.is_dependency = false {repo_filter} {path_ignore}
                 RETURN f.name as function_name, f.path as path, f.cyclomatic_complexity as complexity, f.line_number as line_number
                 ORDER BY f.cyclomatic_complexity DESC
-                LIMIT $limit
+                {limit_clause}
             """
-            result = session.run(query, limit=limit, repo_path=repo_path)
+            result = session.run(query, **params)
             return result.data()
 
-    def find_most_complex_functions_in_file(self, file_path: str, limit: int = 20, repo_path: Optional[str] = None) -> List[Dict]:
-        """Find the most complex functions in a specific file."""
+    def find_most_complex_functions_in_file(self, file_path: str, limit: Optional[int] = 20, repo_path: Optional[str] = None) -> List[Dict]:
+        """Find the most complex functions in a specific file (limit=None = all)."""
         repo_path = self._normalize_repo_path_filter(repo_path)
         with self.driver.session() as session:
             repo_filter = "AND f.path STARTS WITH $repo_path" if repo_path else ""
+            limit_clause = "LIMIT $limit" if limit is not None else ""
+            params = {"file_path": file_path, "repo_path": repo_path}
+            if limit is not None:
+                params["limit"] = limit
             query = f"""
                 MATCH (f:Function)
                 WHERE f.cyclomatic_complexity IS NOT NULL
@@ -1664,9 +1676,9 @@ class CodeFinder:
                 RETURN f.name as function_name, f.path as path,
                        f.cyclomatic_complexity as complexity, f.line_number as line_number
                 ORDER BY f.cyclomatic_complexity DESC
-                LIMIT $limit
+                {limit_clause}
             """
-            result = session.run(query, file_path=file_path, limit=limit, repo_path=repo_path)
+            result = session.run(query, **params)
             return result.data()
 
     def list_indexed_repositories(self, graph_name: str = None) -> List[Dict]:

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -1117,6 +1117,53 @@ class CodeFinder:
                 "note": "These functions might be unused, but could be entry points, callbacks, or called dynamically"
             }
     
+    def export_diagram_edges(self, level: str = "file", repo_path: Optional[str] = None, limit: Optional[int] = 300) -> Dict[str, Any]:
+        """Edges for a Mermaid/DOT export (#1287).
+
+        level="file": File -[IMPORTS]-> Module dependencies.
+        level="call": Function -[CALLS]-> Function within the repo.
+
+        Returns {"edges": [(src, dst), ...], "total_count": n, "truncated": bool}
+        — the cap is reported, never silent.
+        """
+        repo_path = self._normalize_repo_path_filter(repo_path)
+        with self.driver.session() as session:
+            if level == "call":
+                repo_filter = "AND caller.path STARTS WITH $repo_path" if repo_path else ""
+                query = f"""
+                    MATCH (caller:Function)-[:CALLS]->(callee:Function)
+                    WHERE caller.is_dependency = false AND callee.is_dependency = false
+                      AND caller.name <> '<module>' AND callee.name <> '<module>'
+                      {repo_filter}
+                    RETURN DISTINCT caller.name AS src, callee.name AS dst
+                    ORDER BY src, dst
+                """
+            else:
+                repo_filter = "AND file.path STARTS WITH $repo_path" if repo_path else ""
+                query = f"""
+                    MATCH (file:File)-[:IMPORTS]->(module:Module)
+                    WHERE file.is_dependency = false {repo_filter}
+                    RETURN DISTINCT file.relative_path AS src_rel, file.name AS src_name,
+                                    module.name AS dst
+                    ORDER BY src_rel, dst
+                """
+            params = {"repo_path": repo_path} if repo_path else {}
+            rows = session.run(query, **params).data()
+
+        if level == "call":
+            edges = [(r["src"], r["dst"]) for r in rows if r.get("src") and r.get("dst")]
+        else:
+            edges = [
+                ((r.get("src_rel") or r.get("src_name") or ""), r["dst"])
+                for r in rows
+                if (r.get("src_rel") or r.get("src_name")) and r.get("dst")
+            ]
+        total = len(edges)
+        truncated = limit is not None and total > limit
+        if truncated:
+            edges = edges[:limit]
+        return {"edges": edges, "total_count": total, "truncated": truncated}
+
     def find_all_callers(self, function_name: str, path: Optional[str] = None, repo_path: Optional[str] = None, depth: int = 3) -> List[Dict]:
         """Find all direct and indirect callers of a specific function, returning edges."""
         repo_path = self._normalize_repo_path_filter(repo_path)

--- a/src/codegraphcontext/tools/indexing/embeddings.py
+++ b/src/codegraphcontext/tools/indexing/embeddings.py
@@ -121,6 +121,38 @@ class _FastEmbedder:
         return [vec.tolist() for vec in self._model.embed(texts)]
 
 
+def probe_embedding_backend(model_spec: Optional[str] = None):
+    """Cheaply check whether ENABLE_VECTOR_RESOLVE can actually run.
+
+    Import-level only — nothing heavy is loaded. Returns (ok, detail) where
+    *detail* names what is missing, so callers can surface a message that
+    distinguishes "vector resolve is working" from "vector resolve has never
+    run" (#1597).
+    """
+    import importlib.util as _ilu
+
+    spec = model_spec or os.environ.get("CGC_EMBEDDING_MODEL", "local")
+    if spec == "openai":
+        if _ilu.find_spec("openai") is None:
+            return False, "CGC_EMBEDDING_MODEL=openai but the 'openai' package is not installed"
+        if not os.environ.get("OPENAI_API_KEY"):
+            return False, "CGC_EMBEDDING_MODEL=openai but OPENAI_API_KEY is not set"
+        return True, "openai"
+    if spec == "fastembed":
+        if _ilu.find_spec("fastembed") is None:
+            return False, "CGC_EMBEDDING_MODEL=fastembed but the 'fastembed' package is not installed"
+        return True, "fastembed"
+    # 'local' (default) or an explicit sentence-transformers model name
+    if _ilu.find_spec("sentence_transformers") is not None:
+        return True, "sentence-transformers"
+    if spec == "local" and _ilu.find_spec("fastembed") is not None:
+        return True, "fastembed"
+    return False, (
+        "no embedding backend installed — ENABLE_VECTOR_RESOLVE needs "
+        "'sentence-transformers' or 'fastembed' (pip install fastembed)"
+    )
+
+
 def _get_embedder(model_spec: Optional[str] = None):
     """Return the appropriate embedder based on CGC_EMBEDDING_MODEL env var."""
     spec = model_spec or os.environ.get("CGC_EMBEDDING_MODEL", "local")

--- a/src/codegraphcontext/tools/indexing/pipeline.py
+++ b/src/codegraphcontext/tools/indexing/pipeline.py
@@ -389,17 +389,29 @@ async def run_tree_sitter_index_async(
 
     # ── Phase 4: embedding generation (optional, config-gated) ────────────────
     from ...cli.config_manager import get_config_value as _gcv
+    embed_warning: Optional[str] = None
     if (_gcv("ENABLE_VECTOR_RESOLVE") or "false").lower() == "true":
-        if job_id:
-            job_manager.update_job(job_id, status_message="Generating embeddings...")
-        try:
-            from .embeddings import EmbeddingPipeline
-            repo_path_str = path.resolve().as_posix()
-            info_logger("[EMBED] Starting embedding pipeline...")
-            EmbeddingPipeline(writer.driver).run(repo_path_str)
-            info_logger("[EMBED] Embedding pipeline complete.")
-        except Exception as _ee:
-            info_logger(f"[EMBED] Embedding pipeline failed (skipping): {_ee}")
+        # Probe first: with no backend installed the pipeline used to fail
+        # inside a swallowed except at a log level that is off by default,
+        # so 'vector resolve is working' and 'vector resolve has never run'
+        # were indistinguishable (#1597).
+        from .embeddings import probe_embedding_backend
+        _ok, _detail = probe_embedding_backend()
+        if not _ok:
+            embed_warning = f"ENABLE_VECTOR_RESOLVE=true but embeddings were NOT generated: {_detail}"
+            error_logger(f"[EMBED] {embed_warning}")
+        else:
+            if job_id:
+                job_manager.update_job(job_id, status_message="Generating embeddings...")
+            try:
+                from .embeddings import EmbeddingPipeline
+                repo_path_str = path.resolve().as_posix()
+                info_logger("[EMBED] Starting embedding pipeline...")
+                EmbeddingPipeline(writer.driver).run(repo_path_str)
+                info_logger("[EMBED] Embedding pipeline complete.")
+            except Exception as _ee:
+                embed_warning = f"ENABLE_VECTOR_RESOLVE=true but the embedding pipeline failed: {_ee}"
+                error_logger(f"[EMBED] {embed_warning}")
 
     # ── Phase 5: inheritance-aware re-resolution (optional, config-gated) ─────
     if (_gcv("ENABLE_INHERIT_RESOLVE") or "false").lower() == "true":
@@ -432,6 +444,8 @@ async def run_tree_sitter_index_async(
                 parse_failures=parse_failures,
             )
         )
+        if embed_warning:
+            index_summary.setdefault("warnings", []).append(embed_warning)
 
     if job_id:
         job_manager.update_job(job_id, status=JobStatus.COMPLETED, end_time=datetime.now())

--- a/tests/integration/test_analyze_complexity_ci.py
+++ b/tests/integration/test_analyze_complexity_ci.py
@@ -1,0 +1,80 @@
+"""#1333: `cgc analyze complexity` as a CI quality gate.
+
+Machine-readable output on a clean stdout, and an opt-in non-zero exit code.
+Hermetic: per-test HOME, embedded backend.
+"""
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CGC = f"{shlex.quote(sys.executable)} -m codegraphcontext.cli.main"
+
+
+@pytest.fixture()
+def indexed_repo(tmp_path: Path):
+    home = tmp_path / "home"; home.mkdir()
+    repo = tmp_path / "repo"; repo.mkdir()
+    (repo / "app.py").write_text(
+        "def busy(x):\n"
+        "    if x > 0:\n"
+        "        if x > 1:\n"
+        "            if x > 2:\n"
+        "                return 3\n"
+        "            return 2\n"
+        "        return 1\n"
+        "    return 0\n"
+        "\n"
+        "def calm():\n"
+        "    return 1\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["DEFAULT_DATABASE"] = "kuzudb"
+    env["CGC_CONTEXT_MODE"] = "global"
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    subprocess.run(f"{CGC} index {shlex.quote(str(repo))}", shell=True,
+                   capture_output=True, text=True, env=env, check=False)
+    return env
+
+
+def _run(cmd: str, env):
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True, env=env)
+
+
+def test_json_output_is_pure_and_parseable(indexed_repo):
+    r = _run(f"{CGC} analyze complexity --threshold 2 --format json", indexed_repo)
+    doc = json.loads(r.stdout)  # would raise if init chatter leaked to stdout
+    assert doc["threshold"] == 2
+    assert doc["violations_count"] >= 1
+    names = {v["function"] for v in doc["violations"]}
+    assert "busy" in names and "calm" not in names and "<module>" not in names
+    for v in doc["violations"]:
+        assert v["exceeds_by"] == v["complexity"] - 2
+    assert r.returncode == 0  # informational without the gate flag
+
+
+def test_csv_output_has_header_and_rows(indexed_repo):
+    r = _run(f"{CGC} analyze complexity --threshold 2 --format csv", indexed_repo)
+    lines = [l for l in r.stdout.splitlines() if l.strip()]
+    assert lines[0] == "function,file,line,complexity,exceeds_by"
+    assert any(l.startswith("busy,") for l in lines[1:])
+
+
+def test_fail_on_violations_gates_the_exit_code(indexed_repo):
+    r = _run(f"{CGC} analyze complexity --threshold 2 --fail-on-violations --format json", indexed_repo)
+    assert r.returncode == 1, r.stdout + r.stderr
+    # A threshold nothing exceeds must pass the gate.
+    r2 = _run(f"{CGC} analyze complexity --threshold 99 --fail-on-violations --format json", indexed_repo)
+    assert r2.returncode == 0, r2.stdout + r2.stderr
+    assert json.loads(r2.stdout)["violations_count"] == 0
+
+
+def test_unknown_format_is_rejected(indexed_repo):
+    r = _run(f"{CGC} analyze complexity --format yaml", indexed_repo)
+    assert r.returncode == 2

--- a/tests/integration/test_diagram_export.py
+++ b/tests/integration/test_diagram_export.py
@@ -1,0 +1,62 @@
+"""#1287: cgc diagram exports Mermaid/DOT on a clean stdout. Hermetic."""
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CGC = f"{shlex.quote(sys.executable)} -m codegraphcontext.cli.main"
+
+
+@pytest.fixture()
+def indexed(tmp_path: Path):
+    home = tmp_path / "home"; home.mkdir()
+    repo = tmp_path / "repo"; repo.mkdir()
+    (repo / "app.py").write_text(
+        "import os\nfrom pathlib import Path\n\ndef top():\n    helper()\n\ndef helper():\n    pass\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "DEFAULT_DATABASE": "kuzudb",
+                "CGC_CONTEXT_MODE": "global",
+                "PYTHONPATH": os.pathsep.join(sys.path)})
+    subprocess.run(f"{CGC} index {shlex.quote(str(repo))}", shell=True,
+                   capture_output=True, text=True, env=env)
+    return env, repo
+
+
+def _run(cmd, env):
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True, env=env)
+
+
+def test_mermaid_file_level(indexed):
+    env, repo = indexed
+    r = _run(f"{CGC} diagram {shlex.quote(str(repo))}", env)
+    assert r.stdout.startswith("graph LR"), r.stdout + r.stderr
+    assert '--> ' in r.stdout and '"os"' in r.stdout and '"pathlib"' in r.stdout
+    # stdout is pure diagram — no init chatter
+    assert "Initializing" not in r.stdout
+
+
+def test_dot_call_level_and_output_file(indexed, tmp_path):
+    env, repo = indexed
+    out = tmp_path / "g.dot"
+    r = _run(f"{CGC} diagram {shlex.quote(str(repo))} --format dot --level call -o {shlex.quote(str(out))}", env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    text = out.read_text()
+    assert text.startswith("digraph cgc {") and text.rstrip().endswith("}")
+    assert 'label="top"' in text and 'label="helper"' in text
+
+
+def test_truncation_is_reported(indexed):
+    env, repo = indexed
+    r = _run(f"{CGC} diagram {shlex.quote(str(repo))} --limit 1", env)
+    assert "truncated: showing 1 of" in r.stdout
+
+
+def test_bad_format_rejected(indexed):
+    env, repo = indexed
+    r = _run(f"{CGC} diagram {shlex.quote(str(repo))} --format png", env)
+    assert r.returncode == 2

--- a/tests/integration/test_vector_resolve_visibility.py
+++ b/tests/integration/test_vector_resolve_visibility.py
@@ -1,0 +1,49 @@
+"""#1597 end-to-end: an enabled-but-unrunnable vector resolve must be visible.
+
+Uses CGC_EMBEDDING_MODEL=openai with no OPENAI_API_KEY so the probe fails
+deterministically regardless of which embedding packages the environment has.
+"""
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _env(home: Path):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["DEFAULT_DATABASE"] = "kuzudb"
+    env["CGC_CONTEXT_MODE"] = "global"
+    env["CGC_EMBEDDING_MODEL"] = "openai"
+    env.pop("OPENAI_API_KEY", None)
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    return env
+
+
+def _run(cmd: str, home: Path):
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, env=_env(home))
+    return result.stdout + result.stderr
+
+
+CGC = f"{shlex.quote(sys.executable)} -m codegraphcontext.cli.main"
+
+
+def test_config_set_warns_immediately(tmp_path: Path):
+    home = tmp_path / "home"; home.mkdir()
+    out = _run(f"{CGC} config set ENABLE_VECTOR_RESOLVE true", home)
+    assert "cannot run yet" in out, out
+
+
+def test_index_summary_shows_embeddings_not_generated(tmp_path: Path):
+    home = tmp_path / "home"; home.mkdir()
+    repo = tmp_path / "repo"; repo.mkdir()
+    (repo / "a.py").write_text("def f():\n    pass\n", encoding="utf-8")
+
+    _run(f"{CGC} config set ENABLE_VECTOR_RESOLVE true", home)
+    out = _run(f"{CGC} index {shlex.quote(str(repo))}", home)
+    assert "NOT generated" in out, out
+    # The run itself must still succeed — the feature is optional.
+    assert "Successfully finished indexing" in out, out

--- a/tests/unit/tools/test_dead_code_confidence.py
+++ b/tests/unit/tools/test_dead_code_confidence.py
@@ -1,0 +1,81 @@
+"""#1332: dead-code results carry confidence scoring on a real embedded graph."""
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+from codegraphcontext.tools.code_finder import CodeFinder
+from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+kuzu = pytest.importorskip("kuzu")
+
+
+class _DBM:
+    def __init__(self, driver):
+        self._driver = driver
+
+    def get_driver(self, graph_name=None):
+        return self._driver
+
+    def get_backend_type(self):
+        return "kuzudb"
+
+
+@pytest.fixture()
+def finder(tmp_path: Path):
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    driver = manager.get_driver()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    f = repo / "app.py"
+    f.write_text("# fixture\n", encoding="utf-8")
+
+    w = GraphWriter(driver)
+    w.add_repository_to_graph(repo)
+    w.add_file_to_graph(
+        {
+            "path": str(f), "repo_path": str(repo), "lang": "python",
+            "imports": [],
+            "functions": [
+                {"name": "genuinely_dead", "line_number": 1, "end_line": 2, "args": []},
+                {"name": "decorated_dead", "line_number": 4, "end_line": 5, "args": [],
+                 "decorators": ["@app.route"]},
+                {"name": "__str__", "line_number": 7, "end_line": 8, "args": []},
+                {"name": "test_something", "line_number": 10, "end_line": 11, "args": []},
+                {"name": "main", "line_number": 13, "end_line": 14, "args": []},
+            ],
+            "classes": [], "variables": [],
+        },
+        repo.name, {}, repo_path_str=str(repo.resolve()),
+    )
+    yield CodeFinder(_DBM(driver))
+    manager.close_driver()
+
+
+def test_default_results_are_scored_and_low_categories_hidden(finder):
+    res = finder.find_dead_code()
+    by_name = {r["function_name"]: r for r in res["potentially_unused_functions"]}
+    assert by_name["genuinely_dead"]["confidence"] == "high"
+    assert by_name["decorated_dead"]["confidence"] == "medium"
+    assert "decorat" in by_name["decorated_dead"]["confidence_reason"]
+    # Hard-excluded categories stay hidden by default.
+    assert "__str__" not in by_name
+    assert "test_something" not in by_name
+    assert "main" not in by_name
+    assert res["confidence_counts"]["high"] == 1
+    assert res["confidence_counts"]["medium"] == 1
+    assert res["confidence_counts"]["low"] == 0
+
+
+def test_show_all_reintroduces_low_confidence_rows(finder):
+    res = finder.find_dead_code(include_low_confidence=True)
+    by_name = {r["function_name"]: r for r in res["potentially_unused_functions"]}
+    assert by_name["__str__"]["confidence"] == "low"
+    assert "dunder" in by_name["__str__"]["confidence_reason"]
+    assert by_name["test_something"]["confidence"] == "low"
+    assert by_name["main"]["confidence"] == "low"
+    assert "entry-point" in by_name["main"]["confidence_reason"]
+    # The default rows keep their scores alongside.
+    assert by_name["genuinely_dead"]["confidence"] == "high"
+    assert res["confidence_counts"]["low"] == 3
+    assert res["total_count"] == 5

--- a/tests/unit/tools/test_embedding_probe.py
+++ b/tests/unit/tools/test_embedding_probe.py
@@ -1,0 +1,58 @@
+"""#1597: probe_embedding_backend distinguishes 'working' from 'never ran'."""
+import importlib.util
+
+import pytest
+
+from codegraphcontext.tools.indexing import embeddings as emb
+
+
+def test_openai_spec_without_key_fails(monkeypatch):
+    monkeypatch.setenv("CGC_EMBEDDING_MODEL", "openai")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    if importlib.util.find_spec("openai") is None:
+        ok, detail = emb.probe_embedding_backend()
+        assert not ok and "openai" in detail
+    else:
+        ok, detail = emb.probe_embedding_backend()
+        assert not ok and "OPENAI_API_KEY" in detail
+
+
+def test_local_spec_reports_missing_backends(monkeypatch):
+    monkeypatch.setenv("CGC_EMBEDDING_MODEL", "local")
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *a, **k):
+        if name in ("sentence_transformers", "fastembed"):
+            return None
+        return real_find_spec(name, *a, **k)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    ok, detail = emb.probe_embedding_backend()
+    assert not ok
+    assert "sentence-transformers" in detail and "fastembed" in detail
+
+
+def test_local_spec_accepts_fastembed(monkeypatch):
+    monkeypatch.setenv("CGC_EMBEDDING_MODEL", "local")
+    real_find_spec = importlib.util.find_spec
+
+    class _FakeSpec:  # truthy stand-in
+        pass
+
+    def fake_find_spec(name, *a, **k):
+        if name == "sentence_transformers":
+            return None
+        if name == "fastembed":
+            return _FakeSpec()
+        return real_find_spec(name, *a, **k)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    ok, detail = emb.probe_embedding_backend()
+    assert ok and detail == "fastembed"
+
+
+def test_explicit_model_spec_overrides_env(monkeypatch):
+    monkeypatch.setenv("CGC_EMBEDDING_MODEL", "local")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    ok, _ = emb.probe_embedding_backend("openai")
+    assert not ok


### PR DESCRIPTION
Four features/fixes, each with hermetic end-to-end tests. Unit suite 1382 passed / 7 skipped; the new integration tests (10) all pass.

- **#1597**: `ENABLE_VECTOR_RESOLVE=true` with no embedding backend is now loudly visible — probe at config-set time, an always-visible '⚠ embeddings were NOT generated' line in the index summary independent of log level, ERROR-level logging, and the watcher probes once instead of re-failing per file event.
- **#1333**: `cgc analyze complexity --format json|csv --fail-on-violations` — clean stdout (chatter → stderr, `| jq` works), full violation set regardless of display limit, opt-in exit 1 for CI gates, docs/CI_INTEGRATION.md with the GitHub Actions pattern.
- **#1332**: dead-code confidence scoring (high/medium/low + reason); the hard-excluded false-positive categories (dunders, test hooks, entry points, overrides) become visible low-confidence rows via `--show-all` instead of being silently invisible; `confidence_counts` in the tool result.
- **#1287**: `cgc diagram` exports Mermaid (paste into GitHub Markdown) or Graphviz DOT, file→module or call-graph level, edge cap reported inside the diagram, never silent.

Fixes #1597, fixes #1333, fixes #1332, fixes #1287