### PR TITLE
fix(embedded): work around two LadybugDB planner defects that silently dropped edges (#1710)

### DIFF
--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -670,16 +670,19 @@ class EmbeddedDriverWrapper:
         compat_state = getattr(self, "_compat_state", None)
         pool = getattr(self, "_pool", None)
         display_name = getattr(self, "_display_name", "Embedded")
+        backend_id = getattr(self, "_backend_id", "embedded")
         if pool is not None:
             return EmbeddedSessionWrapper(
                 pool, getattr(self, "_write_lock", None),
                 compat_state=compat_state, display_name=display_name,
+                backend_id=backend_id,
             )
         else:
             db = getattr(self, "db", None) or getattr(self, "conn", None)
             write_lock = getattr(self, "_write_lock", None) or getattr(self, "_query_lock", None)
             return EmbeddedSessionWrapper(
                 db, write_lock, compat_state=compat_state, display_name=display_name,
+                backend_id=backend_id,
             )
     def close(self):
         pass
@@ -689,10 +692,12 @@ class EmbeddedDriverWrapper:
 
 
 class EmbeddedSessionWrapper:
-    def __init__(self, pool_or_conn, write_lock=None, compat_state=None, display_name: str = "Embedded"):
+    def __init__(self, pool_or_conn, write_lock=None, compat_state=None, display_name: str = "Embedded",
+                 backend_id: str = "embedded"):
         self._write_lock = write_lock or threading.Lock()
         self._query_lock = self._write_lock
         self._display_name = display_name
+        self._backend_id = backend_id
         # Disabled-query-type state is shared via the manager's compat_state so
         # fail-fast disabling persists across sessions. A standalone session
         # (tests / legacy callers) gets its own private state.
@@ -928,6 +933,22 @@ class EmbeddedSessionWrapper:
             with self._write_lock:
                 result = self.conn.execute(translated_query, translated_params)
 
+                # LadybugDB (0.19.x) state-dependently drops SOME rows of a
+                # batched relationship-only UNWIND MERGE on first execution —
+                # no error, the same batch replayed immediately in the same
+                # session binds the stragglers (reproduced: a 17-row
+                # Struct-CONTAINS batch wrote 12, the identical re-run wrote
+                # the remaining 5; that was the last piece of the parity gap
+                # in #1710). MERGE is idempotent, so a second pass is safe and
+                # only ladybug pays it. Kùzu binds these batches correctly.
+                if (
+                    getattr(self, "_backend_id", "") == "ladybugdb"
+                    and "MERGE" in query
+                    and ("-[" in query or "]->" in query)
+                    and re.search(r"UNWIND\s+\$\w+\s+AS\s+\w+", query)
+                ):
+                    result = self.conn.execute(translated_query, translated_params)
+
             return EmbeddedResultWrapper(result)
         except Exception as e:
             if self._should_fail_fast(query_type, e):
@@ -1104,6 +1125,26 @@ class EmbeddedSessionWrapper:
         #   b) MERGE uid injection from row fields (row.name, row.line_number, …)
         unwind_m = re.search(r'UNWIND\s+\$(\w+)\s+AS\s+(\w+)', query)
         if unwind_m:
+            # 1.5-pre: Collapse consecutive MATCH clauses into one comma-joined
+            # MATCH. LadybugDB's planner silently yields ZERO rows for
+            # UNWIND → MATCH (a {…}) → MATCH (b {…}) when the first MATCH is an
+            # index-map lookup (File-by-path being the everyday case): each
+            # MATCH works alone, chained they produce nothing — no error is
+            # raised, so downstream MERGEs quietly write no edges. That was the
+            # exact signature of the parity gap (all File-sourced CALLS edges
+            # and a handful of Struct CONTAINS edges missing on ladybug only).
+            # The comma form `MATCH (a {…}), (b {…})` is semantically identical
+            # for non-optional patterns and both engines plan it correctly.
+            # Only simple node patterns (no relationship arrows, no parens
+            # inside the pattern) directly adjacent to the next MATCH are
+            # merged, and never across OPTIONAL MATCH.
+            _match_merge_re = re.compile(
+                r'(?<!OPTIONAL )\bMATCH\s*(\([^()]*\)(?:\s*,\s*\([^()]*\))*)\s+MATCH\s*(?=\()'
+            )
+            _prev = None
+            while _prev != query:
+                _prev = query
+                query = _match_merge_re.sub(r'MATCH \1, ', query, count=1)
             batch_param = unwind_m.group(1)
             row_var = unwind_m.group(2)
             batch_data = parameters.get(batch_param)

--- a/tests/unit/core/test_embedded_match_merge.py
+++ b/tests/unit/core/test_embedded_match_merge.py
@@ -1,0 +1,157 @@
+"""#1710: consecutive MATCH clauses inside UNWIND batches merge to comma-form.
+
+LadybugDB's planner silently yields ZERO rows for
+`UNWIND $b AS row MATCH (a:File {path: row.p}) MATCH (b:Function {…})` when
+the first MATCH is an index-map lookup: each MATCH works alone, chained they
+produce nothing, no error is raised — so downstream MERGEs quietly write no
+edges. That was the parity gap's exact signature (every File-sourced CALLS
+edge and five Struct CONTAINS edges missing on ladybug only, run after run).
+
+The comma form `MATCH (a {…}), (b {…})` is semantically identical for
+non-optional patterns and both engines plan it correctly, so the embedded
+translation layer now rewrites adjacent MATCH clauses in UNWIND queries.
+"""
+from pathlib import Path
+
+import pytest
+
+from codegraphcontext.core.database_kuzu import KuzuDBManager
+
+kuzu = pytest.importorskip("kuzu")
+
+
+@pytest.fixture()
+def driver(tmp_path: Path):
+    manager = KuzuDBManager(str(tmp_path / "db"))
+    yield manager.get_driver()
+    manager.close_driver()
+
+
+def _translate(driver, query, **params):
+    with driver.session() as s:
+        translated, _ = s._translate_query(query, params)
+    return translated
+
+
+UNWIND_DOUBLE_MATCH = """
+    UNWIND $batch AS row
+    MATCH (caller:File {path: row.caller_file_path})
+    MATCH (called:Function {name: row.called_name, path: row.called_file_path})
+    WHERE row.called_line_number <= 0 OR called.line_number = row.called_line_number
+    MERGE (caller)-[c:CALLS {line_number: row.line_number}]->(called)
+"""
+
+
+def test_adjacent_matches_merge_to_comma_form(driver):
+    translated = _translate(driver, UNWIND_DOUBLE_MATCH, batch=[{"caller_file_path": "/f.py"}])
+    assert "}), " in translated.replace("\n", " ") or "}) , " in translated
+    # exactly one MATCH keyword must remain
+    assert translated.count("MATCH") == 1, translated
+
+
+def test_triple_match_chain_fully_merges(driver):
+    q = (
+        "UNWIND $batch AS row "
+        "MATCH (a:File {path: row.p}) "
+        "MATCH (b:Function {name: row.n}) "
+        "MATCH (c:Class {name: row.c}) "
+        "RETURN count(*)"
+    )
+    translated = _translate(driver, q, batch=[{"p": "/f.py"}])
+    assert translated.count("MATCH") == 1, translated
+
+
+def test_where_between_matches_blocks_the_merge(driver):
+    # Merging across an interposed WHERE would change which clause the
+    # predicate binds to — that shape must stay untouched.
+    q = (
+        "UNWIND $batch AS row "
+        "MATCH (outer:Function {name: row.outer}) "
+        "WHERE row.outer_line < 0 OR outer.line_number = row.outer_line "
+        "MATCH (inner:Function {name: row.inner_name}) "
+        "MERGE (outer)-[:CONTAINS]->(inner)"
+    )
+    translated = _translate(driver, q, batch=[{"outer": "x"}])
+    assert translated.count("MATCH") == 2, translated
+
+
+def test_optional_match_is_never_merged(driver):
+    q = (
+        "UNWIND $batch AS row "
+        "MATCH (a:File {path: row.p}) "
+        "OPTIONAL MATCH (b:Function {name: row.n}) "
+        "RETURN count(*)"
+    )
+    translated = _translate(driver, q, batch=[{"p": "/f.py"}])
+    assert "OPTIONAL MATCH" in translated, translated
+
+
+def test_non_unwind_queries_stay_untouched(driver):
+    q = (
+        "MATCH (a:File {path: $p}) "
+        "MATCH (b:Function {name: $n}) "
+        "RETURN count(*)"
+    )
+    translated = _translate(driver, q, p="/f.py", n="x")
+    assert translated.count("MATCH") == 2, translated
+
+
+class TestLadybugDoubleExecution:
+    """LadybugDB state-dependently drops SOME rows of a batched rel-only
+    UNWIND MERGE on first execution (no error raised); replaying the same
+    idempotent batch immediately binds the stragglers. The compat layer
+    therefore executes such batches twice on ladybug only."""
+
+    REL_MERGE = (
+        "UNWIND $batch AS row "
+        "MATCH (a:Class {name: row.c}) "
+        "MATCH (b:ExternalClass {name: row.p}) "
+        "MERGE (a)-[r:INHERITS]->(b)"
+    )
+
+    def _run_counting(self, backend_id, query):
+        from unittest.mock import MagicMock
+        from codegraphcontext.core.database_embedded_kuzu import EmbeddedSessionWrapper
+
+        conn = MagicMock()
+        session = EmbeddedSessionWrapper(conn, backend_id=backend_id)
+        session.run(query, batch=[{"c": "A", "p": "P"}])
+        return conn.execute.call_count
+
+    def test_ladybug_executes_rel_merge_batch_twice(self):
+        assert self._run_counting("ladybugdb", self.REL_MERGE) == 2
+
+    def test_kuzu_executes_rel_merge_batch_once(self):
+        assert self._run_counting("kuzudb", self.REL_MERGE) == 1
+
+    def test_ladybug_read_queries_execute_once(self):
+        q = "UNWIND $batch AS row MATCH (a:Class {name: row.c}) RETURN count(a)"
+        assert self._run_counting("ladybugdb", q) == 1
+
+
+def test_merged_form_still_binds_rows_on_kuzu(driver):
+    """End-to-end on the real engine: the rewritten comma-form must produce
+    the same edges the two-MATCH form produced on kuzu before the rewrite."""
+    with driver.session() as s:
+        for name in ("A", "B"):
+            s.run(
+                "MERGE (c:Class {name: $n, path: $p, line_number: $ln, occurrence_index: $oi})",
+                n=name, p="/f.py", ln=1, oi=0,
+            )
+            s.run("MERGE (e:ExternalClass {name: $n})", n=name + "_ext")
+        s.run(
+            """
+            UNWIND $batch AS row
+            MATCH (child:Class {name: row.c, path: '/f.py'})
+            MATCH (parent:ExternalClass {name: row.p})
+            MERGE (child)-[r:INHERITS]->(parent)
+            """,
+            batch=[{"c": "A", "p": "A_ext"}, {"c": "B", "p": "B_ext"}],
+        )
+        got = sorted(
+            (r["c"], r["p"]) for r in s.run(
+                "MATCH (c:Class)-[:INHERITS]->(p:ExternalClass) "
+                "RETURN c.name AS c, p.name AS p"
+            ).data()
+        )
+    assert got == [("A", "A_ext"), ("B", "B_ext")], got


### PR DESCRIPTION
## Summary

Closes #1710 — the last red on the Database Parity Check. LadybugDB was deterministically missing 117 CALLS edges (every File-sourced pair) and 5 CONTAINS edges (Go struct methods), run after run, with identical node counts across all four backends.

Root-caused by capturing exact translated query+params at write time and replaying against raw ladybug:

**Defect 1 — deterministic zero-bind.** `UNWIND $batch AS row MATCH (caller:File {path: row.p}) MATCH (called:… ) MERGE …` binds **zero rows** on ladybug when the first MATCH is an index-map lookup. Each MATCH works alone; chained they produce nothing; no error surfaces, so the writer's binder-guard never fired and MERGE silently wrote nothing. The comma form `MATCH (a {…}), (b {…})` binds correctly and is semantically identical — the translation layer now collapses adjacent MATCH clauses inside UNWIND queries (never across an interposed WHERE, never touching OPTIONAL MATCH; chains of 3+ fully merge).

**Defect 2 — state-dependent partial drop.** A 17-row Struct-CONTAINS batch wrote 12 edges live; the *identical* re-run in the same session immediately wrote the remaining 5, and the same payload replayed on the reopened db binds 17/17. MERGE is idempotent, so batched rel-only UNWIND MERGEs now execute twice on ladybugdb only. (Forcing ladybug through the per-row fallback was tried and rejected: it regresses CONTAINS by 51 edges — the old #1612 flake signature.)

## Verification

- Full reindex of `tests/fixtures/sample_projects` on both embedded backends, counts read directly from each database: **CALLS 718, CONTAINS 4727, IMPORTS 301, INHERITS 145, IMPLEMENTS 17, HAS_PARAMETER 1263, HEURISTIC_CALLS 167, nodes 5471 — identical on kuzu and ladybug.** Previously ladybug read CALLS 601 / CONTAINS 4722, matching CI exactly.
- New `tests/unit/core/test_embedded_match_merge.py`: merge rewrite shape pins (adjacent merge, triple-chain, WHERE blocks merge, OPTIONAL MATCH untouched, non-UNWIND untouched), kuzu end-to-end binding on the merged form, and double-execution pins (ladybugdb twice, kuzudb once, reads once).
- Gates: 1479 unit + 93 integration passed.

Both workarounds should be re-tested when the ladybug `<0.20` pin lifts (#1708).

🤖 Generated with [Claude Code](https://claude.com/claude-code)