### PR TITLE
chore(ci): concurrency groups + pip caching for heavy workflows (#1326)

### DIFF
--- a/.github/workflows/db-parity-check.yml
+++ b/.github/workflows/db-parity-check.yml
@@ -9,6 +9,12 @@ on:
       - main
   workflow_dispatch:
 
+# Cancel superseded runs of the SAME pull request only; pushes to main and
+# scheduled runs are never cancelled (#1326).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   db-parity:
     runs-on: ubuntu-latest
@@ -30,6 +36,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancel superseded runs of the SAME pull request only; pushes to main and
+# scheduled runs are never cancelled (#1326).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     strategy:
@@ -22,6 +28,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.14'
+        cache: 'pip'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel superseded runs of the SAME pull request only; pushes to main and
+# scheduled runs are never cancelled (#1326).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
@@ -18,6 +24,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: 'pip'
 
       - name: Install ruff
         run: python -m pip install --upgrade pip ruff

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel superseded runs of the SAME pull request only; pushes to main and
+# scheduled runs are never cancelled (#1326).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   macos:
     runs-on: macos-latest
@@ -17,6 +23,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
+          cache: 'pip'
 
       - name: Install system deps
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
     - cron: "30 18 * * *"
   workflow_dispatch:  
 
+# Cancel superseded runs of the SAME pull request only; pushes to main and
+# scheduled runs are never cancelled (#1326).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,6 +31,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-09-02 20:43 UTC_
+_Generated: 2026-09-02 21:11 UTC_
 
 
 ## God Nodes — Highest Fan-In


### PR DESCRIPTION
Implements the practical parts of #1326:

- **Concurrency groups** on test/e2e/db-parity/lint/macos: superseded runs of the same PR are cancelled (`cancel-in-progress` is conditioned on `pull_request`, so pushes to main and the scheduled runs are never cancelled)
- **Pip caching** via setup-python's built-in `cache: 'pip'` on the same five workflows
- Python-version **matrix testing already exists** in test.yml (3.12–3.14), and deploy/docker/CodeQL are deliberately left without cancellation — a security scan or publish should finish even when superseded

All 13 workflow files still parse. Fixes #1326