### PR TITLE
fix(viz): display source filenames for synthetic module nodes

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -227,7 +227,14 @@ def _initialize_services(
                     _fail_services_init()
             else:
                 console.print(f"[bold red]Database Connection Error:[/bold red] {e}")
-                console.print("Please ensure your database is configured correctly or run 'cgc doctor'.")
+                if "Could not set lock on file" in str(e):
+                    console.print(
+                        "[yellow]Another CGC process already has this embedded database open. "
+                        "If a CGC Gateway or watcher is running, use its MCP/HTTP interface "
+                        "or stop it before running database-backed CLI commands.[/yellow]"
+                    )
+                else:
+                    console.print("Please ensure your database is configured correctly or run 'cgc doctor'.")
                 _fail_services_init()
     
     # The GraphBuilder requires an event loop, even for synchronous-style execution

--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -709,10 +709,19 @@ def _render_offline_visualization(
             node_id = _meta(value, "_id")
         if node_id is None:
             node_id = props.get("path") or props.get("name")
+        
+        name = props.get("name") or props.get("path") or ""
+        if name == "<module>":
+            _fpath = props.get("path") or props.get("file_path") or ""
+            if _fpath:
+                name = Path(_fpath).name
+            else:
+                name = "<module>"
+
         return {
             "id": _ident(node_id),
             "label": label,
-            "name": props.get("name") or props.get("path") or "",
+            "name": name,
             "file_path": props.get("path", ""),
             "line_number": props.get("line_number"),
         }

--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import time
 import json
+import re
 import sys
 import shutil
 import yaml 
@@ -14,6 +15,48 @@ from codegraphcontext.core.database import DatabaseManager
 from codegraphcontext.cli.config_manager import normalize_config_path
 
 console = Console()
+
+def _strip_jsonc(text: str) -> str:
+    """Drop // and /* */ comments and trailing commas from a JSONC document.
+
+    VS Code and its forks write settings.json as JSONC. json.loads rejects both,
+    and treating that rejection as "no settings yet" discards the user's file.
+    """
+    out = []
+    i, n = 0, len(text)
+    in_string = escaped = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if text.startswith("//", i):
+            i = text.find("\n", i)
+            if i == -1:
+                break
+            continue
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        out.append(ch)
+        i += 1
+    stripped = "".join(out)
+    # A trailing comma before } or ] is legal JSONC, not JSON.
+    return re.sub(r",(\s*[}\]])", r"\1", stripped)
+
 
 def _check_write_access(path: Path) -> bool:
     target = path if path.exists() else path.parent
@@ -483,12 +526,26 @@ def _configure_ide(mcp_config):
 
         console.print(f"Using configuration file at: {target_path}")
         
+        had_comments = False
         try:
-            with open(target_path, "r") as f:
+            raw = target_path.read_text()
+            try:
+                settings = json.loads(raw)
+            except json.JSONDecodeError:
                 try:
-                    settings = json.load(f)
+                    settings = json.loads(_strip_jsonc(raw))
+                    had_comments = True
                 except json.JSONDecodeError:
-                    settings = {}
+                    # Never fall back to {}: this file gets written back below, so
+                    # treating an unreadable file as an empty one destroys it.
+                    console.print(
+                        f"[bold red]Could not parse {target_path}.[/bold red] "
+                        "Leaving it untouched so nothing is lost."
+                    )
+                    console.print(
+                        "Please add the MCP configuration manually from the `mcp.json` file generated above."
+                    )
+                    return
         except FileNotFoundError:
             settings = {}
 
@@ -515,6 +572,15 @@ def _configure_ide(mcp_config):
                 )
                 return
 
+            if target_path.exists():
+                backup_path = target_path.with_suffix(target_path.suffix + ".cgc-backup")
+                shutil.copy2(target_path, backup_path)
+                console.print(f"[dim]Backed up existing configuration to {backup_path}[/dim]")
+            if had_comments:
+                console.print(
+                    "[yellow]Note: this file contained comments. JSON output cannot keep them, "
+                    "so they are dropped in the rewritten file (the backup above still has them).[/yellow]"
+                )
             try:
                 with open(target_path, "w") as f:
                     json.dump(settings, f, indent=2)

--- a/src/codegraphcontext/core/cgcignore.py
+++ b/src/codegraphcontext/core/cgcignore.py
@@ -64,6 +64,32 @@ def find_cgcignore(ignore_root: Path, explicit_path: Optional[str] = None) -> Op
         return explicit_candidate
     return None
 
+def find_gitignore(ignore_root: Path) -> Optional[Path]:
+    """Find a repository-local .gitignore, searched the same way as .cgcignore.
+
+    Bounded to the git worktree for the same reason find_cgcignore is: an indexed
+    path outside a repo must not pick up something like /tmp/.gitignore.
+    """
+    git_root: Optional[Path] = None
+    probe = ignore_root
+    while True:
+        if (probe / ".git").exists():
+            git_root = probe
+            break
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+
+    curr = ignore_root
+    while True:
+        candidate = curr / ".gitignore"
+        if candidate.is_file():
+            return candidate
+        if git_root is None or curr == git_root:
+            return None
+        curr = curr.parent
+
+
 def ensure_default_cgcignore(path: Path, default_patterns: list[str]) -> None:
     """Create a .cgcignore file with default patterns when it does not exist."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -265,9 +291,23 @@ def build_ignore_spec(
             parse_cgcignore_lines(explicit_cgcignore_path.read_text(encoding="utf-8").splitlines())
         )
 
+    gitignore_patterns: list[str] = []
+    gitignore_path = find_gitignore(ignore_root)
+    if gitignore_path is not None:
+        try:
+            gitignore_patterns = parse_cgcignore_lines(
+                gitignore_path.read_text(encoding="utf-8").splitlines()
+            )
+        except OSError as e:
+            warning_logger(f"Failed to read {gitignore_path}: {e}")
+
     # Defaults first, user patterns last: matching is last-match-wins (see
     # CGCIgnoreMatcher.match_file), so appending the defaults would make them
     # unconditionally override the user's rules and leave `!build/` with no way
     # to re-include a directory the built-in list ignores.
-    all_patterns = list(default_patterns) + merged_user_patterns
+    #
+    # .gitignore sits between the two for the same reason: what git ignores is
+    # ignored by default, while a `!pattern` in .cgcignore can still bring a
+    # git-ignored path back into the graph.
+    all_patterns = list(default_patterns) + gitignore_patterns + merged_user_patterns
     return CGCIgnoreMatcher(all_patterns, ignore_root), local_cgcignore_path

--- a/src/codegraphcontext/tools/handlers/management_handlers.py
+++ b/src/codegraphcontext/tools/handlers/management_handlers.py
@@ -98,6 +98,8 @@ def check_job_status(job_manager: JobManager, **args) -> Dict[str, Any]:
         job_dict["start_time"] = job.start_time.strftime("%Y-%m-%d %H:%M:%S")
         if job.end_time:
             job_dict["end_time"] = job.end_time.strftime("%Y-%m-%d %H:%M:%S")
+        if job.last_update_time:
+            job_dict["last_update_time"] = job.last_update_time.strftime("%Y-%m-%d %H:%M:%S")
         
         job_dict["status"] = job.status.value
         
@@ -119,6 +121,8 @@ def list_jobs(job_manager: JobManager) -> Dict[str, Any]:
             job_dict["start_time"] = job.start_time.strftime("%Y-%m-%d %H:%M:%S")
             if job.end_time:
                 job_dict["end_time"] = job.end_time.strftime("%Y-%m-%d %H:%M:%S")
+            if job.last_update_time:
+                job_dict["last_update_time"] = job.last_update_time.strftime("%Y-%m-%d %H:%M:%S")
             jobs_data.append(job_dict)
         
         jobs_data.sort(key=lambda x: x["start_time"], reverse=True)

--- a/src/codegraphcontext/utils/visualize_graph.py
+++ b/src/codegraphcontext/utils/visualize_graph.py
@@ -99,11 +99,15 @@ def build_graph_data(
     for node in nodes:
         node_id = node.get("id") or node.get("name", "unknown")
         label = node.get("label", "Function")
+        name = node.get("name", str(node_id))
+        file_path = node.get("file_path", "")
+        if name == "<module>" and file_path:
+            name = Path(file_path).name
         serialised_nodes.append({
             "id":        str(node_id),
             "label":     label,
-            "name":      node.get("name", str(node_id)),
-            "file_path": node.get("file_path", ""),
+            "name":      name,
+            "file_path": file_path,
             "line":      node.get("line_number"),
             "color":     node_color(label),
         })
@@ -362,7 +366,11 @@ def render_html(
         ctx.fillStyle = '#e2e8f0';
         ctx.font = '10px monospace';
         ctx.textAlign = 'center';
-        ctx.fillText(n.name.length > 16 ? n.name.slice(0,14)+'…' : n.name, p.x, p.y + 24);
+        let displayName = n.name;
+        if (displayName === '<module>' && n.file_path) {{
+          displayName = n.file_path.split('/').pop();
+        }}
+        ctx.fillText(displayName.length > 16 ? displayName.slice(0,14)+'…' : displayName, p.x, p.y + 24);
       }});
     }}
 

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -236,6 +236,12 @@ async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str]
                                 # Extract name/label for frontend
                                 # Prefer 'name' property, fallback to 'label', then 'path' or 'Unknown'
                                 display_name = str(props.get('name', props.get('label', props.get('path', 'Unknown'))))
+                                if display_name == "<module>":
+                                    _fpath = str(props.get('path', props.get('file', '')))
+                                    if _fpath:
+                                        display_name = f"<module: {os.path.basename(_fpath)}>"
+                                        props['name'] = display_name
+                                        props['label'] = display_name
                                 
                                 nodes_dict[eid] = {
                                     "id": eid,
@@ -469,6 +475,12 @@ def parse_node(node, nodes_dict):
             except: pass
             
     display_name = str(props.get('name', props.get('label', props.get('path', 'Unknown'))))
+    if display_name == "<module>":
+        _fpath = str(props.get('path', props.get('file', '')))
+        if _fpath:
+            display_name = f"<module: {os.path.basename(_fpath)}>"
+            props['name'] = display_name
+            props['label'] = display_name
     
     nodes_dict[eid] = {
         "id": eid,

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -239,7 +239,10 @@ async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str]
                                 if display_name == "<module>":
                                     _fpath = str(props.get('path', props.get('file', '')))
                                     if _fpath:
-                                        display_name = f"<module: {os.path.basename(_fpath)}>"
+                                        # Same plain-filename label as the payload builders in
+                                        # cli_helpers/visualize_graph, so one node cannot
+                                        # render two different names in different views.
+                                        display_name = os.path.basename(_fpath)
                                         props['name'] = display_name
                                         props['label'] = display_name
                                 
@@ -478,7 +481,7 @@ def parse_node(node, nodes_dict):
     if display_name == "<module>":
         _fpath = str(props.get('path', props.get('file', '')))
         if _fpath:
-            display_name = f"<module: {os.path.basename(_fpath)}>"
+            display_name = os.path.basename(_fpath)
             props['name'] = display_name
             props['label'] = display_name
     

--- a/tests/unit/cli/test_database_lock_guidance.py
+++ b/tests/unit/cli/test_database_lock_guidance.py
@@ -1,0 +1,39 @@
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from rich.console import Console
+
+from codegraphcontext.cli import cli_helpers
+
+
+def test_initialize_services_explains_embedded_database_lock():
+    db_manager = MagicMock()
+    db_manager.get_driver.side_effect = RuntimeError(
+        "IO exception: Could not set lock on file : /tmp/ladybugdb "
+        "(Error: Resource temporarily unavailable)"
+    )
+    ctx = SimpleNamespace(mode="global", database="ladybugdb", db_path="/tmp/ladybugdb")
+    output = StringIO()
+
+    with (
+        patch.object(cli_helpers, "ensure_first_run_bootstrap"),
+        patch.object(cli_helpers, "resolve_context", return_value=ctx),
+        patch.object(cli_helpers, "get_database_manager", return_value=db_manager),
+        patch.object(
+            cli_helpers,
+            "console",
+            Console(file=output, force_terminal=False, width=120),
+        ),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        cli_helpers._initialize_services()
+
+    message = " ".join(output.getvalue().split())
+    assert exc_info.value.exit_code == 1
+    assert "Another CGC process" in message
+    assert "Gateway or watcher" in message
+    assert "use its MCP/HTTP interface or stop it" in message
+    assert "Please ensure your database is configured correctly" not in message

--- a/tests/unit/cli/test_setup_wizard_jsonc.py
+++ b/tests/unit/cli/test_setup_wizard_jsonc.py
@@ -1,0 +1,70 @@
+"""#660: the setup wizard replaced VS Code's settings.json instead of adding to it.
+
+VS Code and its forks write settings.json as JSONC. `json.load` rejects comments
+and trailing commas, and the wizard treated that rejection as "no settings yet"
+before writing the file back — so a user's whole configuration was replaced by a
+lone `mcpServers` key. These pin the two halves of the fix: JSONC parses, and an
+input that still cannot be parsed is left alone rather than overwritten.
+"""
+
+import ast
+import json
+import re
+
+import pytest
+
+from codegraphcontext.cli import setup_wizard
+
+_strip_jsonc = setup_wizard._strip_jsonc
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ('{\n  // font\n  "editor.fontSize": 14\n}', {"editor.fontSize": 14}),
+        ('{\n  /* multi\n     line */\n  "a": 1\n}', {"a": 1}),
+        ('{\n  "a": 1,\n  "b": [1, 2,],\n}', {"a": 1, "b": [1, 2]}),
+        ('{"url": "https://example.com//path"}', {"url": "https://example.com//path"}),
+        ('{"s": "quote \\" then // text"}', {"s": 'quote " then // text'}),
+        ('{"a": 1, "b": {"c": 2}}', {"a": 1, "b": {"c": 2}}),
+    ],
+)
+def test_strip_jsonc_parses(raw, expected):
+    assert json.loads(_strip_jsonc(raw)) == expected
+
+
+def test_comment_markers_inside_strings_are_not_stripped():
+    """A // or /* inside a string value is data, not a comment."""
+    raw = '{"a": "x // y", "b": "p /* q */ r"}'
+    assert json.loads(_strip_jsonc(raw)) == {"a": "x // y", "b": "p /* q */ r"}
+
+
+def test_real_settings_file_survives_a_round_trip():
+    """The shape from #660: a commented settings.json keeps every key."""
+    raw = """{
+  // Editor
+  "editor.fontSize": 14,
+  "editor.tabSize": 2,
+  /* Theme */
+  "workbench.colorTheme": "Default Dark+",
+  "files.exclude": { "**/.git": true },
+}"""
+    settings = json.loads(_strip_jsonc(raw))
+    assert settings["editor.fontSize"] == 14
+    assert settings["workbench.colorTheme"] == "Default Dark+"
+    assert settings["files.exclude"] == {"**/.git": True}
+
+    settings.setdefault("mcpServers", {})["cgc"] = {"command": "cgc"}
+    assert settings["editor.tabSize"] == 2
+
+
+def test_unparseable_input_is_not_silently_emptied():
+    """Truncated JSONC must raise, so the caller can decline to write."""
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(_strip_jsonc('{"a": 1, "b": '))
+
+
+def test_wizard_returns_without_writing_when_parsing_fails():
+    """The bug was the {} fallback; the source must no longer contain it."""
+    src = ast.unparse(ast.parse(open(setup_wizard.__file__).read()))
+    assert not re.search(r"except json\.JSONDecodeError:\s*settings = \{\}", src)

--- a/tests/unit/core/test_cgcignore_gitignore.py
+++ b/tests/unit/core/test_cgcignore_gitignore.py
@@ -1,0 +1,86 @@
+"""A repository's .gitignore also acts as a .cgcignore (#729)."""
+
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.cgcignore import build_ignore_spec, find_gitignore
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def _spec(root: Path, defaults=None):
+    spec, _ = build_ignore_spec(root, defaults or [])
+    return spec
+
+
+def test_gitignore_patterns_are_honoured(repo: Path):
+    (repo / ".gitignore").write_text("build/\n*.log\n")
+    (repo / "build").mkdir()
+
+    spec = _spec(repo)
+
+    assert spec.match_file(repo / "build" / "out.o")
+    assert spec.match_file(repo / "server.log")
+    assert not spec.match_file(repo / "main.py")
+
+
+def test_cgcignore_negation_re_includes_a_git_ignored_path(repo: Path):
+    """The workflow the issue asks for: keep indexing one git-ignored path."""
+    (repo / ".gitignore").write_text("dist/\n")
+    (repo / ".cgcignore").write_text("!dist/\n")
+    (repo / "dist").mkdir()
+
+    spec = _spec(repo)
+
+    assert not spec.match_file(repo / "dist" / "bundle.js")
+
+
+def test_missing_gitignore_changes_nothing(repo: Path):
+    (repo / ".cgcignore").write_text("*.tmp\n")
+
+    spec = _spec(repo)
+
+    assert spec.match_file(repo / "scratch.tmp")
+    assert not spec.match_file(repo / "main.py")
+
+
+def test_gitignore_comments_and_blank_lines_are_skipped(repo: Path):
+    (repo / ".gitignore").write_text("# a comment\n\n  \n*.bak\n")
+
+    spec = _spec(repo)
+
+    assert spec.match_file(repo / "old.bak")
+    assert not spec.match_file(repo / "a comment")
+
+
+def test_gitignore_is_found_from_a_subdirectory_of_the_worktree(repo: Path):
+    (repo / ".gitignore").write_text("*.log\n")
+    nested = repo / "services" / "api"
+    nested.mkdir(parents=True)
+
+    assert find_gitignore(nested) == repo / ".gitignore"
+
+
+def test_gitignore_outside_a_git_worktree_is_not_picked_up(tmp_path: Path):
+    """Without a .git marker the walk must not escape upward."""
+    (tmp_path / ".gitignore").write_text("*.log\n")
+    loose = tmp_path / "loose"
+    loose.mkdir()
+
+    assert find_gitignore(loose) is None
+
+
+def test_defaults_still_lose_to_a_cgcignore_negation(repo: Path):
+    (repo / ".gitignore").write_text("*.log\n")
+    (repo / ".cgcignore").write_text("!vendor/\n")
+    (repo / "vendor").mkdir()
+
+    spec = _spec(repo, defaults=["vendor/"])
+
+    assert not spec.match_file(repo / "vendor" / "lib.py")
+    assert spec.match_file(repo / "server.log")

--- a/tests/unit/tools/test_management_handlers_jobs.py
+++ b/tests/unit/tools/test_management_handlers_jobs.py
@@ -1,0 +1,35 @@
+import json
+
+import pytest
+
+from codegraphcontext.core.jobs import JobManager
+from codegraphcontext.tools.handlers.management_handlers import (
+    check_job_status,
+    list_jobs,
+)
+
+
+@pytest.fixture
+def updated_job_manager():
+    manager = JobManager()
+    job_id = manager.create_job("/tmp/repo")
+    manager.update_job(job_id, processed_files=1)
+    return manager, job_id
+
+
+def test_check_job_status_returns_json_serializable_updated_job(updated_job_manager):
+    manager, job_id = updated_job_manager
+
+    result = check_job_status(manager, job_id=job_id)
+
+    json.dumps(result)
+    assert isinstance(result["job"]["last_update_time"], str)
+
+
+def test_list_jobs_returns_json_serializable_updated_jobs(updated_job_manager):
+    manager, _ = updated_job_manager
+
+    result = list_jobs(manager)
+
+    json.dumps(result)
+    assert isinstance(result["jobs"][0]["last_update_time"], str)


### PR DESCRIPTION
Fixes #1681 

# Overview
When visualizing call graphs, top-level executable code in files is parsed as synthetic `<module>` nodes. In the graph visualizer, these nodes currently display the literal name `"<module>"`, making it impossible to tell which file they belong to in the visual layout.

This PR updates the visualization payload generation to resolve `<module>` nodes to their actual source filename (e.g., displaying main.py).

## Changes
1. src/codegraphcontext/cli/cli_helpers.py: Updated _node_payload() to parse filename when name == `"<module>"`.
2. src/codegraphcontext/utils/visualize_graph.py: Updated build_graph_data() to set node names to their file name if they are named `<module>`. Added a JS canvas rendering fallback.
3. src/codegraphcontext/viz/server.py: Updated parse_node() to override props['name'] and props['label'] for `<module>` nodes to display their filenames.
(Before and after screenshots are attached in the linked issue #1681).

