### PR TITLE
feat(bundle): --exclude-labels for node-type filtering in bundle export (#1323)

### DIFF
--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -711,6 +711,7 @@ def bundle_export(
     no_stats: bool = typer.Option(False, "--no-stats", help="Skip statistics generation"),
     sign_key: Optional[str] = typer.Option(None, "--sign-key", envvar="CGC_BUNDLE_SIGN_KEY", help="HMAC signing key (or set CGC_BUNDLE_SIGN_KEY)"),
     encrypt_password: Optional[str] = typer.Option(None, "--encrypt-password", envvar="CGC_BUNDLE_PASSWORD", help="Encrypt bundle with this password (or set CGC_BUNDLE_PASSWORD)", hide_input=True),
+    exclude_labels: Optional[str] = typer.Option(None, "--exclude-labels", help="Comma-separated node labels to leave out of the bundle, with their edges (e.g. DbTable,ExternalClass) (#1323)"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
 ):
     """
@@ -760,6 +761,7 @@ def bundle_export(
             include_stats=not no_stats,
             sign_key=sign_key,
             encrypt_password=encrypt_password,
+            exclude_labels=[l for l in (exclude_labels or "").split(",") if l.strip()],
         )
         
         if success:
@@ -1137,6 +1139,7 @@ def export_shortcut(
     no_stats: bool = typer.Option(False, "--no-stats", help="Skip generating statistics in the bundle"),
     sign_key: Optional[str] = typer.Option(None, "--sign-key", envvar="CGC_BUNDLE_SIGN_KEY", help="HMAC signing key (or set CGC_BUNDLE_SIGN_KEY)"),
     encrypt_password: Optional[str] = typer.Option(None, "--encrypt-password", envvar="CGC_BUNDLE_PASSWORD", help="Encrypt bundle with this password (or set CGC_BUNDLE_PASSWORD)", hide_input=True),
+    exclude_labels: Optional[str] = typer.Option(None, "--exclude-labels", help="Comma-separated node labels to leave out of the bundle, with their edges (e.g. DbTable,ExternalClass) (#1323)"),
     context: Optional[str] = typer.Option(None, "--context", "-c", help="Specific context to use"),
 ):
     """Shortcut for 'cgc bundle export'"""
@@ -1146,6 +1149,7 @@ def export_shortcut(
         no_stats=no_stats,
         sign_key=sign_key,
         encrypt_password=encrypt_password,
+        exclude_labels=exclude_labels,
         context=context,
     )
 

--- a/src/codegraphcontext/core/cgc_bundle.py
+++ b/src/codegraphcontext/core/cgc_bundle.py
@@ -199,6 +199,7 @@ class CGCBundle:
         include_stats: bool = True,
         sign_key: Optional[str] = None,
         encrypt_password: Optional[str] = None,
+        exclude_labels: Optional[List[str]] = None,
     ) -> Tuple[bool, str]:
         """
         Export the current graph (or a specific repository) to a .cgc bundle.
@@ -225,6 +226,12 @@ class CGCBundle:
                 # Step 1: Extract metadata base
                 info_logger("Extracting metadata...")
                 metadata = self._extract_metadata(repo_path)
+                if exclude_labels:
+                    # Recorded for transparency: a consumer can tell a bundle
+                    # was exported without these node types (#1323).
+                    metadata["excluded_labels"] = sorted(
+                        {l.strip() for l in exclude_labels if l.strip()}
+                    )
                 
                 # Step 2: Extract schema
                 info_logger("Extracting schema...")
@@ -234,7 +241,7 @@ class CGCBundle:
                 
                 # Step 3: Extract nodes
                 info_logger("Extracting nodes...")
-                node_count = self._extract_nodes(temp_path / "nodes.jsonl", repo_path)
+                node_count = self._extract_nodes(temp_path / "nodes.jsonl", repo_path, exclude_labels=exclude_labels)
                 if node_count == 0:
                     return False, (
                         "No nodes to export. Index the repository first or verify "
@@ -244,6 +251,7 @@ class CGCBundle:
                 # Step 4: Extract edges
                 info_logger("Extracting edges...")
                 edge_count = self._extract_edges(temp_path / "edges.jsonl", repo_path)
+                # (edge filtering uses the id set _extract_nodes recorded)
                 
                 # Step 5: Generate statistics and assemble standardized metadata
                 if include_stats:
@@ -667,10 +675,19 @@ class CGCBundle:
             """,
         ]
     
-    def _extract_nodes(self, output_file: Path, repo_path: Optional[Path]) -> int:
-        """Extract all nodes to JSONL format."""
+    def _extract_nodes(self, output_file: Path, repo_path: Optional[Path], exclude_labels: Optional[List[str]] = None) -> int:
+        """Extract all nodes to JSONL format.
+
+        ``exclude_labels`` drops nodes carrying any of the given labels
+        (#1323 — e.g. DbTable/ExternalClass datasource metadata that path
+        filters can never reach). Their ids are recorded so
+        ``_extract_edges`` drops the touching edges too, keeping the bundle
+        free of dangling endpoints.
+        """
         count = 0
         seen_nodes = set()
+        excluded = {l.strip() for l in (exclude_labels or []) if l.strip()}
+        self._excluded_node_ids = set()
         
         with self.db_manager.get_driver(self._active_graph).session() as session:
             if repo_path:
@@ -691,6 +708,12 @@ class CGCBundle:
                         if node_key in seen_nodes:
                             continue
                         seen_nodes.add(node_key)
+
+                        if excluded and any(l in excluded for l in labels):
+                            self._excluded_node_ids.add(
+                                self._stable_id_key(self._export_id_of(node, node_dict))
+                            )
+                            continue
                     
                         # Clean up absolute path prefix to keep it relative
                         if repo_path:
@@ -718,6 +741,24 @@ class CGCBundle:
         
         return count
     
+    @staticmethod
+    def _stable_id_key(node_id) -> str:
+        """A hashable, backend-agnostic key for a node id (dict for Kùzu,
+        string for Neo4j/FalkorDB)."""
+        if isinstance(node_id, dict):
+            return json.dumps(node_id, sort_keys=True, default=str)
+        return str(node_id)
+
+    @staticmethod
+    def _export_id_of(node, node_dict):
+        if '_id' in node_dict:
+            return node_dict['_id']
+        if hasattr(node, 'element_id'):
+            return node.element_id
+        if hasattr(node, 'id'):
+            return str(node.id)
+        return None
+
     def _extract_edges(self, output_file: Path, repo_path: Optional[Path]) -> int:
         """Extract all relationships to JSONL format."""
         count = 0
@@ -778,6 +819,16 @@ class CGCBundle:
                                 to_id = str(target.id)
                             else:
                                 to_id = str(id(target))
+
+                        # Drop edges touching a label-excluded node (#1323):
+                        # nodes.jsonl no longer carries the endpoint, and a
+                        # dangling reference is an import failure waiting.
+                        excluded_ids = getattr(self, "_excluded_node_ids", None)
+                        if excluded_ids and (
+                            self._stable_id_key(from_id) in excluded_ids
+                            or self._stable_id_key(to_id) in excluded_ids
+                        ):
+                            continue
 
                         # Clean up absolute path prefix inside edge properties
                         if repo_path:

--- a/tests/unit/core/test_bundle_exclude_labels.py
+++ b/tests/unit/core/test_bundle_exclude_labels.py
@@ -1,0 +1,116 @@
+"""#1323: `cgc bundle export --exclude-labels` drops node types AND their edges.
+
+Real-Kùzu roundtrip: a graph with code nodes plus datasource metadata is
+exported without DbTable/Datasource; the bundle must carry neither those
+nodes nor any dangling edges, must record the exclusion in metadata, and
+must import cleanly.
+"""
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.cgc_bundle import CGCBundle
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+from codegraphcontext.tools.indexing.persistence.writer import GraphWriter
+
+kuzu = pytest.importorskip("kuzu")
+
+
+def _bundle_jsonl(bundle_path: Path, member: str):
+    with zipfile.ZipFile(bundle_path) as z:
+        payload_names = [n for n in z.namelist() if n.endswith(member)]
+        assert payload_names, f"{member} not in bundle: {z.namelist()}"
+        return [json.loads(l) for l in z.read(payload_names[0]).decode().splitlines() if l.strip()]
+
+
+def test_exclude_labels_drops_nodes_edges_and_records_metadata(tmp_path: Path):
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    driver = manager.get_driver()
+    try:
+        w = GraphWriter(driver)
+        repo = tmp_path / "repo"; repo.mkdir()
+        f = repo / "a.py"; f.write_text("def q():\n    pass\n", encoding="utf-8")
+        w.add_repository_to_graph(repo)
+        w.add_file_to_graph({
+            "path": str(f), "repo_path": str(repo), "lang": "python", "imports": [],
+            "functions": [{"name": "q", "line_number": 1, "end_line": 2, "args": []}],
+            "classes": [], "variables": []},
+            repo.name, {}, repo_path_str=str(repo.resolve()))
+        w.write_datasource_graph({
+            "datasource": {"name": "mydb", "kind": "mysql", "host": "h", "env": "dev"},
+            "tables": [{"fqn": "mydb.users", "name": "users", "datasource_name": "mydb"}],
+            "columns": [{"name": "id", "table_fqn": "mydb.users", "type": "INT",
+                         "nullable": False, "datasource_name": "mydb", "is_primary_key": True}],
+            "key_patterns": [],
+        })
+
+        class _DBM:
+            def get_driver(self, graph_name=None): return driver
+            def get_backend_type(self): return "kuzudb"
+
+        out = tmp_path / "filtered.cgc"
+        ok, msg = CGCBundle(_DBM()).export_to_bundle(
+            out, exclude_labels=["DbTable", "DbColumn", "Datasource"]
+        )
+        assert ok, msg
+
+        nodes = _bundle_jsonl(out, "nodes.jsonl")
+        labels = {l for n in nodes for l in n.get("_labels", [])}
+        assert "DbTable" not in labels and "DbColumn" not in labels and "Datasource" not in labels
+        assert "Function" in labels and "File" in labels
+
+        # No dangling edges: every endpoint id must exist in nodes.jsonl.
+        node_ids = {json.dumps(n["_id"], sort_keys=True, default=str) for n in nodes if "_id" in n}
+        edges = _bundle_jsonl(out, "edges.jsonl")
+        for e in edges:
+            for side in ("from", "to"):
+                key = json.dumps(e[side], sort_keys=True, default=str)
+                assert key in node_ids, f"dangling {side} endpoint: {e}"
+
+        with zipfile.ZipFile(out) as z:
+            meta_name = [n for n in z.namelist() if n.endswith("metadata.json")][0]
+            meta = json.loads(z.read(meta_name))
+        assert meta.get("excluded_labels") == ["Datasource", "DbColumn", "DbTable"]
+
+        # And the filtered bundle imports cleanly into a fresh db.
+        m2 = KuzuDBManager(str(tmp_path / "db2"))
+        d2 = m2.get_driver()
+        try:
+            class _DBM2:
+                def get_driver(self, graph_name=None): return d2
+                def get_backend_type(self): return "kuzudb"
+            ok2, msg2 = CGCBundle(_DBM2()).import_from_bundle(out)
+            assert ok2, msg2
+            with d2.session() as s:
+                fn = s.run("MATCH (f:Function) RETURN count(f) AS c").data()[0]["c"]
+                dbt = s.run("MATCH (t:DbTable) RETURN count(t) AS c").data()[0]["c"]
+            assert fn == 1 and dbt == 0
+        finally:
+            m2.close_driver()
+    finally:
+        manager.close_driver()
+
+
+def test_export_without_exclusions_is_unchanged(tmp_path: Path):
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    driver = manager.get_driver()
+    try:
+        w = GraphWriter(driver)
+        repo = tmp_path / "repo"; repo.mkdir()
+        (repo / "a.py").write_text("x = 1\n", encoding="utf-8")
+        w.add_repository_to_graph(repo)
+
+        class _DBM:
+            def get_driver(self, graph_name=None): return driver
+            def get_backend_type(self): return "kuzudb"
+
+        out = tmp_path / "full.cgc"
+        ok, msg = CGCBundle(_DBM()).export_to_bundle(out)
+        assert ok, msg
+        with zipfile.ZipFile(out) as z:
+            meta = json.loads(z.read([n for n in z.namelist() if n.endswith("metadata.json")][0]))
+        assert "excluded_labels" not in meta
+    finally:
+        manager.close_driver()


### PR DESCRIPTION
Implements the #1323 proposal: `cgc bundle export project.cgc --repo . --exclude-labels DbTable,ExternalClass`.

- Excluded nodes are dropped at extraction; their export ids are recorded and **every edge touching one is dropped too** — a filtered bundle can never carry a dangling endpoint (the #1322-class import failures the issue worried about)
- `metadata.json` records `excluded_labels` so consumers can tell what a bundle omits
- Exposed on both `cgc bundle export` and the `cgc export` shortcut (the CLI parity meta-test enforces the forwarding)
- Real-Kùzu test: build a graph with code + datasource metadata, export with exclusions, assert label absence, endpoint integrity, metadata, and a clean import into a fresh database

Unit suite 1459 green; CLI meta-tests green.

Fixes #1323