### PR TITLE
fix(jobs): serialize last update time in job responses

### DIFF
--- a/src/codegraphcontext/tools/handlers/management_handlers.py
+++ b/src/codegraphcontext/tools/handlers/management_handlers.py
@@ -98,6 +98,8 @@ def check_job_status(job_manager: JobManager, **args) -> Dict[str, Any]:
         job_dict["start_time"] = job.start_time.strftime("%Y-%m-%d %H:%M:%S")
         if job.end_time:
             job_dict["end_time"] = job.end_time.strftime("%Y-%m-%d %H:%M:%S")
+        if job.last_update_time:
+            job_dict["last_update_time"] = job.last_update_time.strftime("%Y-%m-%d %H:%M:%S")
         
         job_dict["status"] = job.status.value
         
@@ -119,6 +121,8 @@ def list_jobs(job_manager: JobManager) -> Dict[str, Any]:
             job_dict["start_time"] = job.start_time.strftime("%Y-%m-%d %H:%M:%S")
             if job.end_time:
                 job_dict["end_time"] = job.end_time.strftime("%Y-%m-%d %H:%M:%S")
+            if job.last_update_time:
+                job_dict["last_update_time"] = job.last_update_time.strftime("%Y-%m-%d %H:%M:%S")
             jobs_data.append(job_dict)
         
         jobs_data.sort(key=lambda x: x["start_time"], reverse=True)

--- a/tests/unit/tools/test_management_handlers_jobs.py
+++ b/tests/unit/tools/test_management_handlers_jobs.py
@@ -1,0 +1,35 @@
+import json
+
+import pytest
+
+from codegraphcontext.core.jobs import JobManager
+from codegraphcontext.tools.handlers.management_handlers import (
+    check_job_status,
+    list_jobs,
+)
+
+
+@pytest.fixture
+def updated_job_manager():
+    manager = JobManager()
+    job_id = manager.create_job("/tmp/repo")
+    manager.update_job(job_id, processed_files=1)
+    return manager, job_id
+
+
+def test_check_job_status_returns_json_serializable_updated_job(updated_job_manager):
+    manager, job_id = updated_job_manager
+
+    result = check_job_status(manager, job_id=job_id)
+
+    json.dumps(result)
+    assert isinstance(result["job"]["last_update_time"], str)
+
+
+def test_list_jobs_returns_json_serializable_updated_jobs(updated_job_manager):
+    manager, _ = updated_job_manager
+
+    result = list_jobs(manager)
+
+    json.dumps(result)
+    assert isinstance(result["jobs"][0]["last_update_time"], str)


### PR DESCRIPTION
Fixes #1678

Serializes `last_update_time` in job status/list responses and adds regression tests.