### PR TITLE
fix(embedded): the close that never ran, stale-session deadlocks, and the ladybug 0.20 pool floor

### DIFF
--- a/.github/workflows/db-parity-check.yml
+++ b/.github/workflows/db-parity-check.yml
@@ -15,9 +15,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Small fixtures; a large pool made LadybugDB fault on constrained runners
+# Deterministic pool for CI. 2 GiB: ladybug 0.20.x exhausts a 1 GiB pool on
+  # the parity fixture, while the unconstrained 4 GiB default faulted natively
+  # on runners sharing memory with the Neo4j container.
 env:
-  CGC_EMBEDDED_BUFFER_POOL_MB: "1024"
+  CGC_EMBEDDED_BUFFER_POOL_MB: "2048"
 
 jobs:
   db-parity:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,9 +12,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Small fixtures; a large pool made LadybugDB fault on constrained runners
+# Deterministic pool for CI. 2 GiB: ladybug 0.20.x exhausts a 1 GiB pool on
+  # the parity fixture, while the unconstrained 4 GiB default faulted natively
+  # on runners sharing memory with the Neo4j container.
 env:
-  CGC_EMBEDDED_BUFFER_POOL_MB: "1024"
+  CGC_EMBEDDED_BUFFER_POOL_MB: "2048"
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Small fixtures; a large pool made LadybugDB fault on constrained runners
+# Deterministic pool for CI. 2 GiB: ladybug 0.20.x exhausts a 1 GiB pool on
+  # the parity fixture, while the unconstrained 4 GiB default faulted natively
+  # on runners sharing memory with the Neo4j container.
 env:
-  CGC_EMBEDDED_BUFFER_POOL_MB: "1024"
+  CGC_EMBEDDED_BUFFER_POOL_MB: "2048"
 
 jobs:
   build:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -39,6 +39,11 @@ embedded database open — KùzuDB/LadybugDB are single-process. Use the
 running process's interface, or stop it first (#1683). This is not a
 configuration problem; `cgc doctor` won't help.
 
+### LadybugDB: "Buffer manager exception: unable to allocate memory" (or a crash)
+The buffer pool is too small for the workload — ladybug 0.20.x needs more
+pool than 0.19.x for the same graph. Raise `CGC_EMBEDDED_BUFFER_POOL_MB`
+(2048 is a good floor); the unset default adapts to available memory.
+
 ### Which backend am I actually using?
 `cgc config show` prints the resolved backend and its source. FalkorDB is
 the default where its native library loads; environments where it cannot

--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -590,7 +590,15 @@ class EmbeddedGraphManager(GraphQueryInterface):
                 # Without this call the process hangs on exit because the
                 # embedded Kùzu engine keeps background threads alive.
                 try:
-                    if not self._db.is_closed():
+                    # kuzu exposes is_closed as a METHOD on some builds and a
+                    # bool ATTRIBUTE on others (0.11.x). Calling the attribute
+                    # raised "'bool' object is not callable" — which this
+                    # except swallowed, so the close NEVER ran and the
+                    # background threads it exists to stop stayed alive.
+                    closed = self._db.is_closed
+                    if callable(closed):
+                        closed = closed()
+                    if not closed:
                         self._db.close()
                         info_logger(f"{self.BACKEND_SPEC.display_name} database closed successfully")
                 except Exception as e:
@@ -697,7 +705,20 @@ class EmbeddedSessionWrapper:
         # Backward compatibility check: check if it's a pool or connection
         if hasattr(pool_or_conn, "get") and not hasattr(pool_or_conn, "execute"):
             self._pool = pool_or_conn
-            self.conn = self._pool.get()
+            try:
+                # The embedded manager is a per-subclass singleton: switching
+                # db_path closes the old database and drains its pool. A caller
+                # holding a STALE driver reference then blocked here forever
+                # with no diagnostic. Fail loudly instead.
+                self.conn = self._pool.get(timeout=30)
+            except queue.Empty:
+                raise RuntimeError(
+                    "No database connection available after 30s — this driver's "
+                    "connection pool is exhausted or its database manager was "
+                    "closed/switched to another path. Re-acquire the driver via "
+                    "get_database_manager().get_driver() instead of holding a "
+                    "stale reference."
+                )
         else:
             self._pool = None
             self.conn = pool_or_conn


### PR DESCRIPTION
Three lifecycle bugs found by probing the embedded singleton with multiple database paths in one process:

1. **`close_driver` has never actually closed the database.** kuzu 0.11.x exposes `is_closed` as a bool *attribute*; calling it raised `'bool' object is not callable` straight into a swallowing `except` — so the close that exists to stop the engine's background threads silently did nothing, every time, since the day it was written. Now handles both the method and attribute spellings (verified: the warning is gone and the close runs).
2. **Stale driver references deadlocked forever.** The embedded manager is a per-subclass singleton — re-initializing with a new `db_path` closes the old database and drains its pool, and any caller still holding the old driver blocked on `queue.get()` with no timeout and no diagnostic. Now fails after 30s with a RuntimeError naming the cause and the correct re-acquisition path.
3. **The parity job's remaining -11**: CI installs ladybug **0.20.2**, which exhausts a 1 GiB pool on the parity fixture that 0.19.1 handled fine (reproduced locally: `Buffer manager exception` at 1024 MB, clean at 2048 MB). The CI pin moves to 2 GiB and TROUBLESHOOTING.md documents the symptom.

Suite: 1470 unit green; workflows parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)