### PR TITLE
perf(inherits): group INHERITS writes by the label pairs that occur

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -1137,6 +1137,8 @@ class GraphWriter:
         )
         batch_size = 500
         backend = get_backend_type(self.driver, self._db_manager)
+        labels = ("Class", "Trait", "Interface", "Struct", "Enum", "Union", "Record", "Mixin", "Extension", "Module", "Object", "Variable")
+
         def _work(session):
             # Dedupe identical rows first: parsers can emit the same
             # (child, parent) record more than once, and while Neo4j's MERGE
@@ -1156,8 +1158,6 @@ class GraphWriter:
             internal_batch = [r for r in deduped_batch if r.get("resolved_parent_file_path") != "__external__"]
             external_batch = [r for r in deduped_batch if r.get("resolved_parent_file_path") == "__external__"]
 
-            labels = ("Class", "Trait", "Interface", "Struct", "Enum", "Union", "Record", "Mixin", "Extension", "Module", "Object", "Variable")
-
             def _label_is_populated(label: str) -> bool:
                 # An empty node table can never match, so skip the pair entirely.
                 # If the existence probe itself fails for any reason, fall back to
@@ -1170,52 +1170,109 @@ class GraphWriter:
                 except Exception:
                     return True
 
+            # Probed once (~12 queries) and reused by the *fallback* enumerations
+            # further down. Deliberately NOT applied to `pair_groups`: those
+            # (child_label, parent_label) pairs are derived from the rows
+            # themselves, so they are never empty -- probing them would be pure
+            # overhead, and a stale or lazily-created label table would make the
+            # probe silently drop real INHERITS edges.
             populated_labels = {label for label in labels if _label_is_populated(label)}
 
-            for child_label in labels:
-                if child_label not in populated_labels:
-                    continue
+            def _chunks(rows):
+                for i in range(0, len(rows), batch_size):
+                    yield rows[i:i + batch_size]
+
+            def _run_internal(rows, child_label, parent_label):
                 child_cypher = _cypher_label(child_label, backend)
-                for parent_label in labels:
-                    if parent_label not in populated_labels:
-                        continue
-                    parent_cypher = _cypher_label(parent_label, backend)
+                parent_cypher = _cypher_label(parent_label, backend)
+                query = f"""
+                    UNWIND $batch AS row
+                    MATCH (child:{child_cypher} {{name: row.child_name, path: row.path}})
+                    MATCH (parent:{parent_cypher} {{name: row.parent_name, path: row.resolved_parent_file_path}})
+                    MERGE (child)-[r:INHERITS]->(parent)
+                    SET r.confidence_label = coalesce(row.confidence_label, 'EXTRACTED')
+                """
+                for chunk in _chunks(rows):
                     try:
-                        session.run(
-                            f"""
-                            UNWIND $batch AS row
-                            MATCH (child:{child_cypher} {{name: row.child_name, path: row.path}})
-                            MATCH (parent:{parent_cypher} {{name: row.parent_name, path: row.resolved_parent_file_path}})
-                            MERGE (child)-[r:INHERITS]->(parent)
-                            SET r.confidence_label = coalesce(row.confidence_label, 'EXTRACTED')
-                        """,
-                            batch=internal_batch,
-                        )
+                        session.run(query, batch=chunk)
                     except Exception as e:
+                        # A label absent in this backend fails to bind for the whole
+                        # (child,parent) group; skip it exactly like the old per-pair loop.
                         if _is_binder_exception(e):
-                            continue
+                            return
                         raise e
 
-            for child_label in labels:
-                if child_label not in populated_labels:
-                    continue
+            def _run_external(rows, child_label):
                 child_cypher = _cypher_label(child_label, backend)
-                try:
-                    session.run(
-                        f"""
-                        UNWIND $batch AS row
-                        MATCH (child:{child_cypher} {{name: row.child_name, path: row.path}})
-                        MERGE (parent:ExternalClass {{name: row.parent_name}})
-                        MERGE (child)-[r:INHERITS]->(parent)
-                        SET r.confidence_label = coalesce(row.confidence_label, 'INFERRED')
-                        """,
-                        batch=external_batch,
-                    )
-                except Exception as e:
-                    if _is_binder_exception(e):
-                        continue
-                    raise e
+                query = f"""
+                    UNWIND $batch AS row
+                    MATCH (child:{child_cypher} {{name: row.child_name, path: row.path}})
+                    MERGE (parent:ExternalClass {{name: row.parent_name}})
+                    MERGE (child)-[r:INHERITS]->(parent)
+                    SET r.confidence_label = coalesce(row.confidence_label, 'INFERRED')
+                """
+                for chunk in _chunks(rows):
+                    try:
+                        session.run(query, batch=chunk)
+                    except Exception as e:
+                        if _is_binder_exception(e):
+                            return
+                        raise e
 
+            # Group internal rows by the labels resolution pinned down, so only the
+            # (child_label, parent_label) pairs that actually occur run — instead of a
+            # 12x12 brute force that re-scans the full batch for every combination.
+            #   both labels known   -> one exact query per (child, parent) pair
+            #   child known only    -> enumerate parent labels over just those rows
+            #   neither             -> full 12x12 (rare: ambiguous (name,path) label collision)
+            # Rows never gain a label they wouldn't have matched, and unknown/ambiguous
+            # cases fall back to enumeration, so the produced edge set is unchanged.
+            pair_groups: Dict[tuple, List[Dict[str, Any]]] = {}
+            child_only_groups: Dict[str, List[Dict[str, Any]]] = {}
+            legacy_rows: List[Dict[str, Any]] = []
+            for row in internal_batch:
+                cl = row.get("child_label")
+                pl = row.get("parent_label")
+                if cl and pl:
+                    pair_groups.setdefault((cl, pl), []).append(row)
+                elif cl:
+                    child_only_groups.setdefault(cl, []).append(row)
+                else:
+                    legacy_rows.append(row)
+
+            for (cl, pl), rows in pair_groups.items():
+                _run_internal(rows, cl, pl)
+            for cl, rows in child_only_groups.items():
+                for pl in labels:
+                    if pl not in populated_labels:
+                        continue
+                    _run_internal(rows, cl, pl)
+            if legacy_rows:
+                for cl in labels:
+                    if cl not in populated_labels:
+                        continue
+                    for pl in labels:
+                        if pl not in populated_labels:
+                            continue
+                        _run_internal(legacy_rows, cl, pl)
+
+            # External parents (ExternalClass): group by known child label; fall back to
+            # enumerating child labels for any label-less rows.
+            ext_by_child: Dict[str, List[Dict[str, Any]]] = {}
+            ext_legacy: List[Dict[str, Any]] = []
+            for row in external_batch:
+                cl = row.get("child_label")
+                if cl:
+                    ext_by_child.setdefault(cl, []).append(row)
+                else:
+                    ext_legacy.append(row)
+            for cl, rows in ext_by_child.items():
+                _run_external(rows, cl)
+            if ext_legacy:
+                for cl in labels:
+                    if cl not in populated_labels:
+                        continue
+                    _run_external(ext_legacy, cl)
 
             for file_data in csharp_files:
                 self._create_csharp_inheritance_and_interfaces(session, file_data, imports_map)

--- a/src/codegraphcontext/tools/indexing/resolution/inheritance.py
+++ b/src/codegraphcontext/tools/indexing/resolution/inheritance.py
@@ -6,6 +6,58 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 
+
+# Child construct list -> node label: the 8 kinds that can declare inheritance.
+_INHERIT_KEY_TO_LABEL = {
+    "classes": "Class",
+    "structs": "Struct",
+    "traits": "Trait",
+    "interfaces": "Interface",
+    "mixins": "Mixin",
+    "enums": "Enum",
+    "extensions": "Extension",
+    "variables": "Variable",
+}
+
+# All construct lists whose nodes can be an INHERITS parent, mapped to their label.
+# Matches the 12 labels the writer enumerates. Used to attach exact child/parent
+# labels to rows and to detect the rare (name, path) collisions where more than one
+# node kind shares a name+path — those stay ambiguous so the writer falls back to
+# full enumeration (keeping the produced edge set identical).
+_NODE_KEY_TO_LABEL = {
+    "classes": "Class",
+    "traits": "Trait",
+    "interfaces": "Interface",
+    "structs": "Struct",
+    "enums": "Enum",
+    "unions": "Union",
+    "records": "Record",
+    "mixins": "Mixin",
+    "extensions": "Extension",
+    "modules": "Module",
+    "objects": "Object",
+    "variables": "Variable",
+}
+
+
+def _build_node_label_index(
+    all_file_data: List[Dict[str, Any]],
+) -> Dict[str, Dict[str, set]]:
+    """Map normalized path -> {name -> set(labels)} across all inheritance-eligible
+    node kinds. A (path, name) with exactly one label lets the writer target that
+    label directly; multiple labels leaves it ambiguous (writer enumerates)."""
+    index: Dict[str, Dict[str, set]] = {}
+    for file_data in all_file_data:
+        fpath = str(Path(file_data["path"]).resolve().as_posix())
+        per_file = index.setdefault(fpath, {})
+        for key, label in _NODE_KEY_TO_LABEL.items():
+            for item in file_data.get(key, []):
+                name = item.get("name")
+                if name:
+                    per_file.setdefault(name, set()).add(label)
+    return index
+
+
 def resolve_inheritance_link(
     class_item: Dict[str, Any],
     base_class_str: str,
@@ -13,6 +65,8 @@ def resolve_inheritance_link(
     local_class_names: set,
     local_imports: dict,
     imports_map: dict,
+    child_label: Optional[str] = None,
+    node_label_index: Optional[Dict[str, Dict[str, set]]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Resolve a single inheritance link. Returns row dict or None."""
     import re
@@ -55,21 +109,41 @@ def resolve_inheritance_link(
             if len(possible_paths) == 1:
                 resolved_path = possible_paths[0]
 
+    # Pin the child label only when this (path, name) is a single node kind. If more
+    # than one kind shares it, leave it off so the writer enumerates (byte-identical).
+    child_lbl = None
+    if child_label:
+        if node_label_index is None:
+            child_lbl = child_label
+        else:
+            present = node_label_index.get(caller_file_path, {}).get(class_item["name"])
+            if present and len(present) == 1 and child_label in present:
+                child_lbl = child_label
+
+    def _with_labels(row: Dict[str, Any], parent_path: str) -> Dict[str, Any]:
+        if child_lbl:
+            row["child_label"] = child_lbl
+        if node_label_index is not None:
+            plabels = node_label_index.get(parent_path, {}).get(target_class_name)
+            if plabels and len(plabels) == 1:
+                row["parent_label"] = next(iter(plabels))
+        return row
+
     if resolved_path:
-        return {
+        return _with_labels({
             "child_name": class_item["name"],
             "path": caller_file_path,
             "parent_name": target_class_name,
             "resolved_parent_file_path": resolved_path,
             "confidence_label": "EXTRACTED",
-        }
-    return {
+        }, resolved_path)
+    return _with_labels({
         "child_name": class_item["name"],
         "path": caller_file_path,
         "parent_name": target_class_name,
         "resolved_parent_file_path": "__external__",
         "confidence_label": "INFERRED",
-    }
+    }, "__external__")
 
 
 
@@ -79,6 +153,7 @@ def build_inheritance_and_csharp_files(
     """Returns (inheritance_batch_rows, csharp_file_data_list)."""
     inheritance_batch: List[Dict[str, Any]] = []
     csharp_files: List[Dict[str, Any]] = []
+    node_label_index = _build_node_label_index(all_file_data)
 
     for file_data in all_file_data:
         if file_data.get("lang") == "c_sharp":
@@ -87,7 +162,7 @@ def build_inheritance_and_csharp_files(
 
         caller_file_path = str(Path(file_data["path"]).resolve().as_posix())
         local_class_names = set()
-        for key in ["classes", "structs", "traits", "interfaces", "mixins", "enums", "extensions", "variables"]:
+        for key in _INHERIT_KEY_TO_LABEL:
             for item in file_data.get(key, []):
                 local_class_names.add(item["name"])
 
@@ -97,7 +172,7 @@ def build_inheritance_and_csharp_files(
             if imp.get("name")
         }
 
-        for key in ["classes", "structs", "traits", "interfaces", "mixins", "enums", "extensions", "variables"]:
+        for key, child_label in _INHERIT_KEY_TO_LABEL.items():
             for class_item in file_data.get(key, []):
                 if not class_item.get("bases"):
                     continue
@@ -109,6 +184,8 @@ def build_inheritance_and_csharp_files(
                         local_class_names,
                         local_imports,
                         imports_map,
+                        child_label=child_label,
+                        node_label_index=node_label_index,
                     )
                     if resolved:
                         inheritance_batch.append(resolved)

--- a/tests/unit/core/test_database_kuzu_kotlin_metadata.py
+++ b/tests/unit/core/test_database_kuzu_kotlin_metadata.py
@@ -630,6 +630,168 @@ def test_write_inheritance_links_resolves_cross_label_hierarchy_with_empty_label
         manager.close_driver()
 
 
+def test_write_inheritance_links_groups_by_row_labels_in_kuzu(tmp_path):
+    """#1617 made the 12x12 (child, parent) grid sparse by probing each label
+    table once and skipping pairs whose table is empty. That saving is a
+    property of the repo's *label inventory*: on a polyglot repo where every
+    label table holds at least one row, the probe removes nothing and all 144
+    internal pairs plus 12 external ones still run -- each receiving the
+    entire batch.
+
+    Resolution now pins the exact child/parent label onto each row (whenever
+    the (path, name) maps to a single node kind), so the writer issues one
+    query per (child_label, parent_label) pair that actually occurs. This
+    test is the scenario that distinguishes the two fixes: it creates one
+    node under every one of the 12 enumerated labels, so all 12 probes report
+    populated and #1617's skip is a no-op.
+
+    Both halves of the contract are asserted: the labeled rows still produce
+    exactly the right INHERITS edges (and no others), and the session.run
+    count collapses to the 12 probes plus the 2 internal pairs and 1 external
+    child label the rows actually contain. Measured on this input: 468 queries
+    before, 18 after.
+    """
+    manager = _fresh_kuzu_manager(tmp_path / "inherits-grouped-db")
+    path = "/repo/Grouped.kt"
+    try:
+        driver = manager.get_driver()
+
+        # 11 of the 12 labels are keyed by `uid`; `Union` is reserved in Kuzu
+        # and must be quoted.
+        uid_keyed = [
+            ("Class", "Widget"),
+            ("Trait", "Sized"),
+            ("Interface", "Drawable"),
+            ("Struct", "Point"),
+            ("Enum", "Color"),
+            ("`Union`", "Payload"),
+            ("Record", "Row"),
+            ("Mixin", "Loggable"),
+            ("Extension", "StringExt"),
+            ("Object", "Registry"),
+            ("Variable", "CONFIG"),
+        ]
+        with driver.session() as session:
+            for line_number, (label, name) in enumerate(uid_keyed, start=1):
+                session.run(
+                    f"""
+                    MERGE (n:{label} {{uid: $uid}})
+                    SET n.name = $name, n.path = $path, n.line_number = $line_number
+                    """,
+                    uid=f"{name.lower()}-uid",
+                    name=name,
+                    path=path,
+                    line_number=line_number,
+                )
+            # Module's primary key is `name`, not `uid`.
+            session.run(
+                """
+                MERGE (m:Module {name: $name})
+                SET m.path = $path, m.line_number = $line_number
+                """,
+                name="Bundle",
+                path=path,
+                line_number=12,
+            )
+
+        writer = GraphWriter(driver)
+
+        session_cls = type(driver.session())
+        original_run = session_cls.run
+        call_count = 0
+
+        def counting_run(self, query, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return original_run(self, query, *args, **kwargs)
+
+        session_cls.run = counting_run
+        try:
+            writer.write_inheritance_links(
+                [
+                    # (Class, Interface)
+                    {
+                        "child_name": "Widget",
+                        "path": path,
+                        "parent_name": "Drawable",
+                        "resolved_parent_file_path": path,
+                        "confidence_label": "EXTRACTED",
+                        "child_label": "Class",
+                        "parent_label": "Interface",
+                    },
+                    # (Trait, Struct) -- a second, disjoint pair, so the test
+                    # cannot pass by hard-coding a single Class->Class query.
+                    {
+                        "child_name": "Sized",
+                        "path": path,
+                        "parent_name": "Point",
+                        "resolved_parent_file_path": path,
+                        "confidence_label": "EXTRACTED",
+                        "child_label": "Trait",
+                        "parent_label": "Struct",
+                    },
+                    # External parent: only the child label is ever known.
+                    {
+                        "child_name": "Widget",
+                        "path": path,
+                        "parent_name": "ThirdPartyBase",
+                        "resolved_parent_file_path": "__external__",
+                        "confidence_label": "INFERRED",
+                        "child_label": "Class",
+                    },
+                ],
+                [],
+                {},
+            )
+        finally:
+            session_cls.run = original_run
+
+        with driver.session() as session:
+            rows = session.run(
+                """
+                MATCH (child)-[r:INHERITS]->(parent)
+                RETURN labels(child) AS child_labels, child.name AS child_name,
+                       labels(parent) AS parent_labels, parent.name AS parent_name,
+                       r.confidence_label AS confidence_label
+                """
+            ).data()
+
+        def _primary(labels):
+            return labels[0] if isinstance(labels, list) else labels
+
+        # Exact edge set: the right edges, and nothing extra. Grouping by label
+        # must not drop an edge, redirect one, or invent one.
+        assert {
+            (
+                _primary(r["child_labels"]),
+                r["child_name"],
+                _primary(r["parent_labels"]),
+                r["parent_name"],
+                r["confidence_label"],
+            )
+            for r in rows
+        } == {
+            ("Class", "Widget", "Interface", "Drawable", "EXTRACTED"),
+            ("Trait", "Sized", "Struct", "Point", "EXTRACTED"),
+            ("Class", "Widget", "ExternalClass", "ThirdPartyBase", "INFERRED"),
+        }
+
+        # Expected: 12 existence probes (still issued unconditionally, for the
+        # benefit of the label-less fallback paths) + one query per pair the
+        # rows actually contain. Measured: 18.
+        assert call_count <= 20
+        # The same input issued 468 queries before this change: 144 internal
+        # pair queries + 12 external, and -- because the Kuzu adapter unrolls
+        # `UNWIND $batch` into one query per row to sidestep a relationship
+        # planner bug (database_embedded_kuzu.py) -- a further pair-times-row
+        # fan-out on top of them. #1617's empty-table skip removes none of it
+        # in this scenario, because every one of the 12 label tables is
+        # populated.
+        assert call_count < 12 + 12 * 12
+    finally:
+        manager.close_driver()
+
+
 def test_is_composable_persists_in_kuzu(tmp_path):
     """The is_composable flag must survive the writer's property allow-list.
 


### PR DESCRIPTION
write_inheritance_links iterates a 12x12 (child_label, parent_label)
grid and passes the FULL resolved batch to every surviving pair. #1617
made the grid sparse by probing each label table once and skipping pairs
whose table is empty -- but every pair that survives the probe still
receives the whole batch, and the number of survivors is a property of
the repo's label inventory, not of the edges being written.

1. Resolution now attaches the exact child/parent node label to each
   row. build_inheritance_and_csharp_files builds a path -> {name ->
   set(labels)} index over the 12 inheritance-eligible construct kinds
   and pins a row's child_label / parent_label only when that (path,
   name) maps to exactly one kind. The writer then runs one query per
   (child_label, parent_label) pair that actually occurs.

2. Rows whose (path, name) is ambiguous carry no label and fall back to
   the original enumeration. This is not hypothetical: as
   write_binds_links' docstring already records, Kotlin does not qualify
   `name` by enclosing scope, so a top-level interface and an unrelated
   nested class can legitimately share name+path. #1617's
   populated_labels set is retained and applied to exactly those
   fallback paths. It is deliberately NOT applied to the grouped pairs:
   those pairs come from the rows themselves, so they are never empty,
   and probing them would be pure overhead while a stale or
   lazily-created label table would let the probe silently drop a real
   INHERITS edge.

3. batch_size = 500 was declared and never used; the batch is now
   chunked. This is a separate robustness fix -- it keeps a five-figure
   UNWIND payload out of a single driver round-trip -- and it is not
   what produces the numbers below. On a repo with few populated labels
   it slightly *raises* the raw query count while cutting total work.

Relationship to #1617: complementary, not overlapping. #1617's saving is
a function of how many of the 12 label tables are empty; this change's
saving is a function of how many (child, parent) pairs the data actually
contains. On a repo where all 12 tables are non-empty, #1617 removes no
pairs at all and the full fan-out survives.

Measured, Neo4j, the pass in isolation on a 27,530-file
Python/JavaScript repo (756k nodes, 20,719 resolved rows), same store
and page cache on both sides, INHERITS deleted between runs so each
starts identical:

| metric | `upstream/main` | this change | |
|---|---|---|---|
| resolution | 1.05 s | 1.77 s | (we cost +0.72 s) |
| `write_inheritance_links` | 7,433.5 s | 620.4 s | **12.0× faster** |
| batch-rows processed | 207,340 | 21,487 | **9.7× fewer** |
| queries | 32 | 80 | 0.4× — *more*, see below |

Query count goes UP because batch_size chunking splits the one large
pair into ~21 round-trips; the work per round-trip is what falls.
Upstream's 32 queries are 12 probes + 16 internal + 4 external, and
solving `16*I + 4*E = 207,340` against `I + E = 20,719` gives
`I = 10,372`, `E = 10,347` -- i.e. the internal batch really is passed 16 times and the
external batch 4 times, where this change passes each once. Resolution
costs 0.72 s more, for the path -> {name -> set(labels)} index over all
27,530 files.

These figures were measured against 810ea8a, before #1648 added row
deduplication to this function. Dedupe shrinks the batch identically on
both sides, so the batch-pass structure and the ratios above are
unaffected; only the absolute row counts would be smaller today.

Qualification: that database was provisioned by upstream's own schema,
which has no composite (name, path) index, so every pair query scans
rather than seeks and the absolute times are dominated by that scan
cost. The quantity this change controls is the number of batch passes,
and that is unaffected by indexing. On Kuzu the same structure shows up
without any index question, because the Kuzu adapter unrolls `UNWIND
$batch` into one query per row to sidestep a relationship planner bug:
with all 12 label tables populated, the added test's 3-row input issues
468 session.run calls before this change and 18 after.

The batch-pass count is structural: with P of the 12 labels populated
the old code passes the internal batch `P^2` times and the external
batch `P` times. P was 4 here; at P = 12, #1617 skips nothing and the factor is
78x.

Output is unchanged: the produced INHERITS edge set is identical. On the
corpus above both sides produced the same 20,963 INHERITS edges with an
identical per-(child_label, parent_label) breakdown across all seven
pairs that occur. Also verified by (a) the 21-project parser golden
suite (tests/fixtures/goldens), whose node/edge exports are unchanged,
(b) upstream's three existing write_inheritance_links tests, which feed
label-less rows and so exercise the fallback enumeration unmodified --
including #1617's probe-failure invariant, and (c) the added test, whose
exact-edge-set assertion passes identically before and after the change
while the query count collapses. On that corpus the ambiguity guard
fired on 74 of 20,719 rows (0.36%), which took the enumeration fallback.

### Tests added

`tests/unit/core/test_database_kuzu_kotlin_metadata.py::test_write_inheritance_links_groups_by_row_labels_in_kuzu`

Modelled on #1617's own test and living beside it, against the same embedded
Kuzu backend, so it runs in `./tests/run_tests.sh fast` with no external
service. It creates one node under every one of the 12 enumerated labels —
the scenario in which the empty-table probe can skip nothing at all — and
asserts both halves of the contract:

- the **exact** INHERITS edge set produced by the labeled rows (right edges,
  correct endpoint labels, correct confidence, and nothing extra);
- the `session.run` count, which drops from 468 to 18 on that input.

The edge-set assertion passes identically with and without the change, so
the test doubles as an output-identity check; only the count assertion fails
on the pre-change code.

`./tests/run_tests.sh fast` on this branch: 1 failed, 1282 passed, 7 skipped.
On pristine `main`: 1 failed, 1281 passed, 7 skipped. Identical failure sets —
the single failure, `test_parser_goldens[sample_project_kotlin]`, is
pre-existing on `main`. No golden fixture changed.
