### PR TITLE
fix(bundle): guard exclude_labels against Typer OptionInfo (follow-up to #1692)

### DIFF
--- a/src/codegraphcontext/cli/main.py
+++ b/src/codegraphcontext/cli/main.py
@@ -761,7 +761,14 @@ def bundle_export(
             include_stats=not no_stats,
             sign_key=sign_key,
             encrypt_password=encrypt_password,
-            exclude_labels=[l for l in (exclude_labels or "").split(",") if l.strip()],
+            # bundle_export is also called programmatically (the golden
+            # harness does), where unpassed Typer options arrive as OptionInfo
+            # objects rather than their defaults — same trap the CLI meta-test
+            # documents for other commands.
+            exclude_labels=[
+                l for l in (exclude_labels if isinstance(exclude_labels, str) else "").split(",")
+                if l.strip()
+            ],
         )
         
         if success:


### PR DESCRIPTION
The parser-golden harness calls `bundle_export()` programmatically, where unpassed Typer options arrive as `OptionInfo` objects — the #1692 `exclude_labels.split(',')` blew up and every golden's index/export subprocess failed. Guarded with an isinstance check (the same known trap the CLI meta-test documents for other commands). Golden verified green; unit suite 1459.