### PR TITLE
fix(scip): index converges with the discovery census and reports a summary

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -351,7 +351,7 @@ def index_helper(path: str, context: Optional[str] = None, no_progress: bool = F
                 file_count = record["file_count"] if record else 0
                 
                 if file_count > 0:
-                    expected = graph_builder.estimate_processing_time(path_obj) if path_obj.is_dir() else None
+                    expected = graph_builder.estimate_processing_time(path_obj, cgcignore_path=ctx.cgcignore_path) if path_obj.is_dir() else None
                     expected_file_count = expected[0] if expected else None
                     if expected_file_count is None or file_count >= expected_file_count:
                         console.print(f"[yellow]Repository '{path}' is already indexed with {file_count} files. Skipping.[/yellow]")
@@ -361,6 +361,32 @@ def index_helper(path: str, context: Optional[str] = None, no_progress: bool = F
                     console.print(
                         f"[yellow]Repository '{path}' has only {file_count} of {expected_file_count} files indexed. Continuing.[/yellow]"
                     )
+                    # Name the gap: without this, a pipeline that can never
+                    # produce nodes for some files loops on the message above
+                    # forever with nothing actionable (#1673).
+                    try:
+                        from codegraphcontext.tools.indexing.discovery import discover_files_to_index
+                        discovered, _ = discover_files_to_index(
+                            path_obj,
+                            cgcignore_path=ctx.cgcignore_path,
+                            supported_extensions=set(graph_builder.parsers.keys()),
+                        )
+                        with db_manager.get_driver().session() as s2:
+                            res2 = s2.run(
+                                "MATCH (r:Repository {path: $path})-[:CONTAINS*]->(f:File) RETURN DISTINCT f.path AS p",
+                                path=repo_path_str,
+                            )
+                            have = {row["p"] for row in res2 if row.get("p")}
+                        missing = [
+                            str(f) for f in discovered
+                            if str(f.resolve()) not in have and f.resolve().as_posix() not in have
+                        ]
+                        if missing:
+                            shown = ", ".join(Path(m).name for m in missing[:5])
+                            more = f" (+{len(missing) - 5} more)" if len(missing) > 5 else ""
+                            console.print(f"[dim]Missing: {shown}{more}[/dim]")
+                    except Exception:
+                        pass
                 else:
                     console.print(f"[yellow]Repository '{path}' exists but has no files (likely interrupted). Re-indexing...[/yellow]")
         except Exception as e:

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -534,7 +534,7 @@ class GraphBuilder:
             # still reports "Successfully finished indexing".
             return {"path": str(path), "error": str(e), "parse_failed": True}
 
-    def estimate_processing_time(self, path: Path) -> Optional[Tuple[int, float]]:
+    def estimate_processing_time(self, path: Path, cgcignore_path: Optional[str] = None) -> Optional[Tuple[int, float]]:
         """Estimate the time required to index a repository.
 
         Parameters
@@ -550,8 +550,13 @@ class GraphBuilder:
         try:
             from codegraphcontext.tools.indexing.discovery import discover_files_to_index
             supported_extensions = set(self.parsers.keys())
+            # cgcignore_path must match what the indexing pipelines use:
+            # counting files a context-specific ignore excludes made the
+            # resume check expect more files than indexing will ever produce
+            # ("only N of M files indexed" on every run, #1673).
             files, _ = discover_files_to_index(
                 path,
+                cgcignore_path=cgcignore_path,
                 supported_extensions=supported_extensions,
             )
             total_files = len(files)
@@ -566,6 +571,9 @@ class GraphBuilder:
     ):
         from . import scip_indexer
 
+        # Reset here too: without it a SCIP run left (and printed) the
+        # PREVIOUS Tree-sitter run's summary from the same process (#1673).
+        self.last_index_summary = {}
         await run_scip_index_async(
             path,
             is_dependency,
@@ -577,6 +585,7 @@ class GraphBuilder:
             self.get_parser,
             scip_indexer,
             cgcignore_path,
+            index_summary=self.last_index_summary,
         )
 
     def _name_from_symbol(self, symbol: str) -> str:

--- a/src/codegraphcontext/tools/indexing/scip_pipeline.py
+++ b/src/codegraphcontext/tools/indexing/scip_pipeline.py
@@ -42,6 +42,7 @@ async def run_scip_index_async(
     get_parser: Callable[[str], Any],
     scip_indexer_mod: Any,
     cgcignore_path: Optional[str] = None,
+    index_summary: Optional[dict] = None,
 ) -> None:
     """Run SCIP CLI, write graph, supplement with Tree-sitter, write SCIP CALLS edges."""
     ScipIndexer = scip_indexer_mod.ScipIndexer
@@ -171,7 +172,18 @@ async def run_scip_index_async(
                 except Exception as e:
                     debug_log(f"Tree-sitter supplement failed for {abs_path_str}: {e}")
 
-            writer.add_file_to_graph(file_data, repo_name, imports_map)
+            try:
+                writer.add_file_to_graph(file_data, repo_name, imports_map)
+            except Exception as e:
+                # One unwritable file must not abort the run, and it must
+                # still be accounted for — otherwise the graph stays short of
+                # the discovery census and `cgc index` reports "only N of M
+                # files indexed. Continuing." on every run, forever (#1673).
+                warning_logger(f"SCIP file write failed for {abs_path_str}: {e}; recording minimal node")
+                try:
+                    writer.add_minimal_file_node(Path(abs_path_str), index_root, is_dependency)
+                except Exception as e2:
+                    debug_log(f"Minimal node fallback also failed for {abs_path_str}: {e2}")
 
             processed += 1
             if job_id:
@@ -236,6 +248,14 @@ async def run_scip_index_async(
             try:
                 ts_data = ts_parser.parse(repo_file, is_dependency, index_source=True)
                 if "error" in ts_data:
+                    # Same accounting rule as the Tree-sitter pipeline: a file
+                    # that failed to parse still gets a minimal File node so
+                    # the graph count converges with discovery (#1673).
+                    await asyncio.to_thread(
+                        writer.add_minimal_file_node, repo_file, index_root, is_dependency
+                    )
+                    minimal_nodes += 1
+                    processed += 1
                     continue
                 ts_data["repo_path"] = str(index_root)
                 ts_data.setdefault("function_calls_scip", [])
@@ -251,6 +271,14 @@ async def run_scip_index_async(
                     )
             except Exception as e:
                 debug_log(f"Tree-sitter supplement (non-SCIP file) failed for {abs_str}: {e}")
+                try:
+                    await asyncio.to_thread(
+                        writer.add_minimal_file_node, repo_file, index_root, is_dependency
+                    )
+                    minimal_nodes += 1
+                    processed += 1
+                except Exception as e2:
+                    debug_log(f"Minimal node fallback also failed for {abs_str}: {e2}")
         if supplemented:
             # Re-run pre_scan with the expanded file list so imports_map is complete
             all_paths = [Path(p) for p in files_data.keys() if Path(p).exists()]
@@ -283,6 +311,30 @@ async def run_scip_index_async(
         info_logger(f"[CALLS] Tree-sitter call resolution complete in {time.time() - t_calls:.1f}s")
 
         writer.write_scip_call_edges(files_data, name_from_symbol)
+
+        # CLI-facing summary — the SCIP path never populated one, so
+        # `cgc index` finished silently with no file/function/class report
+        # at all (#1673).
+        if index_summary is not None:
+            from collections import Counter
+            extension_counts = Counter()
+            for fp in files_data.keys():
+                suffix = Path(fp).suffix or Path(fp).name
+                extension_counts[suffix] += 1
+            index_summary.clear()
+            index_summary.update({
+                "total_scanned_files": len(files_data) + minimal_nodes,
+                "files_by_extension": dict(extension_counts),
+                "function_nodes": sum(
+                    1 for fd in all_file_data for fn in fd.get("functions", [])
+                    if fn.get("name") != "<module>"
+                ),
+                "class_nodes": sum(len(fd.get("classes", [])) for fd in all_file_data),
+                "call_edges": sum(len(g) for g in resolved_calls),
+                "serialization_seconds": 0.0,
+                "failed_files": 0,
+                "minimal_file_nodes": minimal_nodes,
+            })
 
         if job_id:
             job_manager.update_job(job_id, status=JobStatus.COMPLETED, end_time=datetime.now())

--- a/tests/unit/tools/test_scip_index_convergence.py
+++ b/tests/unit/tools/test_scip_index_convergence.py
@@ -1,0 +1,158 @@
+"""#1673: the SCIP pipeline must converge with the discovery census.
+
+A user with a mixed C#/other repo saw `cgc index .` report
+"repository '.' has only 32 of 46 files indexed. Continuing." on EVERY run,
+forever, and the run finished with no summary at all. Root causes: files
+whose supplemental Tree-sitter parse errored (or whose write raised) got no
+File node of any kind, and the SCIP path never populated the CLI summary.
+
+Driven with a fake scip module against a real embedded database.
+"""
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+from codegraphcontext.tools.graph_builder import GraphBuilder
+from codegraphcontext.tools.indexing.scip_pipeline import run_scip_index_async
+from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+kuzu = pytest.importorskip("kuzu")
+
+
+class _DBM:
+    def __init__(self, driver):
+        self._driver = driver
+
+    def get_driver(self, graph_name=None):
+        return self._driver
+
+    def get_backend_type(self):
+        return "kuzudb"
+
+
+class _JM:
+    def update_job(self, *a, **k):
+        pass
+
+
+def _fake_scip_module(covered_file: Path):
+    """A scip_indexer module double: 'indexes' exactly one file."""
+
+    class FakeIndexer:
+        def run(self, path, lang, tmpdir):
+            return Path(tmpdir) / "index.scip"  # existence is not checked
+
+    class FakeParser:
+        def parse(self, scip_file, path):
+            return {
+                "files": {
+                    str(covered_file.resolve()): {
+                        "path": str(covered_file.resolve()),
+                        "lang": "c_sharp",
+                        "imports": [],
+                        "functions": [
+                            {"name": "Covered", "line_number": 1, "end_line": 2, "args": []}
+                        ],
+                        "classes": [],
+                        "variables": [],
+                        "function_calls_scip": [],
+                        "module_level_calls_scip": [],
+                    }
+                }
+            }
+
+    return SimpleNamespace(ScipIndexer=FakeIndexer, ScipIndexParser=FakeParser)
+
+
+def test_scip_run_converges_with_discovery_census(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    covered = repo / "Program.cs"
+    covered.write_text("class P { void Covered() {} }\n", encoding="utf-8")
+    (repo / "helper.py").write_text("def helper():\n    pass\n", encoding="utf-8")
+    (repo / "README.md").write_text("# readme\n", encoding="utf-8")
+    (repo / "notes.json").write_text("{}\n", encoding="utf-8")
+
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    driver = manager.get_driver()
+    try:
+        gb = GraphBuilder(_DBM(driver), _JM(), asyncio.new_event_loop())
+        summary: dict = {}
+        asyncio.new_event_loop().run_until_complete(
+            run_scip_index_async(
+                repo,
+                False,
+                None,
+                "c_sharp",
+                gb._writer,
+                _JM(),
+                gb.parsers.keys(),
+                gb.get_parser,
+                _fake_scip_module(covered),
+                None,
+                index_summary=summary,
+            )
+        )
+
+        # Every discovered file must have a File node under the repository —
+        # the resume check compares exactly these two numbers.
+        expected_count = gb.estimate_processing_time(repo)[0]
+        with driver.session() as s:
+            row = s.run(
+                "MATCH (r:Repository {path: $p})-[:CONTAINS*]->(f:File) "
+                "RETURN count(DISTINCT f) AS c",
+                p=str(repo.resolve()),
+            ).data()[0]
+        assert row["c"] >= expected_count, (
+            f"graph has {row['c']} File nodes but discovery counts "
+            f"{expected_count} — 'only N of M files indexed' would loop forever"
+        )
+
+        # And the run must produce a summary (it used to finish silently).
+        assert summary.get("total_scanned_files", 0) >= 1
+        assert "files_by_extension" in summary
+    finally:
+        manager.close_driver()
+
+
+def test_supplement_parse_failure_still_records_the_file(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    covered = repo / "Program.cs"
+    covered.write_text("class P {}\n", encoding="utf-8")
+    broken = repo / "broken.py"
+    broken.write_text("def x():\n    pass\n", encoding="utf-8")
+
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    driver = manager.get_driver()
+    try:
+        gb = GraphBuilder(_DBM(driver), _JM(), asyncio.new_event_loop())
+
+        real_get_parser = gb.get_parser
+
+        class _ExplodingParser:
+            def parse(self, *a, **k):
+                raise RuntimeError("simulated parser crash under load")
+
+        def flaky_get_parser(suffix):
+            if suffix == ".py":
+                return _ExplodingParser()
+            return real_get_parser(suffix)
+
+        asyncio.new_event_loop().run_until_complete(
+            run_scip_index_async(
+                repo, False, None, "c_sharp", gb._writer, _JM(),
+                gb.parsers.keys(), flaky_get_parser, _fake_scip_module(covered),
+                None, index_summary={},
+            )
+        )
+        with driver.session() as s:
+            row = s.run(
+                "MATCH (f:File) WHERE f.path ENDS WITH 'broken.py' RETURN count(f) AS c"
+            ).data()[0]
+        assert row["c"] == 1, "a file whose parse crashed vanished from the graph"
+    finally:
+        manager.close_driver()


### PR DESCRIPTION
Fixes the user-reported scip-dotnet loop: no summary after indexing, and *"repository '.' has only 32 of 46 files indexed. Continuing."* on every rerun, forever.

- **Convergence by construction**: every shortfall path in the SCIP pipeline (supplement parse error, parse crash, failed SCIP-covered write) now records at least a minimal File node — the same accounting rule the Tree-sitter pipeline already follows — so graph count reaches the discovery census and reruns hit "already indexed … Skipping".
- **The summary actually prints** for SCIP runs (files by extension, function/class/CALLS counts), and the stale-summary hazard (a SCIP run printing the previous Tree-sitter run's table) is closed by resetting before the run.
- **Census symmetry**: `estimate_processing_time` now takes the context's `cgcignore_path`, so both sides of the "N of M" comparison count the same file set.
- **Actionable gaps**: the "Continuing" branch names up to 5 missing files.

Regression tests drive the full pipeline with a fake scip module against a real embedded database — including a simulated parser crash — asserting graph-count ≥ census and a populated summary. Unit suite **1420 passed / 7 skipped**; full integration gate **89 passed / 0 failed**.

Fixes #1673