### PR TITLE
fix(code-finder): match find_functions_by_argument against arg_types not parameter names

### DIFF
--- a/src/codegraphcontext/tools/code_finder.py
+++ b/src/codegraphcontext/tools/code_finder.py
@@ -635,19 +635,34 @@ class CodeFinder:
         return results
     
     def find_functions_by_argument(self, argument_name: str, path: Optional[str] = None, repo_path: Optional[str] = None, limit: Optional[int] = None) -> List[Dict]:
-        """Find functions that take a specific argument name."""
+        """Find functions that take a specific argument type or name.
+
+        Matches against Function.arg_types (typed languages like Java) first; falls back
+        to Parameter.name for untyped languages when no arg_types match is found.
+        """
         repo_path = self._normalize_repo_path_filter(repo_path)
         with self.driver.session() as session:
             repo_filter = "AND f.path STARTS WITH $repo_path" if repo_path else ""
             limit_clause = "LIMIT $limit" if limit is not None else ""
-            params = {"argument_name": argument_name, "repo_path": repo_path}
+            params = {"arg_type": argument_name, "argument_name": argument_name, "repo_path": repo_path}
             if limit is not None:
                 params["limit"] = limit
             if path:
                 params["path"] = path
                 query = f"""
-                    MATCH (f:Function)-[:HAS_PARAMETER]->(p:Parameter)
-                    WHERE p.name = $argument_name AND f.path = $path {repo_filter}
+                    MATCH (f:Function)
+                    WHERE f.path = $path {repo_filter}
+                      AND (
+                        (f.arg_types IS NOT NULL AND any(t IN f.arg_types WHERE t CONTAINS $arg_type))
+                        OR
+                        (
+                          (f.arg_types IS NULL OR size(f.arg_types) = 0)
+                          AND EXISTS {{
+                            MATCH (f)-[:HAS_PARAMETER]->(p:Parameter)
+                            WHERE p.name = $argument_name
+                          }}
+                        )
+                      )
                     RETURN f.name AS function_name, f.path AS path, f.line_number AS line_number,
                            f.docstring AS docstring, f.is_dependency AS is_dependency
                     ORDER BY f.is_dependency ASC, f.path, f.line_number
@@ -656,8 +671,19 @@ class CodeFinder:
                 result = session.run(query, **params)
             else:
                 query = f"""
-                    MATCH (f:Function)-[:HAS_PARAMETER]->(p:Parameter)
-                    WHERE p.name = $argument_name {repo_filter}
+                    MATCH (f:Function)
+                    WHERE {repo_filter[4:] if repo_filter else "true"}
+                      AND (
+                        (f.arg_types IS NOT NULL AND any(t IN f.arg_types WHERE t CONTAINS $arg_type))
+                        OR
+                        (
+                          (f.arg_types IS NULL OR size(f.arg_types) = 0)
+                          AND EXISTS {{
+                            MATCH (f)-[:HAS_PARAMETER]->(p:Parameter)
+                            WHERE p.name = $argument_name
+                          }}
+                        )
+                      )
                     RETURN f.name AS function_name, f.path AS path, f.line_number AS line_number,
                            f.docstring AS docstring, f.is_dependency AS is_dependency
                     ORDER BY f.is_dependency ASC, f.path, f.line_number


### PR DESCRIPTION
Fixes #1685.

`find_functions_by_argument` was matching against `Parameter.name` (the variable name) rather than the argument type. For typed languages like Java, type information lives on `Function.arg_types`, not on the `Parameter` node, so queries for types like `OrderFilter` returned no results.

The Cypher query now uses `any(t IN f.arg_types WHERE t CONTAINS $arg_type)` to match against the type list, with a fallback to parameter-name matching for untyped languages.

---

**Note:** The CI failures (Build Test 3.12/3.13/3.14, db-parity, e2e) are pre-existing failures on the `main` branch unrelated to this change. Specifically:
- `test_elisp_parser.py::test_parse_elisp_normalized_output` — `KeyError: 'sample-callback'` fails on main (run 33686444387)
- `test_verify_databases_parity.py::test_database_parity_e2e` — `ladybugdb exit code -11` (SIGSEGV in ladybug library) fails on main (run 33686444386)
- e2e tests — same `ladybugdb` crash fails on main (run 33686444388)

This PR is a re-submission of #1687 which was closed due to these pre-existing CI failures.