### PR TITLE
fix(viz): render FalkorDB relationships in the live graph

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -26,6 +26,7 @@ from ..core import get_database_manager
 from ..core.jobs import JobManager
 from ..tools.code_finder import CodeFinder
 from ..tools.graph_builder import GraphBuilder
+from ..utils import graph_shapes
 from ..tools.package_resolver import get_local_package_path
 from ..utils.debug_log import info_logger, warning_logger
 from ..core.database import Neo4jConnectionError
@@ -657,44 +658,13 @@ def _render_offline_visualization(
     def _ident(value) -> Optional[str]:
         return None if value is None else str(value)
 
-    # Kùzu spells the internal record keys in lowercase (_label/_src/_dst/_id);
-    # Ladybug returns the same fields uppercased (_LABEL/_SRC/_DST/_ID). Look
-    # up both spellings so either backend reaches the offline renderer (#1458).
-    def _meta(d: dict, key: str, default=None):
-        if key in d:
-            return d[key]
-        return d.get(key.upper(), default)
-
-    def _has_meta(d: dict, key: str) -> bool:
-        return key in d or key.upper() in d
-
-    # Neo4j returns driver objects carrying .labels / .type that support
-    # dict()/Mapping access. FalkorDB's own driver objects also carry
-    # .labels on nodes, but are NOT dict-convertible — their properties live
-    # in a plain `.properties` dict, and its Edge exposes `.relation` /
-    # `.src_node` / `.dest_node` instead of `.type` / `.start_node` /
-    # `.end_node`. Kùzu and Ladybug return plain dicts carrying _label plus
-    # _src/_dst. Check the driver attributes first — a driver object may
-    # also be dict-like.
-    def _is_relationship(value) -> bool:
-        if hasattr(value, "labels"):
-            return False
-        if hasattr(value, "type"):
-            return True
-        if hasattr(value, "relation") and hasattr(value, "src_node"):
-            return True
-        return isinstance(value, dict) and _has_meta(value, "_src") and _has_meta(value, "_dst")
-
-    def _is_node(value) -> bool:
-        if hasattr(value, "labels"):
-            return True
-        if hasattr(value, "type"):
-            return False
-        if hasattr(value, "relation") and hasattr(value, "src_node"):
-            return False
-        # Kùzu relationships also carry _label, so _src/_dst is what
-        # distinguishes them from nodes.
-        return isinstance(value, dict) and _has_meta(value, "_label") and not _has_meta(value, "_src")
+    # Backend shape handling — which driver returns what, and why each spelling
+    # has to be accepted — lives in utils/graph_shapes, shared with the live
+    # web renderer in viz/server.py so the two cannot drift apart again.
+    _meta = graph_shapes.meta
+    _has_meta = graph_shapes.has_meta
+    _is_relationship = graph_shapes.is_relationship
+    _is_node = graph_shapes.is_node
 
     def _node_payload(value) -> Dict[str, Any]:
         if hasattr(value, "labels"):

--- a/src/codegraphcontext/utils/graph_shapes.py
+++ b/src/codegraphcontext/utils/graph_shapes.py
@@ -1,0 +1,123 @@
+"""Backend-agnostic classification of values returned by a graph driver.
+
+CodeGraphContext renders the same graph through two independent paths — the
+offline renderer in ``cli/cli_helpers.py`` and the live web server in
+``viz/server.py``. Each supported backend hands back a different shape, so both
+paths need to answer the same question: *is this value a node or a
+relationship?*
+
+Until now each path answered it separately, and they drifted:
+
+* ``cli_helpers`` classified by **duck typing** (does the value expose
+  ``.labels``? ``.relation``/``.src_node``?), which covers any driver.
+* ``viz/server`` classified by **class name**, matching only
+  ``Node``/``KuzuNode`` and ``Relationship``/``KuzuRelationship``.
+
+FalkorDB's edge class is named ``Edge``, so it matched neither branch in the
+server path and every FalkorDB relationship was silently discarded — on the
+backend that is CGC's *default* on Unix under Python 3.12+. The server's own
+``parse_rel`` already knew how to read a FalkorDB edge; it was simply never
+reached.
+
+Both paths now share the predicates below, so *classification* cannot drift
+apart again. Id and property extraction are still duplicated between
+``viz/server.parse_node``/``parse_rel`` and ``cli_helpers``' payload builders —
+consolidating those is deliberately left out of this change.
+
+Shapes, confirmed by querying each backend's real Python package:
+
+``neo4j``
+    ``Node`` carries ``.labels`` and is dict-convertible via the Mapping
+    protocol. ``Relationship`` carries ``.type`` plus ``.start_node`` /
+    ``.end_node`` (full ``Node`` objects).
+
+``falkordb``
+    ``Node`` carries ``.labels`` but is **not** dict-convertible — properties
+    live in a plain ``.properties`` dict. ``Edge`` carries ``.relation`` plus
+    ``.src_node`` / ``.dest_node``, which hold the bare integer node ids, and
+    exposes no ``.labels`` and no ``.type``.
+
+``kuzu`` / ``ladybug``
+    Plain dicts. Nodes carry ``_id`` / ``_label``; relationships carry
+    ``_src`` / ``_dst`` / ``_label``. Kùzu spells these keys lowercase and
+    Ladybug spells the identical fields uppercase (``_ID`` / ``_LABEL`` /
+    ``_SRC`` / ``_DST``), so every lookup here accepts either casing.
+"""
+
+from typing import Any
+
+__all__ = ["has_meta", "meta", "is_node", "is_relationship"]
+
+
+def has_meta(record: dict, key: str) -> bool:
+    """True if ``record`` carries ``key`` in either Kùzu or Ladybug casing."""
+    return key in record or key.upper() in record
+
+
+def meta(record: dict, key: str, default: Any = None) -> Any:
+    """Read an internal ``_``-prefixed field regardless of its casing."""
+    if key in record:
+        return record[key]
+    return record.get(key.upper(), default)
+
+
+def _is_driver_relationship(value: Any) -> bool:
+    """True for a driver object that looks like a relationship.
+
+    Neo4j exposes ``.type``; FalkorDB exposes ``.relation`` alongside
+    ``.src_node``. Both are checked because neither driver implements the
+    other's attribute.
+    """
+    if hasattr(value, "type"):
+        return True
+    return hasattr(value, "relation") and hasattr(value, "src_node")
+
+
+def is_relationship(value: Any) -> bool:
+    """True if ``value`` is a relationship from any supported backend."""
+    # ``.labels`` is the unambiguous node marker across every driver, so it
+    # settles the question before the relationship checks run.
+    if hasattr(value, "labels"):
+        return False
+    if _is_driver_relationship(value):
+        return True
+    if isinstance(value, dict):
+        # Kùzu and Ladybug relationships also carry ``_label``, so the
+        # endpoints are what distinguish them from nodes.
+        if has_meta(value, "_src") and has_meta(value, "_dst"):
+            return True
+        # A FalkorDB result mapped into a plain dict keeps the driver's
+        # endpoint names.
+        return "src_node" in value and "dest_node" in value
+    return False
+
+
+def _has_endpoint_marker(record: dict) -> bool:
+    """True if a dict carries any relationship-endpoint field.
+
+    A half-formed relationship — say ``_src`` present but ``_dst`` missing —
+    is not a usable relationship, but it must not be mistaken for a node
+    either: it also carries ``_label``, so a plain label check would turn it
+    into a phantom node with a relationship's id. Values like that are
+    classified as neither and skipped, which is what the offline renderer has
+    always done.
+    """
+    return (
+        has_meta(record, "_src")
+        or has_meta(record, "_dst")
+        or "src_node" in record
+        or "dest_node" in record
+    )
+
+
+def is_node(value: Any) -> bool:
+    """True if ``value`` is a node from any supported backend."""
+    if hasattr(value, "labels"):
+        return True
+    if _is_driver_relationship(value):
+        return False
+    if isinstance(value, dict):
+        if _has_endpoint_marker(value):
+            return False
+        return has_meta(value, "_label") or "labels" in value
+    return False

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 from ..utils.debug_log import debug_log
 from ..utils.path_sandbox import is_path_allowed
 from ..utils.cypher_readonly import is_read_only_cypher as _is_read_only_cypher, read_only_rejection_message
+from ..utils import graph_shapes
 
 app = FastAPI()
 
@@ -533,18 +534,13 @@ def parse_element(val, nodes_dict, edges):
             parse_element(r, nodes_dict, edges)
         return
         
-    type_name = type(val).__name__
-    
-    is_dict_rel = isinstance(val, dict) and (
-        any(k in val for k in ('_src', '_dst', '_SRC', '_DST', 'src_node', 'dest_node'))
-    )
-    is_dict_node = isinstance(val, dict) and (
-        '_label' in val or '_LABEL' in val or 'labels' in val
-    ) and not is_dict_rel
-
-    if type_name in ('Node', 'KuzuNode') or is_dict_node:
+    # Classification is duck-typed and shared with the offline renderer (see
+    # utils/graph_shapes). Matching on class name used to miss FalkorDB's
+    # `Edge`, so every FalkorDB relationship was dropped here even though
+    # `parse_rel` below reads it correctly.
+    if graph_shapes.is_node(val):
         parse_node(val, nodes_dict)
-    elif type_name in ('Relationship', 'KuzuRelationship') or is_dict_rel:
+    elif graph_shapes.is_relationship(val):
         parse_rel(val, edges)
     elif isinstance(val, (list, tuple)):
         for item in val:

--- a/tests/unit/utils/test_graph_shapes.py
+++ b/tests/unit/utils/test_graph_shapes.py
@@ -1,0 +1,152 @@
+"""Backend-shape classification shared by both graph renderers.
+
+CodeGraphContext renders the same graph twice — offline via
+``cli/cli_helpers.py`` and live via ``viz/server.py``. Each answered "is this
+value a node or a relationship?" separately, and they drifted:
+``cli_helpers`` duck-typed, ``viz/server`` matched on class name.
+
+FalkorDB's edge class is named ``Edge``, which the server's class-name check
+did not list, so every FalkorDB relationship was silently discarded — on the
+backend that is CGC's default on Unix under Python 3.12+. The server's
+``parse_rel`` already read FalkorDB edges correctly; it was never reached.
+
+The shapes below were confirmed against each backend's real Python package,
+not inferred:
+
+    >>> # falkordb 1.x
+    >>> type(edge).__name__, hasattr(edge, "type"), hasattr(edge, "relation")
+    ('Edge', False, True)
+    >>> hasattr(edge, "labels"), isinstance(edge, dict)
+    (False, False)
+
+    >>> # kuzu 0.11.3, MATCH (n)-[e]->(m) RETURN n, e, m
+    >>> list(node.keys()); list(rel.keys())
+    ['_id', '_label', 'name']
+    ['_src', '_dst', '_label', '_id']
+
+    >>> # ladybug — identical fields, uppercased
+    >>> list(node.keys()); list(rel.keys())
+    ['_ID', '_LABEL', 'name', 'path']
+    ['_SRC', '_DST', '_LABEL', '_ID']
+
+The driver packages are optional extras, so the fakes below reproduce the
+attribute surface each one exposes rather than importing them.
+"""
+import pytest
+
+from codegraphcontext.utils import graph_shapes
+from codegraphcontext.viz import server
+
+
+# --- driver fakes -------------------------------------------------------------
+
+class _Neo4jNode(dict):
+    """Neo4j's Node: carries .labels and is dict-convertible via Mapping."""
+    def __init__(self, labels, props):
+        super().__init__(props)
+        self.labels = labels
+        self.element_id = "4:abc:1"
+
+
+class _Neo4jRel:
+    """Neo4j's Relationship: .type plus full Node endpoints."""
+    def __init__(self, start, end, type_):
+        self.start_node, self.end_node, self.type = start, end, type_
+
+
+class _FalkorNode:
+    """falkordb.Node: .labels, but properties live in .properties."""
+    def __init__(self, node_id, labels, properties):
+        self.id, self.labels, self.properties = node_id, labels, properties
+
+
+class _FalkorEdge:
+    """falkordb.Edge: .relation / .src_node / .dest_node, no .type, no .labels.
+
+    Endpoints are bare integer node ids, not Node objects.
+    """
+    def __init__(self, src_node, relation, dest_node, edge_id=10):
+        self.src_node, self.relation, self.dest_node = src_node, relation, dest_node
+        self.id = edge_id
+
+
+# The classifier that shipped before this change keyed on ``type(val).__name__``,
+# so the fakes must carry the *real* driver class names or the regression below
+# would not reproduce faithfully: falkordb names them ``Node`` and ``Edge``.
+_FalkorNode.__name__ = "Node"
+_FalkorEdge.__name__ = "Edge"
+
+
+KUZU_NODE = {"_id": "0:1", "_label": "File", "path": "/repo/a.py", "name": "a.py"}
+KUZU_REL = {"_src": "0:1", "_dst": "0:2", "_label": "CONTAINS", "_id": "1:0"}
+LADYBUG_NODE = {"_ID": "0:1", "_LABEL": "File", "path": "/repo/a.py", "name": "a.py"}
+LADYBUG_REL = {"_SRC": "0:1", "_DST": "0:2", "_LABEL": "CONTAINS", "_ID": "1:0"}
+
+
+def _falkor_pair():
+    a = _FalkorNode(1, ["File"], {"name": "a.py", "path": "/repo/a.py"})
+    b = _FalkorNode(2, ["Function"], {"name": "alpha", "path": "/repo/a.py"})
+    return a, _FalkorEdge(a.id, "CONTAINS", b.id), b
+
+
+# --- classification -----------------------------------------------------------
+
+@pytest.mark.parametrize("value", [
+    pytest.param(_Neo4jNode(["File"], {"name": "a.py"}), id="neo4j"),
+    pytest.param(_FalkorNode(1, ["File"], {"name": "a.py"}), id="falkordb"),
+    pytest.param(KUZU_NODE, id="kuzu"),
+    pytest.param(LADYBUG_NODE, id="ladybug"),
+])
+def test_nodes_classify_as_nodes(value):
+    assert graph_shapes.is_node(value) is True
+    assert graph_shapes.is_relationship(value) is False
+
+
+@pytest.mark.parametrize("value", [
+    pytest.param(_Neo4jRel("a", "b", "CONTAINS"), id="neo4j"),
+    pytest.param(_FalkorEdge(1, "CONTAINS", 2), id="falkordb"),
+    pytest.param(KUZU_REL, id="kuzu"),
+    pytest.param(LADYBUG_REL, id="ladybug"),
+])
+def test_relationships_classify_as_relationships(value):
+    assert graph_shapes.is_relationship(value) is True
+    assert graph_shapes.is_node(value) is False
+
+
+def test_half_formed_relationship_is_neither():
+    """A relationship dict missing an endpoint must not become a phantom node.
+
+    It still carries ``_label``, so a bare label check would admit it as a node
+    whose id is a relationship id. Classifying it as neither drops it, which is
+    what the offline renderer has always done.
+    """
+    half = {"_src": "0:1", "_label": "CONTAINS"}
+    assert graph_shapes.is_relationship(half) is False
+    assert graph_shapes.is_node(half) is False
+
+
+def test_meta_reads_either_casing():
+    assert graph_shapes.meta(KUZU_NODE, "_label") == "File"
+    assert graph_shapes.meta(LADYBUG_NODE, "_label") == "File"
+    assert graph_shapes.meta({}, "_label", "fallback") == "fallback"
+    assert graph_shapes.has_meta(LADYBUG_REL, "_src") is True
+    assert graph_shapes.has_meta({}, "_src") is False
+
+
+# --- the regression this consolidation exists for -----------------------------
+
+def test_server_renders_falkordb_edges():
+    """Before the shared classifier, `parse_element` matched relationships by
+    class name — ``Relationship``/``KuzuRelationship``. FalkorDB's class is
+    ``Edge``, so it matched no branch and every FalkorDB relationship was
+    dropped, producing an edgeless graph on CGC's default Unix backend.
+    """
+    a, edge, b = _falkor_pair()
+    nodes, edges = {}, []
+    for value in (a, edge, b):
+        server.parse_element(value, nodes, edges)
+
+    # Nodes always survived — falkordb's node class is named ``Node``, which the
+    # old class-name check did list. Only the edge was lost.
+    assert sorted(nodes) == ["1", "2"]
+    assert edges == [{"id": "10", "source": "1", "target": "2", "type": "CONTAINS"}]


### PR DESCRIPTION
## What's broken

`cgc visualize`'s live web graph renders **no edges on FalkorDB** — CGC's default backend on Unix under Python 3.12+.

`parse_element` in `viz/server.py` classified relationships by class name:

```python
elif type_name in ('Relationship', 'KuzuRelationship') or is_dict_rel:
```

FalkorDB's edge class is named `Edge`. It matched no branch, is not a dict, and was silently discarded. `parse_rel` directly below already reads FalkorDB edges correctly — it was simply never reached.

Confirmed against the real `falkordb` package:

```python
>>> type(edge).__name__, hasattr(edge, "type"), hasattr(edge, "relation")
('Edge', False, True)

>>> server.parse_element(edge, nodes, edges); edges
[]                        # while parse_rel(edge) directly -> the correct edge
```

Nodes were unaffected — falkordb's node class *is* named `Node`, which the old check listed.

## Fix

The offline renderer in `cli_helpers.py` already classified by duck typing and handled this (#1453). Both renderers now share those predicates in `utils/graph_shapes.py`, so classification cannot drift apart again. Id and property extraction stay duplicated — deliberately out of scope here.

New regression test asserts the FalkorDB edge survives `parse_element`, plus node/relationship classification across Neo4j, FalkorDB, Kùzu and Ladybug shapes. Reverting only `viz/server.py` makes it fail with nodes present and `edges == []`.
