### PR TITLE
chore(release): bump version to 0.6.5

### DIFF
--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-08-19 20:03 UTC_
+_Generated: 2026-08-19 21:02 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.4"
+version = "0.6.5"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
0.6.4 → 0.6.5 — completes the #1538 parser audit (now closed):

- **Context attribution across 7 languages** (#1657): Java/C#/Swift/PHP call-site `class_context` was structurally dead — now live, activating super()/same-name-method resolution; Rust impl methods linked to their types; nested-function CONTAINS recovered for JS/TS/Lua/PHP
- **Spurious-record fixes** (#1659): PHP 8.1 enums indexed, C function-like macros (+14 on the fixture) and enum-member attribution, Elixir false self-calls removed, Ruby receiver stealing, C# same-line calls + attribute extraction, Haskell curried-application duplicates

Full integration suite green at the release commit: **89 passed / 0 failed**.