### PR TITLE
chore(release): bump version to 0.6.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegraphcontext"
-version = "0.6.12"
+version = "0.6.13"
 description = "An MCP server that indexes local code into a graph database to provide context to AI assistants."
 authors = [{ name = "Shashank Shekhar Singh", email = "shashankshekharsingh1205@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
Release 0.6.13 — two bugs found by proactive robustness/fuzz testing:

- #1714: cgroup-aware buffer-pool sizing — inside a container /proc/meminfo shows the HOST's memory, so a memory-capped pod sized a 4 GiB pool and was natively OOM-killed at first touch (affects the published Docker images)
- #1715: MCP stdio parse errors no longer reuse the previous request's id (a second response for an already-answered id corrupted clients that match responses by id); unparseable input now answers id null / -32700 per JSON-RPC

Verified hardened in the same pass (no changes needed): Cypher injection, path traversal past CGC_ALLOWED_ROOTS, hostile filesystems (broken/looping symlinks, FIFOs, NUL bytes, invalid-UTF8 names, permission-denied dirs), 400-deep nesting + 2 MB lines + Unicode identifiers, concurrent indexing on one embedded db, bundle export→import byte-exactness.

Gates: 1581 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)