### PR TITLE
fix(cli): explain embedded database lock conflicts

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -227,7 +227,14 @@ def _initialize_services(
                     _fail_services_init()
             else:
                 console.print(f"[bold red]Database Connection Error:[/bold red] {e}")
-                console.print("Please ensure your database is configured correctly or run 'cgc doctor'.")
+                if "Could not set lock on file" in str(e):
+                    console.print(
+                        "[yellow]Another CGC process already has this embedded database open. "
+                        "If a CGC Gateway or watcher is running, use its MCP/HTTP interface "
+                        "or stop it before running database-backed CLI commands.[/yellow]"
+                    )
+                else:
+                    console.print("Please ensure your database is configured correctly or run 'cgc doctor'.")
                 _fail_services_init()
     
     # The GraphBuilder requires an event loop, even for synchronous-style execution

--- a/tests/unit/cli/test_database_lock_guidance.py
+++ b/tests/unit/cli/test_database_lock_guidance.py
@@ -1,0 +1,39 @@
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from rich.console import Console
+
+from codegraphcontext.cli import cli_helpers
+
+
+def test_initialize_services_explains_embedded_database_lock():
+    db_manager = MagicMock()
+    db_manager.get_driver.side_effect = RuntimeError(
+        "IO exception: Could not set lock on file : /tmp/ladybugdb "
+        "(Error: Resource temporarily unavailable)"
+    )
+    ctx = SimpleNamespace(mode="global", database="ladybugdb", db_path="/tmp/ladybugdb")
+    output = StringIO()
+
+    with (
+        patch.object(cli_helpers, "ensure_first_run_bootstrap"),
+        patch.object(cli_helpers, "resolve_context", return_value=ctx),
+        patch.object(cli_helpers, "get_database_manager", return_value=db_manager),
+        patch.object(
+            cli_helpers,
+            "console",
+            Console(file=output, force_terminal=False, width=120),
+        ),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        cli_helpers._initialize_services()
+
+    message = " ".join(output.getvalue().split())
+    assert exc_info.value.exit_code == 1
+    assert "Another CGC process" in message
+    assert "Gateway or watcher" in message
+    assert "use its MCP/HTTP interface or stop it" in message
+    assert "Please ensure your database is configured correctly" not in message


### PR DESCRIPTION
Improves #1683 by replacing the misleading `cgc doctor` suggestion for embedded-database lock conflicts with guidance to use the running Gateway's MCP/HTTP interface or stop the lock-owning process.

Automatic CLI-to-Gateway delegation is intentionally out of scope; the repository has no canonical Gateway discovery mechanism yet. Unrelated connection errors retain the existing guidance.

Verification:
- `.venv/bin/pytest tests/unit/cli tests/integration/cli -q` — 133 passed
- Regression test fails against the pre-fix branch and passes with this change
- `./tests/run_tests.sh fast` — 1497 passed, 7 skipped, 13 failed; all 13 failures reproduce unchanged on `origin/main` (`04c8d390`) under the same environment
