### PR TITLE
chore(release): bump version to 0.6.10

### DIFF
--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-09-02 21:11 UTC_
+_Generated: 2026-09-02 21:30 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.9"
+version = "0.6.10"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
0.6.9 → 0.6.10:

- **Named-context "Repos Linked: 0" desync fixed** (#1691/#1317): registration runs before the already-indexed skip guard and covers default named contexts
- **`cgc bundle export --exclude-labels`** drops node types with their edges — no dangling endpoints, recorded in bundle metadata (#1692/#1323), with an OptionInfo guard follow-up (#1696)
- **CI**: concurrency groups + pip caching across the heavy workflows (#1693/#1326)
- **docs/TROUBLESHOOTING.md**: every entry maps a real reported issue to its fix (#1694/#1567)

Full integration suite green at the release commit: **91 passed / 0 failed**.