### PR TITLE
fix(embedded): cap the LadybugDB/Kuzu buffer pool at 4 GiB by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,7 @@ PYTHONDONTWRITEBYTECODE=1
 
 # Backend selection: falkordb | falkordb-remote | neo4j | kuzudb | ladybugdb
 # DEFAULT_DATABASE=falkordb
+
+# Cap embedded LadybugDB/Kuzu buffer pool (MiB). Default 4096 (4 GiB).
+# Set to 0 to use the library default (~80% of system memory).
+# CGC_EMBEDDED_BUFFER_POOL_MB=4096

--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ CodeGraphContext supports multiple graph database backends to suit your environm
 | **Speed** | ⚡ Extremely Fast | ⚡ Fast | 🚀 Scalable | 🌐 Network-dependent |
 | **Persistence**| Yes (to disk) | Yes (to disk) | Yes (to disk) | Yes (server-side) |
 
+Embedded KuzuDB/LadybugDB default to a **4 GiB** buffer pool (`CGC_EMBEDDED_BUFFER_POOL_MB`). Set that env var to another MiB value, or `0` for the library default (~80% of system RAM).
+
 ---
 
 ## SCIP indexing (optional)

--- a/docs/docs/reference/config.md
+++ b/docs/docs/reference/config.md
@@ -167,6 +167,7 @@ Local embedded database instances are stored on disk. Use the settings below to 
 | **`KUZUDB_PATH`** | `~/.codegraphcontext/global/db/kuzudb/` | Root storage directory for KuzuDB files. |
 | **`LADYBUGDB_PATH`** | `~/.codegraphcontext/global/db/ladybugdb/` | Root storage directory for LadybugDB files. |
 | **`FALKORDB_PATH`** | `~/.codegraphcontext/global/db/falkordb/` | Storage path for FalkorDB Lite database. |
+| **`CGC_EMBEDDED_BUFFER_POOL_MB`** | `4096` | Max buffer pool size in MiB for LadybugDB/Kuzu. Set `0` to use the library default (~80% of system RAM). |
 
 ---
 

--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -23,6 +23,40 @@ from codegraphcontext.core.graph_query import GraphQueryInterface
 from ..utils.cypher_ddl import is_schema_ddl
 from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logger, warning_logger
 
+# Default cap for ladybug/kuzu buffer pools (bytes). Both libraries otherwise
+# default to ~80% of system RAM, which lets long-running gateways grow huge.
+DEFAULT_EMBEDDED_BUFFER_POOL_BYTES = 4 * 1024**3
+
+
+def resolve_embedded_buffer_pool_size() -> int:
+    """
+    Resolve ``buffer_pool_size`` for embedded ``Database(...)`` constructors.
+
+    Reads ``CGC_EMBEDDED_BUFFER_POOL_MB`` (integer MiB). Unset uses a 4 GiB
+    default. ``0`` opts back into the library default (~80% of system memory).
+    Invalid values log a warning and fall back to 4 GiB.
+    """
+    raw = os.getenv("CGC_EMBEDDED_BUFFER_POOL_MB")
+    if raw is None or str(raw).strip() == "":
+        return DEFAULT_EMBEDDED_BUFFER_POOL_BYTES
+    try:
+        mb = int(str(raw).strip())
+    except ValueError:
+        warning_logger(
+            f"Invalid CGC_EMBEDDED_BUFFER_POOL_MB={raw!r}; "
+            f"using default {DEFAULT_EMBEDDED_BUFFER_POOL_BYTES} bytes"
+        )
+        return DEFAULT_EMBEDDED_BUFFER_POOL_BYTES
+    if mb < 0:
+        warning_logger(
+            f"Invalid CGC_EMBEDDED_BUFFER_POOL_MB={raw!r}; "
+            f"using default {DEFAULT_EMBEDDED_BUFFER_POOL_BYTES} bytes"
+        )
+        return DEFAULT_EMBEDDED_BUFFER_POOL_BYTES
+    if mb == 0:
+        return 0
+    return mb * 1024**2
+
 
 @dataclass(frozen=True)
 class EmbeddedBackendSpec:
@@ -117,8 +151,18 @@ class EmbeddedGraphManager(GraphQueryInterface):
                     max_retries = 5
                     for attempt in range(max_retries):
                         try:
-                            info_logger(f"Initializing {spec.display_name} at {self.db_path}")
-                            self._db = backend.Database(self.db_path)
+                            buffer_pool_size = resolve_embedded_buffer_pool_size()
+                            if buffer_pool_size == 0:
+                                pool_msg = "library default (~80% of system memory)"
+                            else:
+                                pool_msg = f"{buffer_pool_size} bytes"
+                            info_logger(
+                                f"Initializing {spec.display_name} at {self.db_path} "
+                                f"(buffer_pool_size={pool_msg})"
+                            )
+                            self._db = backend.Database(
+                                self.db_path, buffer_pool_size=buffer_pool_size
+                            )
 
                             # Initialise connection pool
                             self._pool = queue.Queue()

--- a/tests/unit/core/test_embedded_buffer_pool.py
+++ b/tests/unit/core/test_embedded_buffer_pool.py
@@ -1,0 +1,117 @@
+"""
+Tests for the embedded LadybugDB/Kuzu buffer-pool size resolution and wiring.
+
+Mocks the backend driver so the suite does not require a real kuzu/ladybug install.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+
+
+DEFAULT_POOL = 4 * 1024**3
+
+
+def _reset_kuzu_singleton():
+    if KuzuDBManager._instance is not None:
+        try:
+            KuzuDBManager._instance.close_driver()
+        except Exception:
+            pass
+    KuzuDBManager._instance = None
+    KuzuDBManager._db = None
+    KuzuDBManager._pool = None
+
+
+@pytest.fixture(autouse=True)
+def _clean_singleton():
+    _reset_kuzu_singleton()
+    yield
+    _reset_kuzu_singleton()
+
+
+class TestResolveEmbeddedBufferPoolSize:
+    def test_default_is_4_gib(self, monkeypatch):
+        from codegraphcontext.core.database_embedded_kuzu import (
+            resolve_embedded_buffer_pool_size,
+        )
+
+        monkeypatch.delenv("CGC_EMBEDDED_BUFFER_POOL_MB", raising=False)
+        assert resolve_embedded_buffer_pool_size() == DEFAULT_POOL
+
+    def test_env_override_mib(self, monkeypatch):
+        from codegraphcontext.core.database_embedded_kuzu import (
+            resolve_embedded_buffer_pool_size,
+        )
+
+        monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "512")
+        assert resolve_embedded_buffer_pool_size() == 512 * 1024**2
+
+    def test_zero_means_library_default(self, monkeypatch):
+        from codegraphcontext.core.database_embedded_kuzu import (
+            resolve_embedded_buffer_pool_size,
+        )
+
+        monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "0")
+        assert resolve_embedded_buffer_pool_size() == 0
+
+    def test_invalid_abc_falls_back(self, monkeypatch):
+        from codegraphcontext.core.database_embedded_kuzu import (
+            resolve_embedded_buffer_pool_size,
+        )
+
+        monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "abc")
+        assert resolve_embedded_buffer_pool_size() == DEFAULT_POOL
+
+    def test_invalid_negative_falls_back(self, monkeypatch):
+        from codegraphcontext.core.database_embedded_kuzu import (
+            resolve_embedded_buffer_pool_size,
+        )
+
+        monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "-1")
+        assert resolve_embedded_buffer_pool_size() == DEFAULT_POOL
+
+
+class TestDatabaseReceivesBufferPoolSize:
+    def _open_with_mocked_backend(self, tmp_path):
+        mock_db = MagicMock()
+        mock_db.is_closed.return_value = False
+        backend = MagicMock()
+        backend.Database.return_value = mock_db
+        backend.Connection.return_value = MagicMock()
+
+        with patch(
+            "codegraphcontext.core.database_embedded_kuzu.importlib.import_module",
+            return_value=backend,
+        ), patch.object(KuzuDBManager, "_initialize_schema", return_value=None):
+            manager = KuzuDBManager(db_path=str(tmp_path / "graph.kuzu"))
+            manager.get_driver()
+        return backend
+
+    def test_default_passes_4_gib(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CGC_EMBEDDED_BUFFER_POOL_MB", raising=False)
+        backend = self._open_with_mocked_backend(tmp_path)
+        backend.Database.assert_called_once()
+        _, kwargs = backend.Database.call_args
+        assert kwargs.get("buffer_pool_size") == DEFAULT_POOL
+
+    def test_env_override_passes_bytes(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "512")
+        backend = self._open_with_mocked_backend(tmp_path)
+        _, kwargs = backend.Database.call_args
+        assert kwargs.get("buffer_pool_size") == 512 * 1024**2
+
+    def test_zero_passes_library_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "0")
+        backend = self._open_with_mocked_backend(tmp_path)
+        _, kwargs = backend.Database.call_args
+        # Library default is buffer_pool_size=0 (~80% RAM); pass 0 explicitly.
+        assert "buffer_pool_size" in kwargs
+        assert kwargs["buffer_pool_size"] == 0
+
+    def test_invalid_falls_back_without_raise(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "abc")
+        backend = self._open_with_mocked_backend(tmp_path)
+        _, kwargs = backend.Database.call_args
+        assert kwargs.get("buffer_pool_size") == DEFAULT_POOL


### PR DESCRIPTION
Fixes #1699 by passing an explicit `buffer_pool_size` when opening embedded LadybugDB/Kuzu databases. The default is 4 GiB, overridable with `CGC_EMBEDDED_BUFFER_POOL_MB` (MiB; `0` restores the library ~80%-of-RAM default). Invalid values log a warning and fall back to 4 GiB. FalkorDB and Neo4j are unchanged.

Connection pool size, threading, and the lock-retry loop are intentionally out of scope.

Verification:
- `.venv/bin/pytest tests/unit/core -q` — 305 passed, 8 skipped
- `tests/unit/core/test_embedded_buffer_pool.py` — 9 passed; Database wiring and helper tests fail against `origin/main` source and pass with this change
- `ruff check` on the new test file — clean (pre-existing E701/E741 elsewhere in `database_embedded_kuzu.py` unchanged)
- `./tests/run_tests.sh fast` was not run: LadybugDB `_lbug` segfaults Python 3.14 worker processes (`NodeTable::initScanState` null mutex) and pops macOS crash dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKXSH6V4DpWV34arP5zvHm

Made with [Cursor](https://cursor.com)