### PR TITLE
chore(release): bump version to 0.6.8

### DIFF
--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-08-26 16:58 UTC_
+_Generated: 2026-08-26 18:53 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.7"
+version = "0.6.8"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
0.6.7 → 0.6.8 — the SCIP convergence fix (#1674, fixes #1673):

- SCIP-indexed repos (scip-dotnet et al.) no longer loop on "only N of M files indexed. Continuing." — every discovered file is accounted for, so reruns reach "already indexed"
- `cgc index` prints the summary table after SCIP runs (was silent)
- resume-check census respects the context's .cgcignore
- genuine gaps now name the missing files

Full integration suite green at the release commit: 89 passed / 0 failed.