### PR TITLE
fix(embedded): respect cgroup memory limits when sizing the buffer pool

### DIFF
--- a/src/codegraphcontext/core/database_embedded_kuzu.py
+++ b/src/codegraphcontext/core/database_embedded_kuzu.py
@@ -32,16 +32,59 @@ DEFAULT_EMBEDDED_BUFFER_POOL_BYTES = 4 * 1024**3
 MIN_DEFAULT_BUFFER_POOL_BYTES = 256 * 1024**2
 
 
+def _cgroup_available_bytes():
+    """Memory headroom under the container's cgroup limit, or None when
+    unconfined. /proc/meminfo shows the HOST inside a container, so a pod
+    capped at 1 GiB on a 64 GiB host would otherwise size a 4 GiB pool and
+    be OOM-killed natively at first touch."""
+    # cgroup v2 (unified hierarchy)
+    try:
+        with open("/sys/fs/cgroup/memory.max") as f:
+            raw = f.read().strip()
+        if raw != "max":
+            limit = int(raw)
+            usage = 0
+            try:
+                with open("/sys/fs/cgroup/memory.current") as f:
+                    usage = int(f.read().strip())
+            except (OSError, ValueError):
+                pass
+            return max(limit - usage, 0)
+    except (OSError, ValueError):
+        pass
+    # cgroup v1
+    try:
+        with open("/sys/fs/cgroup/memory/memory.limit_in_bytes") as f:
+            limit = int(f.read().strip())
+        if limit < 1 << 60:  # v1 reports ~8 EiB when unlimited
+            usage = 0
+            try:
+                with open("/sys/fs/cgroup/memory/memory.usage_in_bytes") as f:
+                    usage = int(f.read().strip())
+            except (OSError, ValueError):
+                pass
+            return max(limit - usage, 0)
+    except (OSError, ValueError):
+        pass
+    return None
+
+
 def _available_memory_bytes():
-    """MemAvailable from /proc/meminfo, or None where unavailable (macOS…)."""
+    """The tighter of host MemAvailable (/proc/meminfo) and the cgroup
+    memory headroom, or None where neither is readable (macOS…)."""
+    host = None
     try:
         with open("/proc/meminfo") as f:
             for line in f:
                 if line.startswith("MemAvailable:"):
-                    return int(line.split()[1]) * 1024
+                    host = int(line.split()[1]) * 1024
+                    break
     except OSError:
         pass
-    return None
+    cgroup = _cgroup_available_bytes()
+    if host is not None and cgroup is not None:
+        return min(host, cgroup)
+    return host if host is not None else cgroup
 
 
 def resolve_embedded_buffer_pool_size() -> int:

--- a/tests/unit/core/test_embedded_buffer_pool.py
+++ b/tests/unit/core/test_embedded_buffer_pool.py
@@ -144,3 +144,83 @@ def test_explicit_value_is_honored_verbatim(monkeypatch):
     monkeypatch.setattr(dek, "_available_memory_bytes", lambda: 1 * 1024**3)
     # explicit values are never second-guessed by the availability heuristic
     assert dek.resolve_embedded_buffer_pool_size() == 8192 * 1024**2
+
+
+class TestCgroupAwareness:
+    """Inside a container /proc/meminfo shows the HOST's memory; the pool
+    must respect the tighter cgroup limit or the process is OOM-killed
+    natively when the reservation is first touched."""
+
+    def _patch_files(self, monkeypatch, contents):
+        import builtins
+        real_open = builtins.open
+
+        def fake_open(path, *a, **k):
+            if path in contents:
+                raw = contents[path]
+                if isinstance(raw, OSError):
+                    raise raw
+                import io
+                return io.StringIO(raw)
+            return real_open(path, *a, **k)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+    def test_cgroup_v2_limit_caps_host_available(self, monkeypatch):
+        from codegraphcontext.core import database_embedded_kuzu as dek
+        self._patch_files(monkeypatch, {
+            "/proc/meminfo": "MemTotal: 67108864 kB\nMemAvailable: 33554432 kB\n",  # 32 GiB avail
+            "/sys/fs/cgroup/memory.max": str(1 * 1024**3),   # 1 GiB pod limit
+            "/sys/fs/cgroup/memory.current": str(256 * 1024**2),
+        })
+        # headroom = 1 GiB - 256 MiB = 768 MiB, far below host's 32 GiB
+        assert dek._available_memory_bytes() == 768 * 1024**2
+
+    def test_cgroup_v2_unlimited_uses_host_value(self, monkeypatch):
+        from codegraphcontext.core import database_embedded_kuzu as dek
+        self._patch_files(monkeypatch, {
+            "/proc/meminfo": "MemAvailable: 8388608 kB\n",  # 8 GiB
+            "/sys/fs/cgroup/memory.max": "max",
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes": OSError("no v1"),
+        })
+        assert dek._available_memory_bytes() == 8 * 1024**3
+
+    def test_cgroup_v1_limit_caps_host_available(self, monkeypatch):
+        from codegraphcontext.core import database_embedded_kuzu as dek
+        self._patch_files(monkeypatch, {
+            "/proc/meminfo": "MemAvailable: 33554432 kB\n",
+            "/sys/fs/cgroup/memory.max": OSError("no v2"),
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes": str(2 * 1024**3),
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes": str(1 * 1024**3),
+        })
+        assert dek._available_memory_bytes() == 1 * 1024**3
+
+    def test_cgroup_v1_unlimited_sentinel_ignored(self, monkeypatch):
+        from codegraphcontext.core import database_embedded_kuzu as dek
+        self._patch_files(monkeypatch, {
+            "/proc/meminfo": "MemAvailable: 4194304 kB\n",  # 4 GiB
+            "/sys/fs/cgroup/memory.max": OSError("no v2"),
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes": str(1 << 62),  # "unlimited"
+        })
+        assert dek._available_memory_bytes() == 4 * 1024**3
+
+    def test_no_meminfo_falls_back_to_cgroup_alone(self, monkeypatch):
+        from codegraphcontext.core import database_embedded_kuzu as dek
+        self._patch_files(monkeypatch, {
+            "/proc/meminfo": OSError("macOS-in-container"),
+            "/sys/fs/cgroup/memory.max": str(1 * 1024**3),
+            "/sys/fs/cgroup/memory.current": OSError("unreadable"),
+        })
+        assert dek._available_memory_bytes() == 1 * 1024**3
+
+    def test_pod_limit_shrinks_the_default_pool(self, monkeypatch):
+        """End-to-end: a 1 GiB pod on a 64 GiB host gets a ~384 MiB pool
+        (half of headroom), not the 4 GiB that would OOM-kill it."""
+        from codegraphcontext.core import database_embedded_kuzu as dek
+        monkeypatch.delenv("CGC_EMBEDDED_BUFFER_POOL_MB", raising=False)
+        self._patch_files(monkeypatch, {
+            "/proc/meminfo": "MemAvailable: 67108864 kB\n",  # 64 GiB host
+            "/sys/fs/cgroup/memory.max": str(1 * 1024**3),
+            "/sys/fs/cgroup/memory.current": str(256 * 1024**2),
+        })
+        assert dek.resolve_embedded_buffer_pool_size() == 384 * 1024**2


### PR DESCRIPTION
## Summary

Inside a container `/proc/meminfo` reports the **host's** memory, so the adaptive buffer-pool default (#1704) would size a 4 GiB pool in a pod capped at 1 GiB and get OOM-killed natively at first touch — the same crash class the parity CI hit on constrained runners. This matters directly for the Docker images this repo publishes.

`_available_memory_bytes()` now returns the tighter of host `MemAvailable` and the cgroup headroom:
- cgroup v2: `memory.max` − `memory.current` (skipped when `max`)
- cgroup v1: `memory.limit_in_bytes` − `memory.usage_in_bytes` (the ~8 EiB "unlimited" sentinel is ignored)
- either source alone suffices when the other is unreadable; explicit `CGC_EMBEDDED_BUFFER_POOL_MB` is still honored verbatim.

## Tests

6 new tests in `tests/unit/core/test_embedded_buffer_pool.py` covering v2-capped, v2-unlimited, v1-capped, v1-sentinel, meminfo-missing, and the end-to-end pod-limit-shrinks-pool case. Full unit gate: 1487 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)