### PR TITLE
feat(cgcignore): treat .gitignore as an ignore source

### DIFF
--- a/src/codegraphcontext/core/cgcignore.py
+++ b/src/codegraphcontext/core/cgcignore.py
@@ -64,6 +64,32 @@ def find_cgcignore(ignore_root: Path, explicit_path: Optional[str] = None) -> Op
         return explicit_candidate
     return None
 
+def find_gitignore(ignore_root: Path) -> Optional[Path]:
+    """Find a repository-local .gitignore, searched the same way as .cgcignore.
+
+    Bounded to the git worktree for the same reason find_cgcignore is: an indexed
+    path outside a repo must not pick up something like /tmp/.gitignore.
+    """
+    git_root: Optional[Path] = None
+    probe = ignore_root
+    while True:
+        if (probe / ".git").exists():
+            git_root = probe
+            break
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+
+    curr = ignore_root
+    while True:
+        candidate = curr / ".gitignore"
+        if candidate.is_file():
+            return candidate
+        if git_root is None or curr == git_root:
+            return None
+        curr = curr.parent
+
+
 def ensure_default_cgcignore(path: Path, default_patterns: list[str]) -> None:
     """Create a .cgcignore file with default patterns when it does not exist."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -265,9 +291,23 @@ def build_ignore_spec(
             parse_cgcignore_lines(explicit_cgcignore_path.read_text(encoding="utf-8").splitlines())
         )
 
+    gitignore_patterns: list[str] = []
+    gitignore_path = find_gitignore(ignore_root)
+    if gitignore_path is not None:
+        try:
+            gitignore_patterns = parse_cgcignore_lines(
+                gitignore_path.read_text(encoding="utf-8").splitlines()
+            )
+        except OSError as e:
+            warning_logger(f"Failed to read {gitignore_path}: {e}")
+
     # Defaults first, user patterns last: matching is last-match-wins (see
     # CGCIgnoreMatcher.match_file), so appending the defaults would make them
     # unconditionally override the user's rules and leave `!build/` with no way
     # to re-include a directory the built-in list ignores.
-    all_patterns = list(default_patterns) + merged_user_patterns
+    #
+    # .gitignore sits between the two for the same reason: what git ignores is
+    # ignored by default, while a `!pattern` in .cgcignore can still bring a
+    # git-ignored path back into the graph.
+    all_patterns = list(default_patterns) + gitignore_patterns + merged_user_patterns
     return CGCIgnoreMatcher(all_patterns, ignore_root), local_cgcignore_path

--- a/tests/unit/core/test_cgcignore_gitignore.py
+++ b/tests/unit/core/test_cgcignore_gitignore.py
@@ -1,0 +1,86 @@
+"""A repository's .gitignore also acts as a .cgcignore (#729)."""
+
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.cgcignore import build_ignore_spec, find_gitignore
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def _spec(root: Path, defaults=None):
+    spec, _ = build_ignore_spec(root, defaults or [])
+    return spec
+
+
+def test_gitignore_patterns_are_honoured(repo: Path):
+    (repo / ".gitignore").write_text("build/\n*.log\n")
+    (repo / "build").mkdir()
+
+    spec = _spec(repo)
+
+    assert spec.match_file(repo / "build" / "out.o")
+    assert spec.match_file(repo / "server.log")
+    assert not spec.match_file(repo / "main.py")
+
+
+def test_cgcignore_negation_re_includes_a_git_ignored_path(repo: Path):
+    """The workflow the issue asks for: keep indexing one git-ignored path."""
+    (repo / ".gitignore").write_text("dist/\n")
+    (repo / ".cgcignore").write_text("!dist/\n")
+    (repo / "dist").mkdir()
+
+    spec = _spec(repo)
+
+    assert not spec.match_file(repo / "dist" / "bundle.js")
+
+
+def test_missing_gitignore_changes_nothing(repo: Path):
+    (repo / ".cgcignore").write_text("*.tmp\n")
+
+    spec = _spec(repo)
+
+    assert spec.match_file(repo / "scratch.tmp")
+    assert not spec.match_file(repo / "main.py")
+
+
+def test_gitignore_comments_and_blank_lines_are_skipped(repo: Path):
+    (repo / ".gitignore").write_text("# a comment\n\n  \n*.bak\n")
+
+    spec = _spec(repo)
+
+    assert spec.match_file(repo / "old.bak")
+    assert not spec.match_file(repo / "a comment")
+
+
+def test_gitignore_is_found_from_a_subdirectory_of_the_worktree(repo: Path):
+    (repo / ".gitignore").write_text("*.log\n")
+    nested = repo / "services" / "api"
+    nested.mkdir(parents=True)
+
+    assert find_gitignore(nested) == repo / ".gitignore"
+
+
+def test_gitignore_outside_a_git_worktree_is_not_picked_up(tmp_path: Path):
+    """Without a .git marker the walk must not escape upward."""
+    (tmp_path / ".gitignore").write_text("*.log\n")
+    loose = tmp_path / "loose"
+    loose.mkdir()
+
+    assert find_gitignore(loose) is None
+
+
+def test_defaults_still_lose_to_a_cgcignore_negation(repo: Path):
+    (repo / ".gitignore").write_text("*.log\n")
+    (repo / ".cgcignore").write_text("!vendor/\n")
+    (repo / "vendor").mkdir()
+
+    spec = _spec(repo, defaults=["vendor/"])
+
+    assert not spec.match_file(repo / "vendor" / "lib.py")
+    assert spec.match_file(repo / "server.log")


### PR DESCRIPTION
Fixes #729

Anything git ignores now gets ignored by the indexer too, so you don't need a `.cgcignore` that just restates your `.gitignore`.

Patterns are layered **defaults → .gitignore → .cgcignore**. Since matching is last-match-wins, `.cgcignore` still has the final say — so the escape hatch from the issue works: `dist/` in `.gitignore` plus `!dist/` in `.cgcignore` indexes `dist/` anyway. There's a test for exactly that.

It all goes through `build_ignore_spec`, which is the one place discovery, the SCIP pipeline and the watcher already share, so nothing else needed touching. `.gitignore` is looked up the same way `.cgcignore` is — walking up but stopping at the git worktree, so indexing a loose directory can't pick up something like `/tmp/.gitignore`. A missing or unreadable `.gitignore` is a no-op; unreadable warns rather than raising, matching how the rest of the module behaves.

Worth flagging in review: this changes what gets indexed for existing users by default. Most people will want it (that's the issue's premise), but anyone relying on a git-ignored directory being in the graph will need the `!` line. Happy to put it behind a config flag instead if you'd rather have it opt-in.

```
tests/unit/core/test_cgcignore_gitignore.py                    7 passed   (new)
existing cgcignore/watcher/scip suites                        31 passed
tests/unit                                    1356 passed, 26 skipped
```

`ruff check` is clean on both files. The one unit failure, `test_elisp_parser::test_parse_elisp_normalized_output`, fails identically on a clean `main` — unrelated to this change. Same for the `db-parity` and `build` jobs, which are red on `main` right now.