### PR TITLE
fix(setup-wizard): stop replacing IDE settings that are JSONC

### DIFF
--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import time
 import json
+import re
 import sys
 import shutil
 import yaml 
@@ -14,6 +15,48 @@ from codegraphcontext.core.database import DatabaseManager
 from codegraphcontext.cli.config_manager import normalize_config_path
 
 console = Console()
+
+def _strip_jsonc(text: str) -> str:
+    """Drop // and /* */ comments and trailing commas from a JSONC document.
+
+    VS Code and its forks write settings.json as JSONC. json.loads rejects both,
+    and treating that rejection as "no settings yet" discards the user's file.
+    """
+    out = []
+    i, n = 0, len(text)
+    in_string = escaped = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if text.startswith("//", i):
+            i = text.find("\n", i)
+            if i == -1:
+                break
+            continue
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        out.append(ch)
+        i += 1
+    stripped = "".join(out)
+    # A trailing comma before } or ] is legal JSONC, not JSON.
+    return re.sub(r",(\s*[}\]])", r"\1", stripped)
+
 
 def _check_write_access(path: Path) -> bool:
     target = path if path.exists() else path.parent
@@ -483,12 +526,26 @@ def _configure_ide(mcp_config):
 
         console.print(f"Using configuration file at: {target_path}")
         
+        had_comments = False
         try:
-            with open(target_path, "r") as f:
+            raw = target_path.read_text()
+            try:
+                settings = json.loads(raw)
+            except json.JSONDecodeError:
                 try:
-                    settings = json.load(f)
+                    settings = json.loads(_strip_jsonc(raw))
+                    had_comments = True
                 except json.JSONDecodeError:
-                    settings = {}
+                    # Never fall back to {}: this file gets written back below, so
+                    # treating an unreadable file as an empty one destroys it.
+                    console.print(
+                        f"[bold red]Could not parse {target_path}.[/bold red] "
+                        "Leaving it untouched so nothing is lost."
+                    )
+                    console.print(
+                        "Please add the MCP configuration manually from the `mcp.json` file generated above."
+                    )
+                    return
         except FileNotFoundError:
             settings = {}
 
@@ -515,6 +572,15 @@ def _configure_ide(mcp_config):
                 )
                 return
 
+            if target_path.exists():
+                backup_path = target_path.with_suffix(target_path.suffix + ".cgc-backup")
+                shutil.copy2(target_path, backup_path)
+                console.print(f"[dim]Backed up existing configuration to {backup_path}[/dim]")
+            if had_comments:
+                console.print(
+                    "[yellow]Note: this file contained comments. JSON output cannot keep them, "
+                    "so they are dropped in the rewritten file (the backup above still has them).[/yellow]"
+                )
             try:
                 with open(target_path, "w") as f:
                     json.dump(settings, f, indent=2)

--- a/tests/unit/cli/test_setup_wizard_jsonc.py
+++ b/tests/unit/cli/test_setup_wizard_jsonc.py
@@ -1,0 +1,70 @@
+"""#660: the setup wizard replaced VS Code's settings.json instead of adding to it.
+
+VS Code and its forks write settings.json as JSONC. `json.load` rejects comments
+and trailing commas, and the wizard treated that rejection as "no settings yet"
+before writing the file back — so a user's whole configuration was replaced by a
+lone `mcpServers` key. These pin the two halves of the fix: JSONC parses, and an
+input that still cannot be parsed is left alone rather than overwritten.
+"""
+
+import ast
+import json
+import re
+
+import pytest
+
+from codegraphcontext.cli import setup_wizard
+
+_strip_jsonc = setup_wizard._strip_jsonc
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ('{\n  // font\n  "editor.fontSize": 14\n}', {"editor.fontSize": 14}),
+        ('{\n  /* multi\n     line */\n  "a": 1\n}', {"a": 1}),
+        ('{\n  "a": 1,\n  "b": [1, 2,],\n}', {"a": 1, "b": [1, 2]}),
+        ('{"url": "https://example.com//path"}', {"url": "https://example.com//path"}),
+        ('{"s": "quote \\" then // text"}', {"s": 'quote " then // text'}),
+        ('{"a": 1, "b": {"c": 2}}', {"a": 1, "b": {"c": 2}}),
+    ],
+)
+def test_strip_jsonc_parses(raw, expected):
+    assert json.loads(_strip_jsonc(raw)) == expected
+
+
+def test_comment_markers_inside_strings_are_not_stripped():
+    """A // or /* inside a string value is data, not a comment."""
+    raw = '{"a": "x // y", "b": "p /* q */ r"}'
+    assert json.loads(_strip_jsonc(raw)) == {"a": "x // y", "b": "p /* q */ r"}
+
+
+def test_real_settings_file_survives_a_round_trip():
+    """The shape from #660: a commented settings.json keeps every key."""
+    raw = """{
+  // Editor
+  "editor.fontSize": 14,
+  "editor.tabSize": 2,
+  /* Theme */
+  "workbench.colorTheme": "Default Dark+",
+  "files.exclude": { "**/.git": true },
+}"""
+    settings = json.loads(_strip_jsonc(raw))
+    assert settings["editor.fontSize"] == 14
+    assert settings["workbench.colorTheme"] == "Default Dark+"
+    assert settings["files.exclude"] == {"**/.git": True}
+
+    settings.setdefault("mcpServers", {})["cgc"] = {"command": "cgc"}
+    assert settings["editor.tabSize"] == 2
+
+
+def test_unparseable_input_is_not_silently_emptied():
+    """Truncated JSONC must raise, so the caller can decline to write."""
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(_strip_jsonc('{"a": 1, "b": '))
+
+
+def test_wizard_returns_without_writing_when_parsing_fails():
+    """The bug was the {} fallback; the source must no longer contain it."""
+    src = ast.unparse(ast.parse(open(setup_wizard.__file__).read()))
+    assert not re.search(r"except json\.JSONDecodeError:\s*settings = \{\}", src)


### PR DESCRIPTION
The wizard read the target settings file like this:

```python
try:
    settings = json.load(f)
except json.JSONDecodeError:
    settings = {}
```

and then wrote `settings` back over the same file. VS Code and its forks write `settings.json` as JSONC, so a file with `// comments` or a trailing comma raises `JSONDecodeError` — the wizard read that as "no settings yet" and replaced the whole configuration with a lone `mcpServers` key. Two people on the issue lost their settings this way; one only recovered because Settings Sync was on.

Three changes:

- Parse JSONC before giving up. `_strip_jsonc` removes `//` and `/* */` comments and trailing commas, tracking string state so a `//` inside a URL or an escaped quote is left alone.
- If it still will not parse, print why and return **without writing**. That fallback to `{}` was the actual data loss; an unreadable file should be left alone, not replaced.
- Back up the file to `.cgc-backup` before writing, and say so when comments were present, since `json.dump` cannot preserve them. The backup keeps them.

Comment preservation on the rewritten file would need a JSONC-aware writer and a new dependency, so I kept it to the data loss and made the tradeoff visible instead of silent. Happy to go further if you would rather.

Tests: `tests/unit/cli/test_setup_wizard_jsonc.py`, 10 passing. They cover line and block comments, trailing commas, comment markers inside strings and URLs, a realistic commented `settings.json` keeping every key across a round trip, and that unparseable input raises rather than resolving to `{}`.

```
$ python -m pytest tests/unit/cli/test_setup_wizard_jsonc.py -q
..........                                                               [100%]
10 passed in 0.82s
```

Fixes #660