### PR TITLE
fix(embedded): adaptive buffer-pool default — LadybugDB segfaulted on constrained runners

### DIFF
--- a/.github/workflows/db-parity-check.yml
+++ b/.github/workflows/db-parity-check.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Small fixtures; a large pool made LadybugDB fault on constrained runners
+env:
+  CGC_EMBEDDED_BUFFER_POOL_MB: "1024"
+
 jobs:
   db-parity:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Small fixtures; a large pool made LadybugDB fault on constrained runners
+env:
+  CGC_EMBEDDED_BUFFER_POOL_MB: "1024"
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Small fixtures; a large pool made LadybugDB fault on constrained runners
+env:
+  CGC_EMBEDDED_BUFFER_POOL_MB: "1024"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -27,18 +27,42 @@ from codegraphcontext.utils.debug_log import debug_log, info_logger, error_logge
 # default to ~80% of system RAM, which lets long-running gateways grow huge.
 DEFAULT_EMBEDDED_BUFFER_POOL_BYTES = 4 * 1024**3
 
+# Floor for the availability-derived default, so a briefly-busy machine does
+# not shrink the pool into pathological territory.
+MIN_DEFAULT_BUFFER_POOL_BYTES = 256 * 1024**2
+
+
+def _available_memory_bytes():
+    """MemAvailable from /proc/meminfo, or None where unavailable (macOS…)."""
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    return None
+
 
 def resolve_embedded_buffer_pool_size() -> int:
     """
     Resolve ``buffer_pool_size`` for embedded ``Database(...)`` constructors.
 
-    Reads ``CGC_EMBEDDED_BUFFER_POOL_MB`` (integer MiB). Unset uses a 4 GiB
-    default. ``0`` opts back into the library default (~80% of system memory).
-    Invalid values log a warning and fall back to 4 GiB.
+    Reads ``CGC_EMBEDDED_BUFFER_POOL_MB`` (integer MiB). Unset uses an
+    adaptive default: 4 GiB, capped at half of currently-available memory
+    (floored at 256 MiB) — on a memory-constrained host (CI runners sharing
+    RAM with a Neo4j container, small VMs) a fixed 4 GiB pool made LadybugDB
+    fault natively (SIGSEGV, parity run exit -11) when the reservation could
+    not be backed. An explicit env value is always honored as-is; ``0`` opts
+    back into the library default (~80% of system memory).
     """
     raw = os.getenv("CGC_EMBEDDED_BUFFER_POOL_MB")
     if raw is None or str(raw).strip() == "":
-        return DEFAULT_EMBEDDED_BUFFER_POOL_BYTES
+        available = _available_memory_bytes()
+        if available is None:
+            return DEFAULT_EMBEDDED_BUFFER_POOL_BYTES
+        adaptive = max(MIN_DEFAULT_BUFFER_POOL_BYTES, available // 2)
+        return min(DEFAULT_EMBEDDED_BUFFER_POOL_BYTES, adaptive)
     try:
         mb = int(str(raw).strip())
     except ValueError:
@@ -160,9 +184,15 @@ class EmbeddedGraphManager(GraphQueryInterface):
                                 f"Initializing {spec.display_name} at {self.db_path} "
                                 f"(buffer_pool_size={pool_msg})"
                             )
-                            self._db = backend.Database(
-                                self.db_path, buffer_pool_size=buffer_pool_size
-                            )
+                            if buffer_pool_size == 0:
+                                # 0 means "library default": omit the kwarg
+                                # rather than trusting every backend to treat
+                                # a literal 0 that way.
+                                self._db = backend.Database(self.db_path)
+                            else:
+                                self._db = backend.Database(
+                                    self.db_path, buffer_pool_size=buffer_pool_size
+                                )
 
                             # Initialise connection pool
                             self._pool = queue.Queue()

--- a/tests/unit/core/test_embedded_buffer_pool.py
+++ b/tests/unit/core/test_embedded_buffer_pool.py
@@ -32,13 +32,14 @@ def _clean_singleton():
 
 
 class TestResolveEmbeddedBufferPoolSize:
-    def test_default_is_4_gib(self, monkeypatch):
-        from codegraphcontext.core.database_embedded_kuzu import (
-            resolve_embedded_buffer_pool_size,
-        )
+    def test_default_is_4_gib_when_memory_is_plentiful(self, monkeypatch):
+        from codegraphcontext.core import database_embedded_kuzu as dek
 
         monkeypatch.delenv("CGC_EMBEDDED_BUFFER_POOL_MB", raising=False)
-        assert resolve_embedded_buffer_pool_size() == DEFAULT_POOL
+        # The default is 4 GiB capped at half of available memory — a fixed
+        # 4 GiB pool made LadybugDB fault natively on constrained CI runners.
+        monkeypatch.setattr(dek, "_available_memory_bytes", lambda: 64 * 1024**3)
+        assert dek.resolve_embedded_buffer_pool_size() == DEFAULT_POOL
 
     def test_env_override_mib(self, monkeypatch):
         from codegraphcontext.core.database_embedded_kuzu import (
@@ -90,7 +91,9 @@ class TestDatabaseReceivesBufferPoolSize:
         return backend
 
     def test_default_passes_4_gib(self, tmp_path, monkeypatch):
+        from codegraphcontext.core import database_embedded_kuzu as dek
         monkeypatch.delenv("CGC_EMBEDDED_BUFFER_POOL_MB", raising=False)
+        monkeypatch.setattr(dek, "_available_memory_bytes", lambda: 64 * 1024**3)
         backend = self._open_with_mocked_backend(tmp_path)
         backend.Database.assert_called_once()
         _, kwargs = backend.Database.call_args
@@ -102,16 +105,42 @@ class TestDatabaseReceivesBufferPoolSize:
         _, kwargs = backend.Database.call_args
         assert kwargs.get("buffer_pool_size") == 512 * 1024**2
 
-    def test_zero_passes_library_default(self, tmp_path, monkeypatch):
+    def test_zero_omits_the_kwarg_entirely(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "0")
         backend = self._open_with_mocked_backend(tmp_path)
         _, kwargs = backend.Database.call_args
-        # Library default is buffer_pool_size=0 (~80% RAM); pass 0 explicitly.
-        assert "buffer_pool_size" in kwargs
-        assert kwargs["buffer_pool_size"] == 0
+        # 0 means "library default": the kwarg is omitted rather than trusting
+        # every backend to treat a literal 0 that way.
+        assert "buffer_pool_size" not in kwargs
 
     def test_invalid_falls_back_without_raise(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "abc")
         backend = self._open_with_mocked_backend(tmp_path)
         _, kwargs = backend.Database.call_args
         assert kwargs.get("buffer_pool_size") == DEFAULT_POOL
+
+
+def test_default_adapts_to_available_memory(monkeypatch):
+    """On a constrained host the unset default must shrink below 4 GiB —
+    a fixed 4 GiB pool made LadybugDB fault natively on CI runners."""
+    from codegraphcontext.core import database_embedded_kuzu as dek
+    monkeypatch.delenv("CGC_EMBEDDED_BUFFER_POOL_MB", raising=False)
+    monkeypatch.setattr(dek, "_available_memory_bytes", lambda: 2 * 1024**3)
+    assert dek.resolve_embedded_buffer_pool_size() == 1 * 1024**3  # half of avail
+
+    monkeypatch.setattr(dek, "_available_memory_bytes", lambda: 64 * 1024**3)
+    assert dek.resolve_embedded_buffer_pool_size() == 4 * 1024**3  # capped at 4 GiB
+
+    monkeypatch.setattr(dek, "_available_memory_bytes", lambda: 100 * 1024**2)
+    assert dek.resolve_embedded_buffer_pool_size() == 256 * 1024**2  # floor
+
+    monkeypatch.setattr(dek, "_available_memory_bytes", lambda: None)
+    assert dek.resolve_embedded_buffer_pool_size() == 4 * 1024**3  # unknown → 4 GiB
+
+
+def test_explicit_value_is_honored_verbatim(monkeypatch):
+    from codegraphcontext.core import database_embedded_kuzu as dek
+    monkeypatch.setenv("CGC_EMBEDDED_BUFFER_POOL_MB", "8192")
+    monkeypatch.setattr(dek, "_available_memory_bytes", lambda: 1 * 1024**3)
+    # explicit values are never second-guessed by the availability heuristic
+    assert dek.resolve_embedded_buffer_pool_size() == 8192 * 1024**2


### PR DESCRIPTION
Follow-up to #1700, which turned the Database Parity Check red on main: the fixed 4 GiB pool made LadybugDB fault natively (`Indexing process failed for ladybugdb with exit code -11`) on runners sharing memory with the Neo4j container.

- **Unset default is now adaptive**: `min(4 GiB, MemAvailable / 2)`, floored at 256 MiB — dev machines keep the 4 GiB cap, constrained hosts stop over-reserving. Explicit `CGC_EMBEDDED_BUFFER_POOL_MB` values are never second-guessed.
- **`0` now genuinely omits the kwarg** instead of passing a literal 0 and trusting every backend to read that as "library default".
- **CI pins `CGC_EMBEDDED_BUFFER_POOL_MB: 1024`** in the parity/e2e/test workflows — tiny fixtures, deterministic behavior.

Mechanism verified: under a virtual-memory cap Ladybug raises a clean mmap error, but under physical/cgroup pressure the failure is a native fault — matching the parity log exactly. #1700's contract tests updated to the adaptive semantics; suite 1470 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)