### PR TITLE
test: end-to-end coverage for the MCP stdio session and live watcher events

### DIFF
--- a/tests/integration/test_mcp_stdio_session.py
+++ b/tests/integration/test_mcp_stdio_session.py
@@ -1,0 +1,85 @@
+"""End-to-end MCP stdio session: initialize → tools/list → a real tool call.
+
+This is how agents actually consume CGC; until now only the dispatcher was
+tested (with mocks), so protocol-level breakage could ship unnoticed.
+Hermetic: per-test HOME, embedded database.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def mcp_session(tmp_path: Path):
+    home = tmp_path / "home"; home.mkdir()
+    repo = tmp_path / "repo"; repo.mkdir()
+    (repo / "app.py").write_text("def greet(name):\n    return f'hi {name}'\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["DEFAULT_DATABASE"] = "kuzudb"
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    env["CGC_ALLOWED_ROOTS"] = str(repo)
+
+    subprocess.run(
+        [sys.executable, "-m", "codegraphcontext.cli.main", "index", str(repo)],
+        capture_output=True, text=True, env=env, timeout=180, check=False,
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "codegraphcontext.cli.main", "mcp", "start"],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, env=env,
+    )
+    yield proc
+    proc.kill()
+    proc.wait(timeout=10)
+
+
+def _send(proc, obj):
+    proc.stdin.write(json.dumps(obj) + "\n")
+    proc.stdin.flush()
+
+
+def _read_response(proc, want_id, max_lines=100):
+    for _ in range(max_lines):
+        line = proc.stdout.readline()
+        if not line:
+            return None
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("id") == want_id:
+            return msg
+    return None
+
+
+def test_full_stdio_session(mcp_session):
+    proc = mcp_session
+
+    _send(proc, {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+                 "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                            "clientInfo": {"name": "test", "version": "0"}}})
+    r = _read_response(proc, 1)
+    assert r is not None and "result" in r, f"initialize failed: {r}"
+    _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    _send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+    r = _read_response(proc, 2)
+    assert r is not None and "result" in r, f"tools/list failed: {r}"
+    tools = {t["name"] for t in r["result"]["tools"]}
+    assert "find_code" in tools and "add_code_to_graph" in tools
+    assert len(tools) >= 20
+
+    _send(proc, {"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                 "params": {"name": "find_code", "arguments": {"query": "greet"}}})
+    r = _read_response(proc, 3)
+    assert r is not None and "result" in r, f"tools/call failed: {r}"
+    assert "greet" in json.dumps(r["result"]), "indexed function not found over MCP"

--- a/tests/integration/test_watcher_live_events.py
+++ b/tests/integration/test_watcher_live_events.py
@@ -1,0 +1,84 @@
+"""End-to-end live watcher: real watchdog events → debounce → graph updates.
+
+The startup-sync and handler internals are unit-tested; this covers the one
+path nothing exercised — actual filesystem events driving incremental
+updates on a real embedded database.
+"""
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+from codegraphcontext.core.watcher import CodeWatcher
+from codegraphcontext.tools.graph_builder import GraphBuilder
+
+kuzu = pytest.importorskip("kuzu")
+
+
+class _DBM:
+    def __init__(self, d): self._d = d
+    def get_driver(self, graph_name=None): return self._d
+    def get_backend_type(self): return "kuzudb"
+
+
+class _JM:
+    def update_job(self, *a, **k): pass
+
+
+def _wait_until(predicate, timeout=30.0, interval=0.5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+def test_watcher_applies_modify_create_and_delete(tmp_path: Path):
+    repo = tmp_path / "repo"; repo.mkdir()
+    (repo / "a.py").write_text("def one():\n    pass\n", encoding="utf-8")
+
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    driver = manager.get_driver()
+    gb = GraphBuilder(_DBM(driver), _JM(), asyncio.new_event_loop())
+    asyncio.new_event_loop().run_until_complete(
+        gb.build_graph_from_path_async(repo, is_dependency=False)
+    )
+
+    def funcs():
+        with driver.session() as s:
+            return sorted(
+                r["n"] for r in s.run(
+                    "MATCH (f:Function) WHERE f.name <> '<module>' RETURN f.name AS n"
+                ).data()
+            )
+
+    assert funcs() == ["one"]
+
+    watcher = CodeWatcher(gb)
+    watcher.watch_directory(str(repo), perform_initial_scan=False)
+    watcher.start()
+    try:
+        (repo / "a.py").write_text(
+            "def one():\n    pass\n\ndef two():\n    return 1\n", encoding="utf-8"
+        )
+        assert _wait_until(lambda: "two" in funcs()), (
+            f"modify event never reached the graph: {funcs()}"
+        )
+
+        (repo / "b.py").write_text("def three():\n    return 3\n", encoding="utf-8")
+        assert _wait_until(lambda: "three" in funcs()), (
+            f"create event never reached the graph: {funcs()}"
+        )
+
+        (repo / "b.py").unlink()
+        assert _wait_until(lambda: "three" not in funcs()), (
+            f"delete event never reached the graph: {funcs()}"
+        )
+
+        assert funcs() == ["one", "two"]
+    finally:
+        watcher.stop()
+        manager.close_driver()


### PR DESCRIPTION
Locks in the two seams this week's hunting proved were never exercised for real:

- **MCP stdio**: spawn `cgc mcp start`, do the initialize handshake, list tools (asserting ≥20 incl. `find_code`/`add_code_to_graph`), and make a real `tools/call` that resolves an indexed function. Everything before this tested the dispatcher with mocks — protocol-level breakage could ship silently.
- **Live watcher**: real watchdog events (modify, create, delete) flowing through the debounce into incremental updates on a real embedded database, with patient polling rather than sleeps.

Both hermetic (per-test HOME / tmp dirs). This coverage class is where the recent mock-blind bugs lived (FalkorDB `Edge` falling through the viz classifier, the buffer-pool native fault). Suite: 1470 unit green, both new tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)