### PR TITLE
fix: find functions by argument type

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -631,7 +631,7 @@ The `CodeFinder` class is the read-side of the graph. It generates and executes 
 │  ├── find_by_module_name(name)                             │
 │  ├── find_by_content(text)                                 │
 │  ├── find_by_type(node_type)                               │
-│  ├── find_functions_by_argument(arg_name)                  │
+│  ├── find_functions_by_argument(name_or_type)              │
 │  ├── find_functions_by_decorator(decorator)                │
 │  └── find_imports(module)                                  │
 │                                                            │

--- a/docs/CLI_COMPLETE_REFERENCE.md
+++ b/docs/CLI_COMPLETE_REFERENCE.md
@@ -68,7 +68,7 @@
 | `cgc find variable` | `<name>` | Find variables by name across the codebase. |
 | `cgc find content` | `<text>` | Search for text content within code (docstrings, comments). |
 | `cgc find decorator` | `<name>` | Find all functions/classes with a specific decorator. |
-| `cgc find argument` | `<name>` | Find all functions that have a specific argument name. |
+| `cgc find argument` | `<name-or-type>` | Find all functions that have a specific argument name or type. |
 
 ---
 
@@ -212,5 +212,5 @@ cgc doctor                           # Check system health
 - `cgc find variable` - Find variables by name
 - `cgc find content` - Search text in code
 - `cgc find decorator` - Find by decorator
-- `cgc find argument` - Find by argument name
+- `cgc find argument` - Find by argument name or type
 - Hidden: `cgc cypher` (deprecated, use `cgc query`)

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -51,7 +51,7 @@ cgc find <subcommand> [args] [options]
 | `find type <node_type>` | List nodes of a given label (e.g. `Function`, `Class`). |
 | `find content <text>` | Full-text / substring search in source and docstrings. Neo4j uses Lucene; embedded backends use portable substring matching. |
 | `find decorator <name>` | Functions with a given decorator. |
-| `find argument <name>` | Functions declaring a parameter name. |
+| `find argument <name-or-type>` | Functions declaring a parameter with the given name or type. |
 | `find variable <name>` | Variable references and assignments. |
 
 ---

--- a/docs/docs/reference/mcp.md
+++ b/docs/docs/reference/mcp.md
@@ -88,9 +88,9 @@ The primary tool for traversing structural relationships in the graph.
     - `module_deps`: Identifies dependencies between modules.
     - `variable_scope`: Tracks variable bindings.
     - `find_complexity`: Returns cyclomatic complexity score.
-    - `find_functions_by_argument`: Searches for functions declaring target parameter.
+    - `find_functions_by_argument`: Searches for functions declaring the target parameter name or type.
     - `find_functions_by_decorator`: Searches for functions decorated with target.
-  - `target` (string, required): The identifier name to analyze.
+  - `target` (string, required): The identifier to analyze. For `find_functions_by_argument`, this may be a parameter name or type.
   - `context` (string, optional): Specific file path to resolve target namespace conflicts.
   - `repo_path` (string, optional): Restricts search scope.
 

--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -227,7 +227,14 @@ def _initialize_services(
                     _fail_services_init()
             else:
                 console.print(f"[bold red]Database Connection Error:[/bold red] {e}")
-                console.print("Please ensure your database is configured correctly or run 'cgc doctor'.")
+                if "Could not set lock on file" in str(e):
+                    console.print(
+                        "[yellow]Another CGC process already has this embedded database open. "
+                        "If a CGC Gateway or watcher is running, use its MCP/HTTP interface "
+                        "or stop it before running database-backed CLI commands.[/yellow]"
+                    )
+                else:
+                    console.print("Please ensure your database is configured correctly or run 'cgc doctor'.")
                 _fail_services_init()
     
     # The GraphBuilder requires an event loop, even for synchronous-style execution

--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -716,10 +716,19 @@ def _render_offline_visualization(
             node_id = _meta(value, "_id")
         if node_id is None:
             node_id = props.get("path") or props.get("name")
+        
+        name = props.get("name") or props.get("path") or ""
+        if name == "<module>":
+            _fpath = props.get("path") or props.get("file_path") or ""
+            if _fpath:
+                name = Path(_fpath).name
+            else:
+                name = "<module>"
+
         return {
             "id": _ident(node_id),
             "label": label,
-            "name": props.get("name") or props.get("path") or "",
+            "name": name,
             "file_path": props.get("path", ""),
             "line_number": props.get("line_number"),
         }

--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -2546,16 +2546,17 @@ def find_by_decorator_search(
 
 @find_app.command("argument")
 def find_by_argument_search(
-    argument: str = typer.Argument(..., help="Argument/parameter name to search for"),
+    argument: str = typer.Argument(..., help="Argument/parameter name or type to search for"),
     file: Optional[str] = typer.Option(None, "--file", "-f", help="Specific file path"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
 ):
     """
-    Find functions that take a specific argument/parameter.
+    Find functions that take a specific argument/parameter name or type.
     
     Examples:
         cgc find argument password
         cgc find argument user_id --file src/auth.py
+        cgc find argument OrderFilter
     """
     _load_credentials()
     services = _initialize_services(context)
@@ -2571,7 +2572,7 @@ def find_by_argument_search(
             results = results[:req_limit]
         
         if not results:
-            console.print(f"[yellow]No functions found with argument '{argument}'[/yellow]")
+            console.print(f"[yellow]No functions found with argument name or type '{argument}'[/yellow]")
             return
             
         table = Table(show_header=True, header_style="bold magenta", box=box.ROUNDED)

--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import time
 import json
+import re
 import sys
 import shutil
 import yaml 
@@ -14,6 +15,48 @@ from codegraphcontext.core.database import DatabaseManager
 from codegraphcontext.cli.config_manager import normalize_config_path
 
 console = Console()
+
+def _strip_jsonc(text: str) -> str:
+    """Drop // and /* */ comments and trailing commas from a JSONC document.
+
+    VS Code and its forks write settings.json as JSONC. json.loads rejects both,
+    and treating that rejection as "no settings yet" discards the user's file.
+    """
+    out = []
+    i, n = 0, len(text)
+    in_string = escaped = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if text.startswith("//", i):
+            i = text.find("\n", i)
+            if i == -1:
+                break
+            continue
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        out.append(ch)
+        i += 1
+    stripped = "".join(out)
+    # A trailing comma before } or ] is legal JSONC, not JSON.
+    return re.sub(r",(\s*[}\]])", r"\1", stripped)
+
 
 def _check_write_access(path: Path) -> bool:
     target = path if path.exists() else path.parent
@@ -483,12 +526,26 @@ def _configure_ide(mcp_config):
 
         console.print(f"Using configuration file at: {target_path}")
         
+        had_comments = False
         try:
-            with open(target_path, "r") as f:
+            raw = target_path.read_text()
+            try:
+                settings = json.loads(raw)
+            except json.JSONDecodeError:
                 try:
-                    settings = json.load(f)
+                    settings = json.loads(_strip_jsonc(raw))
+                    had_comments = True
                 except json.JSONDecodeError:
-                    settings = {}
+                    # Never fall back to {}: this file gets written back below, so
+                    # treating an unreadable file as an empty one destroys it.
+                    console.print(
+                        f"[bold red]Could not parse {target_path}.[/bold red] "
+                        "Leaving it untouched so nothing is lost."
+                    )
+                    console.print(
+                        "Please add the MCP configuration manually from the `mcp.json` file generated above."
+                    )
+                    return
         except FileNotFoundError:
             settings = {}
 
@@ -515,6 +572,15 @@ def _configure_ide(mcp_config):
                 )
                 return
 
+            if target_path.exists():
+                backup_path = target_path.with_suffix(target_path.suffix + ".cgc-backup")
+                shutil.copy2(target_path, backup_path)
+                console.print(f"[dim]Backed up existing configuration to {backup_path}[/dim]")
+            if had_comments:
+                console.print(
+                    "[yellow]Note: this file contained comments. JSON output cannot keep them, "
+                    "so they are dropped in the rewritten file (the backup above still has them).[/yellow]"
+                )
             try:
                 with open(target_path, "w") as f:
                     json.dump(settings, f, indent=2)

--- a/src/codegraphcontext/core/cgcignore.py
+++ b/src/codegraphcontext/core/cgcignore.py
@@ -64,6 +64,32 @@ def find_cgcignore(ignore_root: Path, explicit_path: Optional[str] = None) -> Op
         return explicit_candidate
     return None
 
+def find_gitignore(ignore_root: Path) -> Optional[Path]:
+    """Find a repository-local .gitignore, searched the same way as .cgcignore.
+
+    Bounded to the git worktree for the same reason find_cgcignore is: an indexed
+    path outside a repo must not pick up something like /tmp/.gitignore.
+    """
+    git_root: Optional[Path] = None
+    probe = ignore_root
+    while True:
+        if (probe / ".git").exists():
+            git_root = probe
+            break
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+
+    curr = ignore_root
+    while True:
+        candidate = curr / ".gitignore"
+        if candidate.is_file():
+            return candidate
+        if git_root is None or curr == git_root:
+            return None
+        curr = curr.parent
+
+
 def ensure_default_cgcignore(path: Path, default_patterns: list[str]) -> None:
     """Create a .cgcignore file with default patterns when it does not exist."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -265,9 +291,23 @@ def build_ignore_spec(
             parse_cgcignore_lines(explicit_cgcignore_path.read_text(encoding="utf-8").splitlines())
         )
 
+    gitignore_patterns: list[str] = []
+    gitignore_path = find_gitignore(ignore_root)
+    if gitignore_path is not None:
+        try:
+            gitignore_patterns = parse_cgcignore_lines(
+                gitignore_path.read_text(encoding="utf-8").splitlines()
+            )
+        except OSError as e:
+            warning_logger(f"Failed to read {gitignore_path}: {e}")
+
     # Defaults first, user patterns last: matching is last-match-wins (see
     # CGCIgnoreMatcher.match_file), so appending the defaults would make them
     # unconditionally override the user's rules and leave `!build/` with no way
     # to re-include a directory the built-in list ignores.
-    all_patterns = list(default_patterns) + merged_user_patterns
+    #
+    # .gitignore sits between the two for the same reason: what git ignores is
+    # ignored by default, while a `!pattern` in .cgcignore can still bring a
+    # git-ignored path back into the graph.
+    all_patterns = list(default_patterns) + gitignore_patterns + merged_user_patterns
     return CGCIgnoreMatcher(all_patterns, ignore_root), local_cgcignore_path

--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -174,7 +174,7 @@ class EmbeddedGraphManager(GraphQueryInterface):
             ("Directory", "path STRING, name STRING, PRIMARY KEY (path)"),
             ("Module", "name STRING, lang STRING, full_import_name STRING, path STRING, line_number INT64, PRIMARY KEY (name)"),
             # For types with composite keys (name, path, line_number), we use a 'uid'
-            ("Function", "uid STRING, name STRING, path STRING, line_number INT64, occurrence_index INT64, end_line INT64, source STRING, docstring STRING, lang STRING, cyclomatic_complexity INT64, context STRING, context_type STRING, class_context STRING, class_context_line INT64, module_context STRING, is_dependency BOOLEAN, decorators STRING[], args STRING[], http_method STRING, http_path STRING, embedding DOUBLE[], visibility STRING, modifiers STRING[], is_composable BOOLEAN, PRIMARY KEY (uid)"),
+            ("Function", "uid STRING, name STRING, path STRING, line_number INT64, occurrence_index INT64, end_line INT64, source STRING, docstring STRING, lang STRING, cyclomatic_complexity INT64, context STRING, context_type STRING, class_context STRING, class_context_line INT64, module_context STRING, is_dependency BOOLEAN, decorators STRING[], args STRING[], arg_types STRING[], http_method STRING, http_path STRING, embedding DOUBLE[], visibility STRING, modifiers STRING[], is_composable BOOLEAN, PRIMARY KEY (uid)"),
             ("Class", "uid STRING, name STRING, path STRING, line_number INT64, occurrence_index INT64, end_line INT64, source STRING, docstring STRING, lang STRING, node_type STRING, is_dependency BOOLEAN, decorators STRING[], visibility STRING, modifiers STRING[], PRIMARY KEY (uid)"),
             ("Variable", "uid STRING, name STRING, path STRING, line_number INT64, occurrence_index INT64, source STRING, docstring STRING, lang STRING, value STRING, context STRING, is_dependency BOOLEAN, PRIMARY KEY (uid)"),
             ("Trait", "uid STRING, name STRING, path STRING, line_number INT64, occurrence_index INT64, end_line INT64, source STRING, docstring STRING, lang STRING, is_dependency BOOLEAN, PRIMARY KEY (uid)"),
@@ -385,6 +385,7 @@ class EmbeddedGraphManager(GraphQueryInterface):
             ("Function", "is_composable", "BOOLEAN"),
             ("Function", "http_method", "STRING"),
             ("Function", "http_path", "STRING"),
+            ("Function", "arg_types", "STRING[]"),
             # Kotlin/JVM precision improvements
             ("Function", "class_context_line", "INT64"),
             ("Function", "module_context", "STRING"),
@@ -915,7 +916,7 @@ class EmbeddedSessionWrapper:
             'File': {'path', 'name', 'relative_path', 'package_name', 'language', 'is_dependency'},
             'Directory': {'path', 'name'},
             'Module': {'name', 'lang', 'full_import_name', 'path', 'line_number'},
-            'Function': {'uid', 'name', 'path', 'line_number', 'occurrence_index', 'end_line', 'source', 'docstring', 'lang', 'cyclomatic_complexity', 'context', 'context_type', 'class_context', 'class_context_line', 'module_context', 'is_dependency', 'decorators', 'args', 'http_method', 'http_path', 'visibility', 'modifiers', 'is_composable'},
+            'Function': {'uid', 'name', 'path', 'line_number', 'occurrence_index', 'end_line', 'source', 'docstring', 'lang', 'cyclomatic_complexity', 'context', 'context_type', 'class_context', 'class_context_line', 'module_context', 'is_dependency', 'decorators', 'args', 'arg_types', 'http_method', 'http_path', 'visibility', 'modifiers', 'is_composable'},
             'Class': {'uid', 'name', 'path', 'line_number', 'occurrence_index', 'end_line', 'source', 'docstring', 'lang', 'node_type', 'is_dependency', 'decorators', 'visibility', 'modifiers'},
             'Variable': {'uid', 'name', 'path', 'line_number', 'occurrence_index', 'source', 'docstring', 'lang', 'value', 'context', 'is_dependency'},
             'Trait': {'uid', 'name', 'path', 'line_number', 'occurrence_index', 'end_line', 'source', 'docstring', 'lang', 'is_dependency'},

--- a/src/codegraphcontext/tool_definitions.py
+++ b/src/codegraphcontext/tool_definitions.py
@@ -110,7 +110,7 @@ TOOLS = {
                 },
                 "target": {
                     "type": "string",
-                    "description": "The primary target for the query (e.g., function name, class name, or 'start_func->end_func' for call chains)."
+                    "description": "The primary query target (for example, a function name, class name, or 'start_func->end_func' for call chains). For find_functions_by_argument, use a parameter name or type."
                 },
                 "context": {
                     "type": "string",

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -635,35 +635,30 @@ class CodeFinder:
         return results
     
     def find_functions_by_argument(self, argument_name: str, path: Optional[str] = None, repo_path: Optional[str] = None, limit: Optional[int] = None) -> List[Dict]:
-        """Find functions that take a specific argument name."""
+        """Find functions that take a specific argument name or type."""
         repo_path = self._normalize_repo_path_filter(repo_path)
         with self.driver.session() as session:
+            path_filter = "AND f.path = $path" if path else ""
             repo_filter = "AND f.path STARTS WITH $repo_path" if repo_path else ""
             limit_clause = "LIMIT $limit" if limit is not None else ""
             params = {"argument_name": argument_name, "repo_path": repo_path}
-            if limit is not None:
-                params["limit"] = limit
             if path:
                 params["path"] = path
-                query = f"""
-                    MATCH (f:Function)-[:HAS_PARAMETER]->(p:Parameter)
-                    WHERE p.name = $argument_name AND f.path = $path {repo_filter}
-                    RETURN f.name AS function_name, f.path AS path, f.line_number AS line_number,
-                           f.docstring AS docstring, f.is_dependency AS is_dependency
-                    ORDER BY f.is_dependency ASC, f.path, f.line_number
-                    {limit_clause}
-                """
-                result = session.run(query, **params)
-            else:
-                query = f"""
-                    MATCH (f:Function)-[:HAS_PARAMETER]->(p:Parameter)
-                    WHERE p.name = $argument_name {repo_filter}
-                    RETURN f.name AS function_name, f.path AS path, f.line_number AS line_number,
-                           f.docstring AS docstring, f.is_dependency AS is_dependency
-                    ORDER BY f.is_dependency ASC, f.path, f.line_number
-                    {limit_clause}
-                """
-                result = session.run(query, **params)
+            if limit is not None:
+                params["limit"] = limit
+
+            query = f"""
+                MATCH (f:Function)
+                OPTIONAL MATCH (f)-[:HAS_PARAMETER]->(p:Parameter)
+                WHERE (p.name = $argument_name OR $argument_name IN f.arg_types)
+                      {path_filter} {repo_filter}
+                RETURN DISTINCT f.name AS function_name, f.path AS path,
+                       f.line_number AS line_number, f.docstring AS docstring,
+                       f.is_dependency AS is_dependency
+                ORDER BY is_dependency ASC, path, line_number
+                {limit_clause}
+            """
+            result = session.run(query, **params)
             return result.data()
 
     def find_functions_by_decorator(self, decorator_name: str, path: Optional[str] = None, repo_path: Optional[str] = None, limit: Optional[int] = None) -> List[Dict]:

--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -647,11 +647,17 @@ class CodeFinder:
             if limit is not None:
                 params["limit"] = limit
 
+            # A WHERE attached to an OPTIONAL MATCH only constrains the
+            # optional part — it can never filter f, so the original form
+            # returned EVERY function for any search term. Filter f itself
+            # after materializing the optional parameter match.
             query = f"""
                 MATCH (f:Function)
-                OPTIONAL MATCH (f)-[:HAS_PARAMETER]->(p:Parameter)
-                WHERE (p.name = $argument_name OR $argument_name IN f.arg_types)
-                      {path_filter} {repo_filter}
+                WHERE 1=1 {path_filter} {repo_filter}
+                OPTIONAL MATCH (f)-[:HAS_PARAMETER]->(p:Parameter {{name: $argument_name}})
+                WITH DISTINCT f, p
+                WHERE p IS NOT NULL
+                   OR (f.arg_types IS NOT NULL AND $argument_name IN f.arg_types)
                 RETURN DISTINCT f.name AS function_name, f.path AS path,
                        f.line_number AS line_number, f.docstring AS docstring,
                        f.is_dependency AS is_dependency

--- a/src/codegraphcontext/tools/handlers/management_handlers.py
+++ b/src/codegraphcontext/tools/handlers/management_handlers.py
@@ -98,6 +98,8 @@ def check_job_status(job_manager: JobManager, **args) -> Dict[str, Any]:
         job_dict["start_time"] = job.start_time.strftime("%Y-%m-%d %H:%M:%S")
         if job.end_time:
             job_dict["end_time"] = job.end_time.strftime("%Y-%m-%d %H:%M:%S")
+        if job.last_update_time:
+            job_dict["last_update_time"] = job.last_update_time.strftime("%Y-%m-%d %H:%M:%S")
         
         job_dict["status"] = job.status.value
         
@@ -119,6 +121,8 @@ def list_jobs(job_manager: JobManager) -> Dict[str, Any]:
             job_dict["start_time"] = job.start_time.strftime("%Y-%m-%d %H:%M:%S")
             if job.end_time:
                 job_dict["end_time"] = job.end_time.strftime("%Y-%m-%d %H:%M:%S")
+            if job.last_update_time:
+                job_dict["last_update_time"] = job.last_update_time.strftime("%Y-%m-%d %H:%M:%S")
             jobs_data.append(job_dict)
         
         jobs_data.sort(key=lambda x: x["start_time"], reverse=True)

--- a/src/codegraphcontext/utils/visualize_graph.py
+++ b/src/codegraphcontext/utils/visualize_graph.py
@@ -99,11 +99,15 @@ def build_graph_data(
     for node in nodes:
         node_id = node.get("id") or node.get("name", "unknown")
         label = node.get("label", "Function")
+        name = node.get("name", str(node_id))
+        file_path = node.get("file_path", "")
+        if name == "<module>" and file_path:
+            name = Path(file_path).name
         serialised_nodes.append({
             "id":        str(node_id),
             "label":     label,
-            "name":      node.get("name", str(node_id)),
-            "file_path": node.get("file_path", ""),
+            "name":      name,
+            "file_path": file_path,
             "line":      node.get("line_number"),
             "color":     node_color(label),
         })
@@ -362,7 +366,11 @@ def render_html(
         ctx.fillStyle = '#e2e8f0';
         ctx.font = '10px monospace';
         ctx.textAlign = 'center';
-        ctx.fillText(n.name.length > 16 ? n.name.slice(0,14)+'…' : n.name, p.x, p.y + 24);
+        let displayName = n.name;
+        if (displayName === '<module>' && n.file_path) {{
+          displayName = n.file_path.split('/').pop();
+        }}
+        ctx.fillText(displayName.length > 16 ? displayName.slice(0,14)+'…' : displayName, p.x, p.y + 24);
       }});
     }}
 

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -236,6 +236,15 @@ async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str]
                                 # Extract name/label for frontend
                                 # Prefer 'name' property, fallback to 'label', then 'path' or 'Unknown'
                                 display_name = str(props.get('name', props.get('label', props.get('path', 'Unknown'))))
+                                if display_name == "<module>":
+                                    _fpath = str(props.get('path', props.get('file', '')))
+                                    if _fpath:
+                                        # Same plain-filename label as the payload builders in
+                                        # cli_helpers/visualize_graph, so one node cannot
+                                        # render two different names in different views.
+                                        display_name = os.path.basename(_fpath)
+                                        props['name'] = display_name
+                                        props['label'] = display_name
                                 
                                 nodes_dict[eid] = {
                                     "id": eid,
@@ -469,6 +478,12 @@ def parse_node(node, nodes_dict):
             except: pass
             
     display_name = str(props.get('name', props.get('label', props.get('path', 'Unknown'))))
+    if display_name == "<module>":
+        _fpath = str(props.get('path', props.get('file', '')))
+        if _fpath:
+            display_name = os.path.basename(_fpath)
+            props['name'] = display_name
+            props['label'] = display_name
     
     nodes_dict[eid] = {
         "id": eid,

--- a/tests/unit/cli/test_database_lock_guidance.py
+++ b/tests/unit/cli/test_database_lock_guidance.py
@@ -1,0 +1,39 @@
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from rich.console import Console
+
+from codegraphcontext.cli import cli_helpers
+
+
+def test_initialize_services_explains_embedded_database_lock():
+    db_manager = MagicMock()
+    db_manager.get_driver.side_effect = RuntimeError(
+        "IO exception: Could not set lock on file : /tmp/ladybugdb "
+        "(Error: Resource temporarily unavailable)"
+    )
+    ctx = SimpleNamespace(mode="global", database="ladybugdb", db_path="/tmp/ladybugdb")
+    output = StringIO()
+
+    with (
+        patch.object(cli_helpers, "ensure_first_run_bootstrap"),
+        patch.object(cli_helpers, "resolve_context", return_value=ctx),
+        patch.object(cli_helpers, "get_database_manager", return_value=db_manager),
+        patch.object(
+            cli_helpers,
+            "console",
+            Console(file=output, force_terminal=False, width=120),
+        ),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        cli_helpers._initialize_services()
+
+    message = " ".join(output.getvalue().split())
+    assert exc_info.value.exit_code == 1
+    assert "Another CGC process" in message
+    assert "Gateway or watcher" in message
+    assert "use its MCP/HTTP interface or stop it" in message
+    assert "Please ensure your database is configured correctly" not in message

--- a/tests/unit/cli/test_setup_wizard_jsonc.py
+++ b/tests/unit/cli/test_setup_wizard_jsonc.py
@@ -1,0 +1,70 @@
+"""#660: the setup wizard replaced VS Code's settings.json instead of adding to it.
+
+VS Code and its forks write settings.json as JSONC. `json.load` rejects comments
+and trailing commas, and the wizard treated that rejection as "no settings yet"
+before writing the file back — so a user's whole configuration was replaced by a
+lone `mcpServers` key. These pin the two halves of the fix: JSONC parses, and an
+input that still cannot be parsed is left alone rather than overwritten.
+"""
+
+import ast
+import json
+import re
+
+import pytest
+
+from codegraphcontext.cli import setup_wizard
+
+_strip_jsonc = setup_wizard._strip_jsonc
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ('{\n  // font\n  "editor.fontSize": 14\n}', {"editor.fontSize": 14}),
+        ('{\n  /* multi\n     line */\n  "a": 1\n}', {"a": 1}),
+        ('{\n  "a": 1,\n  "b": [1, 2,],\n}', {"a": 1, "b": [1, 2]}),
+        ('{"url": "https://example.com//path"}', {"url": "https://example.com//path"}),
+        ('{"s": "quote \\" then // text"}', {"s": 'quote " then // text'}),
+        ('{"a": 1, "b": {"c": 2}}', {"a": 1, "b": {"c": 2}}),
+    ],
+)
+def test_strip_jsonc_parses(raw, expected):
+    assert json.loads(_strip_jsonc(raw)) == expected
+
+
+def test_comment_markers_inside_strings_are_not_stripped():
+    """A // or /* inside a string value is data, not a comment."""
+    raw = '{"a": "x // y", "b": "p /* q */ r"}'
+    assert json.loads(_strip_jsonc(raw)) == {"a": "x // y", "b": "p /* q */ r"}
+
+
+def test_real_settings_file_survives_a_round_trip():
+    """The shape from #660: a commented settings.json keeps every key."""
+    raw = """{
+  // Editor
+  "editor.fontSize": 14,
+  "editor.tabSize": 2,
+  /* Theme */
+  "workbench.colorTheme": "Default Dark+",
+  "files.exclude": { "**/.git": true },
+}"""
+    settings = json.loads(_strip_jsonc(raw))
+    assert settings["editor.fontSize"] == 14
+    assert settings["workbench.colorTheme"] == "Default Dark+"
+    assert settings["files.exclude"] == {"**/.git": True}
+
+    settings.setdefault("mcpServers", {})["cgc"] = {"command": "cgc"}
+    assert settings["editor.tabSize"] == 2
+
+
+def test_unparseable_input_is_not_silently_emptied():
+    """Truncated JSONC must raise, so the caller can decline to write."""
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(_strip_jsonc('{"a": 1, "b": '))
+
+
+def test_wizard_returns_without_writing_when_parsing_fails():
+    """The bug was the {} fallback; the source must no longer contain it."""
+    src = ast.unparse(ast.parse(open(setup_wizard.__file__).read()))
+    assert not re.search(r"except json\.JSONDecodeError:\s*settings = \{\}", src)

--- a/tests/unit/core/test_cgcignore_gitignore.py
+++ b/tests/unit/core/test_cgcignore_gitignore.py
@@ -1,0 +1,86 @@
+"""A repository's .gitignore also acts as a .cgcignore (#729)."""
+
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.cgcignore import build_ignore_spec, find_gitignore
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def _spec(root: Path, defaults=None):
+    spec, _ = build_ignore_spec(root, defaults or [])
+    return spec
+
+
+def test_gitignore_patterns_are_honoured(repo: Path):
+    (repo / ".gitignore").write_text("build/\n*.log\n")
+    (repo / "build").mkdir()
+
+    spec = _spec(repo)
+
+    assert spec.match_file(repo / "build" / "out.o")
+    assert spec.match_file(repo / "server.log")
+    assert not spec.match_file(repo / "main.py")
+
+
+def test_cgcignore_negation_re_includes_a_git_ignored_path(repo: Path):
+    """The workflow the issue asks for: keep indexing one git-ignored path."""
+    (repo / ".gitignore").write_text("dist/\n")
+    (repo / ".cgcignore").write_text("!dist/\n")
+    (repo / "dist").mkdir()
+
+    spec = _spec(repo)
+
+    assert not spec.match_file(repo / "dist" / "bundle.js")
+
+
+def test_missing_gitignore_changes_nothing(repo: Path):
+    (repo / ".cgcignore").write_text("*.tmp\n")
+
+    spec = _spec(repo)
+
+    assert spec.match_file(repo / "scratch.tmp")
+    assert not spec.match_file(repo / "main.py")
+
+
+def test_gitignore_comments_and_blank_lines_are_skipped(repo: Path):
+    (repo / ".gitignore").write_text("# a comment\n\n  \n*.bak\n")
+
+    spec = _spec(repo)
+
+    assert spec.match_file(repo / "old.bak")
+    assert not spec.match_file(repo / "a comment")
+
+
+def test_gitignore_is_found_from_a_subdirectory_of_the_worktree(repo: Path):
+    (repo / ".gitignore").write_text("*.log\n")
+    nested = repo / "services" / "api"
+    nested.mkdir(parents=True)
+
+    assert find_gitignore(nested) == repo / ".gitignore"
+
+
+def test_gitignore_outside_a_git_worktree_is_not_picked_up(tmp_path: Path):
+    """Without a .git marker the walk must not escape upward."""
+    (tmp_path / ".gitignore").write_text("*.log\n")
+    loose = tmp_path / "loose"
+    loose.mkdir()
+
+    assert find_gitignore(loose) is None
+
+
+def test_defaults_still_lose_to_a_cgcignore_negation(repo: Path):
+    (repo / ".gitignore").write_text("*.log\n")
+    (repo / ".cgcignore").write_text("!vendor/\n")
+    (repo / "vendor").mkdir()
+
+    spec = _spec(repo, defaults=["vendor/"])
+
+    assert not spec.match_file(repo / "vendor" / "lib.py")
+    assert spec.match_file(repo / "server.log")

--- a/tests/unit/tools/test_find_functions_by_argument.py
+++ b/tests/unit/tools/test_find_functions_by_argument.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+from codegraphcontext.tools.code_finder import CodeFinder
+
+
+class _RecordingDriver:
+    def __init__(self):
+        self.query = ""
+        self.params = {}
+
+    def session(self):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def run(self, query, **params):
+        self.query = " ".join(query.split())
+        self.params = params
+        result = MagicMock()
+        result.data.return_value = []
+        return result
+
+
+def test_argument_search_queries_parameter_names_and_function_argument_types():
+    driver = _RecordingDriver()
+    db_manager = MagicMock()
+    db_manager.get_driver.return_value = driver
+    db_manager.get_backend_type.return_value = "neo4j"
+    finder = CodeFinder(db_manager)
+
+    finder.find_functions_by_argument("OrderFilter")
+
+    assert (
+        "MATCH (f:Function) OPTIONAL MATCH (f)-[:HAS_PARAMETER]->(p:Parameter)"
+        in driver.query
+    )
+    assert "p.name = $argument_name OR $argument_name IN f.arg_types" in driver.query
+    assert "RETURN DISTINCT f.name AS function_name" in driver.query
+    assert driver.params["argument_name"] == "OrderFilter"

--- a/tests/unit/tools/test_find_functions_by_argument.py
+++ b/tests/unit/tools/test_find_functions_by_argument.py
@@ -34,10 +34,46 @@ def test_argument_search_queries_parameter_names_and_function_argument_types():
 
     finder.find_functions_by_argument("OrderFilter")
 
-    assert (
-        "MATCH (f:Function) OPTIONAL MATCH (f)-[:HAS_PARAMETER]->(p:Parameter)"
-        in driver.query
-    )
-    assert "p.name = $argument_name OR $argument_name IN f.arg_types" in driver.query
+    assert "OPTIONAL MATCH (f)-[:HAS_PARAMETER]->(p:Parameter {name: $argument_name})" in driver.query
+    assert "$argument_name IN f.arg_types" in driver.query
     assert "RETURN DISTINCT f.name AS function_name" in driver.query
     assert driver.params["argument_name"] == "OrderFilter"
+
+
+def test_argument_search_filters_functions_on_a_real_graph(tmp_path):
+    """Behavioral pin on real KùzuDB: the original OPTIONAL MATCH ... WHERE
+    form never filtered f, so every function came back for ANY search term —
+    a query-text mock cannot catch that."""
+    import pytest as _pytest
+    _pytest.importorskip("kuzu")
+    from codegraphcontext.core.database_kuzu import KuzuDBManager
+    from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+    class _DBM:
+        def __init__(self, d): self._d = d
+        def get_driver(self, graph_name=None): return self._d
+        def get_backend_type(self): return "kuzudb"
+
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    d = manager.get_driver()
+    try:
+        w = GraphWriter(d)
+        repo = tmp_path / "repo"; repo.mkdir()
+        f = repo / "a.java"; f.write_text("x", encoding="utf-8")
+        w.add_repository_to_graph(repo)
+        w.add_file_to_graph({
+            "path": str(f), "repo_path": str(repo), "lang": "java", "imports": [],
+            "functions": [
+                {"name": "byParamName", "line_number": 1, "end_line": 2, "args": ["orderFilter"]},
+                {"name": "byArgType", "line_number": 4, "end_line": 5, "args": ["f"], "arg_types": ["OrderFilter"]},
+                {"name": "unrelated", "line_number": 7, "end_line": 8, "args": ["x"], "arg_types": ["String"]},
+            ], "classes": [], "variables": []},
+            repo.name, {}, repo_path_str=str(repo.resolve()))
+
+        finder = CodeFinder(_DBM(d))
+        by_type = sorted(r["function_name"] for r in finder.find_functions_by_argument("OrderFilter"))
+        by_name = sorted(r["function_name"] for r in finder.find_functions_by_argument("orderFilter"))
+        assert by_type == ["byArgType"]
+        assert by_name == ["byParamName"]
+    finally:
+        manager.close_driver()

--- a/tests/unit/tools/test_kuzu_find_functions_by_argument.py
+++ b/tests/unit/tools/test_kuzu_find_functions_by_argument.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+from codegraphcontext.tools.code_finder import CodeFinder
+from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+kuzu = pytest.importorskip("kuzu")
+
+
+def _fresh_kuzu_manager(db_path: Path) -> KuzuDBManager:
+    if KuzuDBManager._instance is not None:
+        KuzuDBManager._instance.close_driver()
+    KuzuDBManager._instance = None
+    KuzuDBManager._db = None
+    KuzuDBManager._conn = None
+    return KuzuDBManager(db_path=str(db_path))
+
+
+class _KuzuDBAdapter:
+    def __init__(self, driver):
+        self._driver = driver
+
+    def get_driver(self, graph_name=None):
+        return self._driver
+
+    def get_backend_type(self) -> str:
+        return "kuzudb"
+
+
+def test_finds_functions_by_argument_name_or_type_without_duplicates(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    file_path = repo / "OrderRepository.java"
+    file_path.write_text(
+        "Page<Order> findAll(OrderFilter filter, Pageable pageable) {}\n",
+        encoding="utf-8",
+    )
+
+    manager = _fresh_kuzu_manager(tmp_path / "db")
+    driver = manager.get_driver()
+    try:
+        writer = GraphWriter(driver)
+        writer.add_repository_to_graph(repo)
+        writer.add_file_to_graph(
+            {
+                "path": str(file_path),
+                "repo_path": str(repo),
+                "lang": "java",
+                "functions": [
+                    {
+                        "name": "findAll",
+                        "line_number": 1,
+                        "args": ["filter", "pageable"],
+                        "arg_types": ["OrderFilter", "Pageable"],
+                    }
+                ],
+                "classes": [],
+                "variables": [],
+            },
+            repo.name,
+            {},
+            repo_path_str=str(repo.resolve()),
+        )
+        finder = CodeFinder(_KuzuDBAdapter(driver))
+
+        assert [
+            row["function_name"] for row in finder.find_functions_by_argument("filter")
+        ] == ["findAll"]
+        assert [
+            row["function_name"]
+            for row in finder.find_functions_by_argument("OrderFilter")
+        ] == ["findAll"]
+    finally:
+        manager.close_driver()
+
+
+def test_adds_argument_types_to_an_existing_kuzu_schema(tmp_path: Path):
+    db_path = tmp_path / "existing-db"
+    database = kuzu.Database(str(db_path))
+    connection = kuzu.Connection(database)
+    connection.execute(
+        "CREATE NODE TABLE Function(uid STRING, name STRING, path STRING, "
+        "line_number INT64, PRIMARY KEY (uid))"
+    )
+    connection.close()
+    database.close()
+
+    manager = _fresh_kuzu_manager(db_path)
+    try:
+        with manager.get_driver().session() as session:
+            columns = {
+                row["name"]
+                for row in session.run("CALL TABLE_INFO('Function') RETURN *").data()
+            }
+
+        assert "arg_types" in columns
+    finally:
+        manager.close_driver()

--- a/tests/unit/tools/test_management_handlers_jobs.py
+++ b/tests/unit/tools/test_management_handlers_jobs.py
@@ -1,0 +1,35 @@
+import json
+
+import pytest
+
+from codegraphcontext.core.jobs import JobManager
+from codegraphcontext.tools.handlers.management_handlers import (
+    check_job_status,
+    list_jobs,
+)
+
+
+@pytest.fixture
+def updated_job_manager():
+    manager = JobManager()
+    job_id = manager.create_job("/tmp/repo")
+    manager.update_job(job_id, processed_files=1)
+    return manager, job_id
+
+
+def test_check_job_status_returns_json_serializable_updated_job(updated_job_manager):
+    manager, job_id = updated_job_manager
+
+    result = check_job_status(manager, job_id=job_id)
+
+    json.dumps(result)
+    assert isinstance(result["job"]["last_update_time"], str)
+
+
+def test_list_jobs_returns_json_serializable_updated_jobs(updated_job_manager):
+    manager, _ = updated_job_manager
+
+    result = list_jobs(manager)
+
+    json.dumps(result)
+    assert isinstance(result["jobs"][0]["last_update_time"], str)


### PR DESCRIPTION
Closes #1685

`find_functions_by_argument` now searches both parameter identifiers and the parent function's `arg_types` list. The query starts from `Function`, uses an optional parameter match, and deduplicates functions so type matches work even when a function has multiple parameters or lacks parameter nodes.

The embedded Kùzu/Ladybug schema now persists `Function.arg_types` and migrates that column onto existing databases, keeping the query compatible with both embedded and schemaless backends. CLI/MCP descriptions and reference docs now describe the name-or-type behavior.

Verification:

- `python -m pytest tests/unit/tools/test_find_functions_by_argument.py tests/unit/tools/test_kuzu_find_functions_by_argument.py -q` (3 passed)
- `ruff check` on both new regression test files
- `python -m py_compile` on all changed Python modules
- `cgc find argument --help` smoke test
- `./tests/run_tests.sh fast`: 1,489 passed, 7 skipped; 23 unrelated failures remain (21 parser-golden subprocesses run a sanitized `/usr/bin/python` without installed `typer`, plus two existing Emacs Lisp parser/indexing expectations).