### PR TITLE
chore(release): bump version to 0.6.6

### DIFF
--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-08-19 21:02 UTC_
+_Generated: 2026-08-26 14:25 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.5"
+version = "0.6.6"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
0.6.5 → 0.6.6:

- **Relationship writes seek instead of scan on Neo4j**: (name, path) composite indexes for all 11 positional labels — up to 485× on large graphs (#1653, @mollyjester)
- **Rust module-scoped and `Type::method()` CALLS now land end-to-end**: the label-aware called-context clause is wired in (#1667/#1510) and the full scoped-resolution chain is pinned by regression test (#1668/#1658)
- README star-history chart replaced with a link while the upstream API is restricted (#1666); broken docs reference removed (#1663)
- Complexity-CI test fixture made diagnosable under load (#1669)

Full integration suite green at the release commit: **89 passed / 0 failed**.