### PR TITLE
fix(writer): wire the label-aware called-context clause (#1510)

### DIFF
--- a/src/codegraphcontext/tools/indexing/persistence/writer.py
+++ b/src/codegraphcontext/tools/indexing/persistence/writer.py
@@ -154,13 +154,29 @@ def _cypher_label(label: str, backend: str) -> str:
 
 
 def _called_context_clause(called_label: str) -> str:
-    """Match CALLS targets that store scope in context, class_context, or module_context."""
-    if called_label in ("Function", "Variable"):
+    """Match CALLS targets that store scope in context, class_context, or module_context.
+
+    Resolution stores the resolved scope in `called_context`, but which node
+    property carries that scope differs by parser: Python/JS use `context`,
+    C++/PHP methods use `class_context`, and Rust functions carry ONLY
+    `module_context` (#1510). Matching `context` alone filtered every
+    correctly-resolved Rust module-scoped call out at write time.
+
+    Variable is restricted to `context`: the Kùzu Variable table declares no
+    class_context/module_context columns, and referencing a missing column
+    binder-errors the whole batch on typed backends.
+    """
+    if called_label == "Function":
         return (
             'AND (row.called_context = "" OR row.called_context IS NULL '
             "OR called.context = row.called_context "
             "OR called.class_context = row.called_context "
             "OR called.module_context = row.called_context)"
+        )
+    if called_label == "Variable":
+        return (
+            'AND (row.called_context = "" OR row.called_context IS NULL '
+            "OR called.context = row.called_context)"
         )
     return ""
 
@@ -1006,10 +1022,12 @@ class GraphWriter:
                         precise_batch.append(row)
 
                 # Define which labels have a 'context' property in the schema
-                labels_with_context = {"Function", "Variable"}
-                called_context_clause = ""
-                if called_label in labels_with_context:
-                    called_context_clause = 'AND (row.called_context = "" OR called.context = row.called_context)'
+                # The label-aware helper matches context, class_context or
+                # module_context depending on what the label's parsers emit —
+                # the inline context-only predicate silently dropped Rust
+                # module-scoped calls whose functions carry only
+                # module_context (#1510).
+                called_context_clause = _called_context_clause(called_label)
 
                 # ...and which have a 'line_number'. File and Directory do not:
                 # the Kùzu File table is (path, name, relative_path, package_name,

--- a/tests/unit/tools/test_called_context_matching.py
+++ b/tests/unit/tools/test_called_context_matching.py
@@ -1,0 +1,86 @@
+"""#1510: resolved CALLS whose target scope lives in module_context must land.
+
+The writer matched `called.context` only, but Rust functions carry their scope
+exclusively in `module_context` — so correctly-resolved module-scoped Rust
+calls were filtered out at write time (or binder-skipped the batch on Kùzu).
+Verified against a real embedded database.
+"""
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+from codegraphcontext.tools.indexing.persistence.writer import (
+    GraphWriter,
+    _called_context_clause,
+)
+
+kuzu = pytest.importorskip("kuzu")
+
+
+def test_clause_is_label_aware():
+    fn = _called_context_clause("Function")
+    assert "module_context" in fn and "class_context" in fn
+    var = _called_context_clause("Variable")
+    # Kùzu's Variable table has no class/module_context columns; referencing
+    # them binder-errors the whole batch on typed backends.
+    assert "module_context" not in var and "class_context" not in var
+    assert "called.context" in var
+    assert _called_context_clause("File") == ""
+
+
+def test_module_context_scoped_call_lands_on_kuzu(tmp_path: Path):
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    driver = manager.get_driver()
+    try:
+        w = GraphWriter(driver)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        f = repo / "lib.rs"
+        f.write_text("mod utils { pub fn helper() {} }\n", encoding="utf-8")
+        w.add_repository_to_graph(repo)
+        # A Rust-style function: scope in module_context, NO context key.
+        w.add_file_to_graph(
+            {
+                "path": str(f), "repo_path": str(repo), "lang": "rust",
+                "imports": [],
+                "functions": [
+                    {"name": "helper", "line_number": 1, "end_line": 1,
+                     "args": [], "module_context": "utils"},
+                    {"name": "caller", "line_number": 2, "end_line": 3,
+                     "args": [], "module_context": "crate"},
+                ],
+                "classes": [], "variables": [],
+            },
+            repo.name, {}, repo_path_str=str(repo.resolve()),
+        )
+        # A resolved call whose called_context is the module scope.
+        w.write_function_call_groups(
+            [
+                {
+                    "type": "function",
+                    "caller_name": "caller",
+                    "caller_file_path": str(f),
+                    "caller_line_number": 2,
+                    "called_name": "helper",
+                    "called_file_path": str(f),
+                    "called_line_number": 1,
+                    "called_context": "utils",
+                    "line_number": 2,
+                    "full_call_name": "utils::helper",
+                    "args": [],
+                    "args_key": "",
+                    "resolution_tier": 5,
+                    "confidence": 0.9,
+                    "confidence_label": "RESOLVED",
+                }
+            ],
+        )
+        with driver.session() as s:
+            rows = s.run(
+                "MATCH (a:Function {name:'caller'})-[r:CALLS]->(b:Function {name:'helper'}) "
+                "RETURN count(r) AS c"
+            ).data()
+        assert rows[0]["c"] == 1, "module_context-scoped CALLS edge was dropped"
+    finally:
+        manager.close_driver()


### PR DESCRIPTION
The dead helper the issue identified is now label-aware and actually wired in: Function matches `context | class_context | module_context`; Variable stays `context`-only because the Kùzu Variable table declares no class/module_context columns and a missing-column reference binder-skips the whole batch on typed backends.

Real-Kùzu regression test: a Rust-style function (scope only in `module_context`, no `context` key) + a resolved call with `called_context='utils'` → the CALLS edge lands (it was dropped before). Unit suite 1413 passed / 7 skipped; all 21 goldens unchanged.

Fixes #1510