### PR TITLE
fix(elisp): capture function-quoted targets in (funcall #'fn)/(apply #'fn)

### DIFF
--- a/src/codegraphcontext/tools/languages/elisp.py
+++ b/src/codegraphcontext/tools/languages/elisp.py
@@ -242,11 +242,26 @@ class ElispTreeSitterParser:
         return None
 
     def _first_symbol_in_quote(self, node: Any) -> Optional[str]:
-        if node.type != "quote":
+        # (quote symbol) -> symbol
+        if node.type == "quote":
+            for child in self._named_children(node):
+                if child.type == "symbol":
+                    return self._get_node_text(child)
             return None
-        for child in self._named_children(node):
-            if child.type == "symbol":
-                return self._get_node_text(child)
+        # #'symbol (function quote): tree-sitter-elisp parses `(funcall #'fn ...)`
+        # as (special_form (symbol "function") (symbol "fn")). Without this branch
+        # funcall/apply targets are dropped, so function_calls never records them
+        # and elisp call tests fail (KeyError / missing call edges).
+        if node.type == "special_form" and self._form_head(node) == "function":
+            named = self._named_children(node)
+            if len(named) >= 2 and named[1].type == "symbol":
+                return self._get_node_text(named[1])
+            return None
+        # Some grammar builds expose #'/quote as a `quoted_symbol` node wrapping a
+        # single symbol child; cover that variant too.
+        named = self._named_children(node)
+        if len(named) == 1 and named[0].type == "symbol":
+            return self._get_node_text(named[0])
         return None
 
     def _quoted_symbol_argument(self, node: Any, index: int = 1) -> Optional[str]:


### PR DESCRIPTION
## Root cause
`_quoted_symbol_argument` -> `_first_symbol_in_quote` only recognized `(quote symbol)`. Emacs Lisp `(funcall #'fn ...)` / `(apply #'fn ...)` use a **function quote** (`#'`), which tree-sitter-elisp parses as a `special_form`/`quoted_symbol` node rather than a plain `quote`. So the helper returned `None`, no call was recorded, and:

- `tests/unit/parsers/test_elisp_parser.py::test_parse_elisp_normalized_output` failed with `KeyError: 'sample-callback'` (and missed the `apply #'sample-variadic` call).
- `tests/integration/test_elisp_indexing_smoke.py::test_elisp_fixture_indexes_end_to_end_with_kuzu` missed the `foo-ui-render -> foo-ui-after-render` call edge (from `(funcall #'foo-ui-after-render ...)`), failing the `issubset` assertion.

## Fix
Extend `_first_symbol_in_quote` to also extract the symbol from `#'fn` (function-quote) forms, with a `quoted_symbol` fallback for grammar variants. Plain `(quote symbol)` handling is unchanged. All existing gates (Build Test / End-to-end Tests / Database Parity Check) should turn green.

## Scope
- Only `src/codegraphcontext/tools/languages/elisp.py` changed.
- No behavior change for `(quote ...)` or non-funcall calls.

Co-Authored-By: Gu <gu@workbuddy>