### PR TITLE
fix(mcp): parse errors no longer reuse the previous request's id

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -803,6 +803,11 @@ class MCPServer:
     async def _run_loop(self, loop):
         request_count = 0
         while True:
+            # Reset per iteration: on a parse error `request` would otherwise
+            # still hold the PREVIOUS request, and the error response would
+            # reuse its id — a second response for an already-answered id,
+            # which desyncs clients that match responses by id.
+            request = None
             try:
                 if request_count and request_count % 50 == 0:
                     self.job_manager.cleanup_old_jobs(max_age_hours=24)
@@ -880,15 +885,19 @@ class MCPServer:
 
             except Exception as e:
                 error_logger(f"Error processing request: {e}\n{traceback.format_exc()}")
-                request_id = "unknown"
-                if 'request' in locals() and isinstance(request, dict):
-                    request_id = request.get('id', "unknown")
+                # JSON-RPC: parse errors respond with id null and -32700;
+                # errors while handling a parsed request keep that request's id.
+                request_id = request.get('id') if isinstance(request, dict) else None
+                is_parse_error = not isinstance(request, dict)
 
                 error_response = {
                     "jsonrpc": "2.0", "id": request_id,
                     "error": {
-                        "code": -32603,
-                        "message": f"Internal error: {str(e)}",
+                        "code": -32700 if is_parse_error else -32603,
+                        "message": (
+                            f"Parse error: {str(e)}" if is_parse_error
+                            else f"Internal error: {str(e)}"
+                        ),
                     },
                 }
                 print(json.dumps(error_response), flush=True)

--- a/tests/integration/test_mcp_stdio_session.py
+++ b/tests/integration/test_mcp_stdio_session.py
@@ -83,3 +83,30 @@ def test_full_stdio_session(mcp_session):
     r = _read_response(proc, 3)
     assert r is not None and "result" in r, f"tools/call failed: {r}"
     assert "greet" in json.dumps(r["result"]), "indexed function not found over MCP"
+
+
+def test_parse_errors_never_reuse_a_previous_request_id(mcp_session):
+    """A malformed line must answer with id null / -32700 — NOT the id of
+    the previous request. The old handler read the stale `request` variable
+    from the prior loop iteration, emitting a SECOND response for an
+    already-answered id, which desyncs clients that match responses by id."""
+    proc = mcp_session
+
+    _send(proc, {"jsonrpc": "2.0", "id": 7, "method": "initialize",
+                 "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                            "clientInfo": {"name": "test", "version": "0"}}})
+    r = _read_response(proc, 7)
+    assert r is not None and "result" in r
+
+    # raw garbage after a valid exchange — the trigger for the stale-id bug
+    proc.stdin.write("this is not json\n")
+    proc.stdin.flush()
+    r = _read_response(proc, None)
+    assert r is not None, "no response to malformed input"
+    assert r["id"] is None, f"parse error reused a stale id: {r}"
+    assert r["error"]["code"] == -32700, f"expected -32700 parse error: {r}"
+
+    # the session must still work afterwards, with ids intact
+    _send(proc, {"jsonrpc": "2.0", "id": 8, "method": "tools/list"})
+    r = _read_response(proc, 8)
+    assert r is not None and "result" in r, f"session broken after parse error: {r}"


### PR DESCRIPTION
## Summary

Found by fuzzing the MCP stdio loop with malformed JSON-RPC. The error handler at the bottom of the request loop read the stale `request` variable left over from the previous iteration (`'request' in locals()`), so any unparseable line arriving after a valid request produced a **second response bearing the already-answered id** — clients that match responses by id see protocol corruption. It also answered parse errors with the nonstandard id `"unknown"` and `-32603`.

Fix: `request` resets to `None` each iteration; unparseable input now answers with `id: null` and JSON-RPC's `-32700` parse-error code, while errors thrown mid-handling of a parsed request keep that request's id exactly as before.

Fuzz transcript before → after:
```
garbage line        → id=4 (stale!) -32603     → id=null -32700
valid tools/list    → id=5 result              → id=5 result (session survives)
```

## Tests

New regression test in `tests/integration/test_mcp_stdio_session.py` driving a real `cgc mcp start` subprocess: valid initialize → raw garbage → asserts id null/-32700 and that the session still answers the next request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)