### PR TITLE
chore(release): bump version to 0.6.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.11"
+version = "0.6.12"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
Release 0.6.12 — ships the full LadybugDB parity recovery plus the reliability batch since 0.6.11:

- #1711 / #1712: two ladybug 0.19.x planner defects worked around (adjacent-MATCH comma-merge in UNWIND queries; best-effort single-row replay of rel-MERGE batches on ladybug only) — **Database Parity Check green on main** (#1710)
- #1704: adaptive embedded buffer pool (min(4GiB, available/2), 256MiB floor)
- #1705: MCP stdio session + live watcher integration seams
- #1706: embedded close_driver actually closes; stale-session pool deadlock fails loudly
- #1707: ladybug pinned <0.20 (0.20.2 segfaults on Python 3.14 — un-pin tracked in #1708)
- #1709: per-row fallback retry + drop accounting

Gates: 1573 unit+integration passed (one fixture-contamination failure re-verified clean); parity green on 06ab3741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)