### PR TITLE
chore(release): bump version to 0.6.11

### DIFF
--- a/CGC_REPORT.md
+++ b/CGC_REPORT.md
@@ -1,6 +1,6 @@
 # CGC Report
 
-_Generated: 2026-09-02 21:30 UTC_
+_Generated: 2026-09-06 09:56 UTC_
 
 
 ## God Nodes — Highest Fan-In

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.10"
+version = "0.6.11"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
0.6.10 → 0.6.11:

- **Fixes main's red CI** (#1698): elisp `#'fn` targets in `funcall`/`apply` are captured across all tree-sitter grammar generations — the language pack drifted inside the pyproject pin and CI's fresh installs parsed function quotes differently than existing venvs
- **Embedded KùzuDB/LadybugDB buffer pool capped at 4 GiB** by default, overridable via `CGC_EMBEDDED_BUFFER_POOL_MB` (`0` restores the library's ~80%-of-RAM default) — long-running gateways no longer balloon (#1700/#1699)
- Fork PRs no longer show a failed Discord-invite check (#1695)

Full integration suite green at the release commit on grammar 1.16.2: **91 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)