### PR TITLE
fix(viz): use filename instead of <module> for top-level script nodes

### DIFF
--- a/src/codegraphcontext/cli/cli_helpers.py
+++ b/src/codegraphcontext/cli/cli_helpers.py
@@ -709,11 +709,15 @@ def _render_offline_visualization(
             node_id = _meta(value, "_id")
         if node_id is None:
             node_id = props.get("path") or props.get("name")
+        raw_name = props.get("name") or props.get("path") or ""
+        file_path_val = props.get("path", "")
+        if raw_name == "<module>" and file_path_val:
+            raw_name = os.path.splitext(os.path.basename(file_path_val))[0]
         return {
             "id": _ident(node_id),
             "label": label,
-            "name": props.get("name") or props.get("path") or "",
-            "file_path": props.get("path", ""),
+            "name": raw_name,
+            "file_path": file_path_val,
             "line_number": props.get("line_number"),
         }
 

--- a/src/codegraphcontext/utils/visualize_graph.py
+++ b/src/codegraphcontext/utils/visualize_graph.py
@@ -99,11 +99,15 @@ def build_graph_data(
     for node in nodes:
         node_id = node.get("id") or node.get("name", "unknown")
         label = node.get("label", "Function")
+        raw_name = node.get("name", str(node_id))
+        file_path = node.get("file_path", "")
+        if raw_name == "<module>" and file_path:
+            raw_name = os.path.splitext(os.path.basename(file_path))[0]
         serialised_nodes.append({
             "id":        str(node_id),
             "label":     label,
-            "name":      node.get("name", str(node_id)),
-            "file_path": node.get("file_path", ""),
+            "name":      raw_name,
+            "file_path": file_path,
             "line":      node.get("line_number"),
             "color":     node_color(label),
         })

--- a/src/codegraphcontext/viz/server.py
+++ b/src/codegraphcontext/viz/server.py
@@ -235,7 +235,11 @@ async def get_graph(repo_path: Optional[str] = None, cypher_query: Optional[str]
                                 
                                 # Extract name/label for frontend
                                 # Prefer 'name' property, fallback to 'label', then 'path' or 'Unknown'
-                                display_name = str(props.get('name', props.get('label', props.get('path', 'Unknown'))))
+                                raw_name = str(props.get('name', props.get('label', props.get('path', 'Unknown'))))
+                                file_prop = str(props.get('path', props.get('file', '')))
+                                if raw_name == '<module>' and file_prop:
+                                    raw_name = os.path.splitext(os.path.basename(file_prop))[0]
+                                display_name = raw_name
                                 
                                 nodes_dict[eid] = {
                                     "id": eid,
@@ -468,8 +472,12 @@ def parse_node(node, nodes_dict):
                 props = dict(node.items())
             except: pass
             
-    display_name = str(props.get('name', props.get('label', props.get('path', 'Unknown'))))
-    
+    raw_name = str(props.get('name', props.get('label', props.get('path', 'Unknown'))))
+    file_prop = str(props.get('path', props.get('file', '')))
+    if raw_name == '<module>' and file_prop:
+        raw_name = os.path.splitext(os.path.basename(file_prop))[0]
+    display_name = raw_name
+
     nodes_dict[eid] = {
         "id": eid,
         "name": display_name,


### PR DESCRIPTION
Fixes #1681.

Top-level module nodes were all labeled `<module>`, making multiple files indistinguishable in the call graph visualizer. When the node name is `<module>`, the label now uses the file basename instead, giving each file a unique, readable identifier in the graph.

---

**Note:** The CI failures (Build Test 3.12/3.13/3.14, db-parity, e2e) are pre-existing failures on the `main` branch unrelated to this change. Specifically:
- `test_elisp_parser.py::test_parse_elisp_normalized_output` — `KeyError: 'sample-callback'` fails on main (run 33686444387)
- `test_verify_databases_parity.py::test_database_parity_e2e` — `ladybugdb exit code -11` (SIGSEGV in ladybug library) fails on main (run 33686444386)
- e2e tests — same `ladybugdb` crash fails on main (run 33686444388)

This PR is a re-submission of #1688 which was closed due to these pre-existing CI failures.