### PR TITLE
chore(release): bump version to 0.6.7

### DIFF
--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-08-26 14:25 UTC_
+_Generated: 2026-08-26 16:58 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.6"
+version = "0.6.7"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
0.6.6 → 0.6.7 — the #1671 batch, closing #1660 (the last split from the #1538 parser audit):

- Kotlin/PHP annotated declarations report their **declaration line**, not the annotation line — with the context walkers aligned so Hilt/Previews resolution joins stay intact
- Ruby `@@class_variables` and `$globals` captured; variable `values` populated (were always None due to wrapper-identity bucketing); type ladder fixed
- Neo4j `(name, path)` indexes for EnumMember/Object/Mixin/Extension/Parameter — previously label scans (#1653's closing observation)

Also: #1576 verified-and-closed (claims don't reproduce). Full integration suite green at the release commit: **89 passed / 0 failed**.