### PR TITLE
fix(deps): pin ladybug <0.20 — 0.20.x segfaults on Python 3.14 CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     # wheels for all three platforms and remains the unconditional default.
     # ------------------------------------------------------------------
     "kuzu; python_version < '3.14' or sys_platform == 'linux'",
-    "ladybug; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
+    "ladybug>=0.19,<0.20; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
     # Cap below 2.0: the low-level `mcp.server.Server` dropped its `list_tools`
     # and `call_tool` decorators in 2.0.0, which api/mcp_sse.py registers its
     # handlers with. With an unbounded pin, CI resolved 2.0.0 on release day and
@@ -110,7 +110,7 @@ kuzu = [
     "kuzu; python_version < '3.14' or sys_platform == 'linux'",
 ]
 ladybug = [
-    "ladybug; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
+    "ladybug>=0.19,<0.20; sys_platform == 'win32' or (sys_platform != 'win32' and python_version >= '3.10')",
 ]
 neo4j = [
     "neo4j>=5.15.0",


### PR DESCRIPTION
The Database Parity job has been red since ladybug 0.20.2 started arriving in fresh CI installs. Elimination trail across three main commits: the elisp/grammar fix (#1698 — recovered Build Test but not parity), an adaptive buffer-pool default (#1704), a 2 GiB deterministic pool pin (#1706, confirmed active in the failing run's env) — **ladybug 0.20.2 still exits -11 on CI's Python 3.14** while the identical version+workload+pool is clean locally on 3.12, and 0.19.1 was green on CI for months.

That leaves the cp314 build of 0.20.x itself. Pinned `>=0.19,<0.20` in both dependency declarations until upstream stabilizes; un-pinning tracked in the follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)