### PR TITLE
docs: link out to star-history while the chart API is restricted

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,12 @@ flowchart LR
 ---
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[Star History Chart ↗](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+<!-- The inline chart image is temporarily removed: api.star-history.com currently
+     renders "GitHub restricted access to star data" instead of the chart
+     (GitHub-side restriction, see PR #1642). Restore the image once the
+     official service recovers:
+     [![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date) -->
 
 ---
 

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -119,7 +119,12 @@
 ---
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[Star History Chart ↗](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+<!-- The inline chart image is temporarily removed: api.star-history.com currently
+     renders "GitHub restricted access to star data" instead of the chart
+     (GitHub-side restriction, see PR #1642). Restore the image once the
+     official service recovers:
+     [![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date) -->
 
 ---
 

--- a/docs/translations/README.kor.md
+++ b/docs/translations/README.kor.md
@@ -118,7 +118,12 @@
 ---
 
 ## Star 기록
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[Star History Chart ↗](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+<!-- The inline chart image is temporarily removed: api.star-history.com currently
+     renders "GitHub restricted access to star data" instead of the chart
+     (GitHub-side restriction, see PR #1642). Restore the image once the
+     official service recovers:
+     [![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date) -->
 
 ---
 

--- a/docs/translations/README.ru-RU.md
+++ b/docs/translations/README.ru-RU.md
@@ -118,7 +118,12 @@
 ---
 
 ## Динамика звезд
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[Star History Chart ↗](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+<!-- The inline chart image is temporarily removed: api.star-history.com currently
+     renders "GitHub restricted access to star data" instead of the chart
+     (GitHub-side restriction, see PR #1642). Restore the image once the
+     official service recovers:
+     [![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date) -->
 
 ---
 

--- a/docs/translations/README.ta.md
+++ b/docs/translations/README.ta.md
@@ -122,7 +122,12 @@
 ---
 
 ## நட்சத்திர வரலாறு
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[Star History Chart ↗](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+<!-- The inline chart image is temporarily removed: api.star-history.com currently
+     renders "GitHub restricted access to star data" instead of the chart
+     (GitHub-side restriction, see PR #1642). Restore the image once the
+     official service recovers:
+     [![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date) -->
 
 ---
 

--- a/docs/translations/README.uk.md
+++ b/docs/translations/README.uk.md
@@ -118,7 +118,12 @@
 ---
 
 ## Історія зірок
-[![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+[Star History Chart ↗](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date)
+<!-- The inline chart image is temporarily removed: api.star-history.com currently
+     renders "GitHub restricted access to star data" instead of the chart
+     (GitHub-side restriction, see PR #1642). Restore the image once the
+     official service recovers:
+     [![Star History Chart](https://api.star-history.com/svg?repos=CodeGraphContext/CodeGraphContext&type=Date)](https://www.star-history.com/#CodeGraphContext/CodeGraphContext&Date) -->
 
 ---
 


### PR DESCRIPTION
`api.star-history.com` currently serves a syntactically valid SVG whose rendered text is **"GitHub restricted access to star data / GitHub team is looking into it"** — so the README (and all six translations) have been displaying an error banner where the chart was. Credit to the report on #1642 for flagging that the image content (not just the payload) was broken.

This keeps the official star-history **link** and comments out the inline image with a restore note, so recovering is a one-line revert once the upstream restriction lifts. The website's StarGraph card is left as-is — it has its own refresh/fallback UI and self-heals.

(Repointing to a third-party mirror remains off the table for the reasons in #1642.)